### PR TITLE
feat(skill): migrate morph-ppt helpers from bash to Python

### DIFF
--- a/skills/morph-ppt/SKILL.md
+++ b/skills/morph-ppt/SKILL.md
@@ -79,24 +79,22 @@ Follow the installation check in `reference/officecli-pptx-min.md` section 0 (ch
 
 **IMPORTANT: Use morph-helpers for reliable workflow**
 
-Generate a bash script that uses `reference/morph-helpers.sh` — this provides helper functions with built-in verification.
+Generate a Python script that uses `reference/morph-helpers.py` — this provides helper functions with built-in verification. Python works cross-platform (Mac / Windows / Linux).
 
 **Shape naming rules (for best results)**:
 
 Use these naming patterns for clear code and reliable verification:
 
 1. **Scene actors** (persistent across slides):
-   - Format: `'!!actor-name'` (double `!!` prefix, single quotes required)
-   - Examples: `'!!ring-1'`, `'!!dot-accent'`, `'!!line-top'`
+   - Format: `name=!!actor-name`
+   - Examples: `name=!!ring-1`, `name=!!dot-accent`, `name=!!line-top`
    - Behavior: Modify position/size/color, NEVER ghost
 
 2. **Content shapes** (unique per slide):
-   - Format: `'#sN-description'` (single quotes required)
+   - Format: `name=#sN-description`
    - Pattern: `#` + `s` + slide_number + `-` + description
-   - Examples: `'#s1-title'`, `'#s2-card1'`, `'#s3-stats'`
+   - Examples: `name=#s1-title`, `name=#s2-card1`, `name=#s3-stats`
    - Behavior: Ghost (x=36cm) when moving to next slide
-
-**Why single quotes?** Shell treats `!` and `#` as special characters. Single quotes prevent this: `'#s1-title'`
 
 **Why this naming matters:**
 
@@ -109,69 +107,91 @@ Use these naming patterns for clear code and reliable verification:
 
 **Then proceed with pattern**:
 
-```bash
-#!/bin/bash
-set -e
+```python
+#!/usr/bin/env python3
+import subprocess, sys, os
+
+def run(*args):
+    result = subprocess.run(list(args))
+    if result.returncode != 0:
+        sys.exit(result.returncode)
 
 # Load helper functions (provides morph_clone_slide, morph_ghost_content, morph_verify_slide)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/morph-helpers.sh"
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+def helper(*args):
+    run(sys.executable, os.path.join(SCRIPT_DIR, "reference", "morph-helpers.py"), *[str(a) for a in args])
 
-OUTPUT="deck.pptx"
-officecli create "$OUTPUT"
+OUTPUT = "deck.pptx"
+run("officecli", "create", OUTPUT)
 
 # ============ SLIDE 1 ============
-echo "Building Slide 1..."
-officecli add "$OUTPUT" '/' --type slide
-officecli set "$OUTPUT" '/slide[1]' --prop background=1A1A2E
+print("Building Slide 1...")
+run("officecli", "add", OUTPUT, "/", "--type", "slide")
+run("officecli", "set", OUTPUT, "/slide[1]", "--prop", "background=1A1A2E")
 
 # Scene actors (!!-prefixed, will persist and morph across slides)
-officecli add "$OUTPUT" '/slide[1]' --type shape --prop 'name=!!ring-1' --prop preset=ellipse --prop fill=E94560 --prop opacity=0.3 --prop x=5cm --prop y=3cm --prop width=8cm --prop height=8cm
-officecli add "$OUTPUT" '/slide[1]' --type shape --prop 'name=!!dot-accent' --prop preset=ellipse --prop fill=0F3460 --prop x=28cm --prop y=15cm --prop width=1cm --prop height=1cm
+run("officecli", "add", OUTPUT, "/slide[1]", "--type", "shape",
+    "--prop", "name=!!ring-1", "--prop", "preset=ellipse", "--prop", "fill=E94560",
+    "--prop", "opacity=0.3", "--prop", "x=5cm", "--prop", "y=3cm", "--prop", "width=8cm", "--prop", "height=8cm")
+run("officecli", "add", OUTPUT, "/slide[1]", "--type", "shape",
+    "--prop", "name=!!dot-accent", "--prop", "preset=ellipse", "--prop", "fill=0F3460",
+    "--prop", "x=28cm", "--prop", "y=15cm", "--prop", "width=1cm", "--prop", "height=1cm")
 
 # Content shapes (#s1- prefix, will be ghosted on next slide)
-# ⚠️ Use generous width (25-30cm for titles) to avoid text wrapping!
-officecli add "$OUTPUT" '/slide[1]' --type shape --prop 'name=#s1-title' --prop text="Main Title" --prop font="Arial Black" --prop size=64 --prop bold=true --prop color=FFFFFF --prop x=10cm --prop y=8cm --prop width=28cm --prop height=3cm --prop fill=none
+# Use generous width (25-30cm for titles) to avoid text wrapping!
+run("officecli", "add", OUTPUT, "/slide[1]", "--type", "shape",
+    "--prop", "name=#s1-title", "--prop", "text=Main Title",
+    "--prop", "font=Arial Black", "--prop", "size=64", "--prop", "bold=true",
+    "--prop", "color=FFFFFF", "--prop", "x=10cm", "--prop", "y=8cm",
+    "--prop", "width=28cm", "--prop", "height=3cm", "--prop", "fill=none")
 
 # ============ SLIDE 2 ============
-echo "Building Slide 2..."
+print("Building Slide 2...")
 
 # Use helper: automatically clone + set transition + list shapes + verify
-morph_clone_slide "$OUTPUT" 1 2
+helper("clone", OUTPUT, 1, 2)
 
-# Use helper: ghost all content from slide 1 (shape indices 3 = #s1-title)
-morph_ghost_content "$OUTPUT" 2 3
+# Use helper: ghost all content from slide 1 (shape index 3 = #s1-title)
+helper("ghost", OUTPUT, 2, 3)
 
 # Add new content for slide 2
-officecli add "$OUTPUT" '/slide[2]' --type shape --prop 'name=#s2-title' --prop text="Second Slide" --prop font="Arial Black" --prop size=64 --prop bold=true --prop color=FFFFFF --prop x=10cm --prop y=8cm --prop width=28cm --prop height=3cm --prop fill=none
+run("officecli", "add", OUTPUT, "/slide[2]", "--type", "shape",
+    "--prop", "name=#s2-title", "--prop", "text=Second Slide",
+    "--prop", "font=Arial Black", "--prop", "size=64", "--prop", "bold=true",
+    "--prop", "color=FFFFFF", "--prop", "x=10cm", "--prop", "y=8cm",
+    "--prop", "width=28cm", "--prop", "height=3cm", "--prop", "fill=none")
 
 # Adjust scene actors to create motion
-officecli set "$OUTPUT" '/slide[2]/shape[1]' --prop x=15cm --prop y=5cm  # !!ring-1 moves
-officecli set "$OUTPUT" '/slide[2]/shape[2]' --prop x=5cm --prop y=10cm  # !!dot-accent moves
+run("officecli", "set", OUTPUT, "/slide[2]/shape[1]", "--prop", "x=15cm", "--prop", "y=5cm")  # !!ring-1 moves
+run("officecli", "set", OUTPUT, "/slide[2]/shape[2]", "--prop", "x=5cm",  "--prop", "y=10cm") # !!dot-accent moves
 
 # Use helper: verify slide is correct (transition + ghosting)
-morph_verify_slide "$OUTPUT" 2
+helper("verify", OUTPUT, 2)
 
 # ============ SLIDE 3 ============
-echo "Building Slide 3..."
+print("Building Slide 3...")
 
-morph_clone_slide "$OUTPUT" 2 3
-morph_ghost_content "$OUTPUT" 3 4  # Ghost #s2-title (now at index 4)
+helper("clone", OUTPUT, 2, 3)
+helper("ghost", OUTPUT, 3, 4)  # Ghost #s2-title (now at index 4)
 
-officecli add "$OUTPUT" '/slide[3]' --type shape --prop 'name=#s3-title' --prop text="Third Slide" --prop font="Arial Black" --prop size=64 --prop bold=true --prop color=FFFFFF --prop x=10cm --prop y=8cm --prop width=28cm --prop height=3cm --prop fill=none
+run("officecli", "add", OUTPUT, "/slide[3]", "--type", "shape",
+    "--prop", "name=#s3-title", "--prop", "text=Third Slide",
+    "--prop", "font=Arial Black", "--prop", "size=64", "--prop", "bold=true",
+    "--prop", "color=FFFFFF", "--prop", "x=10cm", "--prop", "y=8cm",
+    "--prop", "width=28cm", "--prop", "height=3cm", "--prop", "fill=none")
 
-officecli set "$OUTPUT" '/slide[3]/shape[1]' --prop x=25cm --prop y=8cm
-officecli set "$OUTPUT" '/slide[3]/shape[2]' --prop x=10cm --prop y=5cm
+run("officecli", "set", OUTPUT, "/slide[3]/shape[1]", "--prop", "x=25cm", "--prop", "y=8cm")
+run("officecli", "set", OUTPUT, "/slide[3]/shape[2]", "--prop", "x=10cm", "--prop", "y=5cm")
 
-morph_verify_slide "$OUTPUT" 3
+helper("verify", OUTPUT, 3)
 
 # ============ FINAL VERIFICATION ============
-echo ""
-echo "========================================="
-morph_final_check "$OUTPUT"
+print()
+print("=========================================")
+helper("final-check", OUTPUT)
 
-echo ""
-echo "✅ Build complete! Open $OUTPUT in PowerPoint to see morph animations."
+print()
+print("Build complete! Open", OUTPUT, "in PowerPoint to see morph animations.")
 ```
 
 **Key advantages of using helpers:**
@@ -215,7 +235,7 @@ echo "✅ Build complete! Open $OUTPUT in PowerPoint to see morph animations."
 
 **Verification** (your build script already includes this):
 
-If you used `morph-helpers.sh`, verification is already done! The build script calls `morph_verify_slide` and `morph_final_check` automatically.
+If you used `morph-helpers.py`, verification is already done! The build script calls `helper("verify", ...)` and `helper("final-check", ...)` automatically.
 
 Just validate the final structure:
 
@@ -252,16 +272,16 @@ officecli view <file>.pptx outline
 
 2. **Unghosted content**:
 
-   ```bash
+   ```python
    # Find unghosted shapes manually
-   for slide in 2 3 4 5 6; do
-       echo "Slide $slide:"
-       officecli get <file>.pptx "/slide[$slide]" --depth 1 | grep -E "#s[0-9]"
-   done
+   import subprocess
+   for slide in range(2, 7):
+       print(f"Slide {slide}:")
+       subprocess.run(["officecli", "get", "<file>.pptx", f"/slide[{slide}]", "--depth", "1"])
    # If you see shapes like "#s1-title" on slide 2 (not at x=36cm), they should be ghosted
 
-   # Fix:
-   officecli set <file>.pptx '/slide[N]/shape[X]' --prop x=36cm
+   # Fix (run in terminal):
+   # officecli set <file>.pptx /slide[N]/shape[X] --prop x=36cm
    ```
 
 3. **Visual issues**:
@@ -289,6 +309,6 @@ Ask user for feedback, support quick adjustments.
 
 ---
 
-**First time?** Read "Understanding Morph" above, skim one style reference for inspiration, then generate. Always use `morph-helpers.sh` workflow. You'll learn by doing.
+**First time?** Read "Understanding Morph" above, skim one style reference for inspiration, then generate. Always use `morph-helpers.py` workflow. You'll learn by doing.
 
 **Trust yourself.** You have vision, design sense, and the ability to iterate. These tools enable you — your creativity makes it excellent.

--- a/skills/morph-ppt/reference/morph-helpers.py
+++ b/skills/morph-ppt/reference/morph-helpers.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""
+Morph PPT Helper Functions
+Cross-platform replacement for morph-helpers.sh (Mac / Windows / Linux)
+
+Usage (CLI):
+  python morph-helpers.py clone <deck> <from_slide> <to_slide>
+  python morph-helpers.py ghost <deck> <slide> <idx> [idx ...]
+  python morph-helpers.py verify <deck> <slide>
+  python morph-helpers.py final-check <deck>
+
+Usage (import):
+  from morph_helpers import morph_clone_slide, morph_ghost_content, morph_verify_slide, morph_final_check
+"""
+
+import sys
+import json
+import subprocess
+import argparse
+import re
+
+# Cross-platform color support (colorama optional)
+try:
+    from colorama import init, Fore, Style
+    init(autoreset=True)
+    GREEN  = Fore.GREEN
+    RED    = Fore.RED
+    YELLOW = Fore.YELLOW
+    BLUE   = Fore.CYAN
+    NC     = Style.RESET_ALL
+except ImportError:
+    GREEN = RED = YELLOW = BLUE = NC = ""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _run(*args):
+    """Run a command, return (returncode, stdout, stderr)."""
+    result = subprocess.run(list(args), capture_output=True, text=True)
+    return result.returncode, result.stdout, result.stderr
+
+
+def _find_nested(data, key):
+    """Recursively search a nested dict for a key, return its value or None."""
+    if isinstance(data, dict):
+        if key in data:
+            return data[key]
+        for v in data.values():
+            found = _find_nested(v, key)
+            if found is not None:
+                return found
+    return None
+
+
+def _has_morph_transition(json_str):
+    """Check whether JSON output from officecli contains transition=morph."""
+    if '"transition": "morph"' in json_str:
+        return True
+    try:
+        data = json.loads(json_str)
+        return _find_nested(data, "transition") == "morph"
+    except Exception:
+        return False
+
+
+def _collect_shapes(children, callback):
+    """Walk a shape tree depth-first, calling callback(child) for each node."""
+    for child in children:
+        callback(child)
+        if "Children" in child:
+            _collect_shapes(child["Children"], callback)
+
+
+# ---------------------------------------------------------------------------
+# morph_clone_slide
+# ---------------------------------------------------------------------------
+
+def morph_clone_slide(deck, from_slide, to_slide):
+    """Clone slide and automatically set transition=morph, then verify.
+
+    Args:
+        deck:       path to .pptx file
+        from_slide: source slide number (1-based)
+        to_slide:   destination slide number (1-based)
+    """
+    from_slide, to_slide = int(from_slide), int(to_slide)
+
+    print(f"{BLUE}Cloning slide {from_slide} -> {to_slide}...{NC}")
+    _run("officecli", "add", deck, "/", "--from", f"/slide[{from_slide}]")
+
+    print(f"{BLUE}Setting morph transition...{NC}")
+    _run("officecli", "set", deck, f"/slide[{to_slide}]", "--prop", "transition=morph")
+
+    print(f"{BLUE}Listing shapes for ghosting reference:{NC}")
+    rc, out, _ = _run("officecli", "get", deck, f"/slide[{to_slide}]", "--depth", "1")
+    print(out)
+
+    # Verify
+    print(f"{BLUE}Verifying transition...{NC}")
+    rc, out, _ = _run("officecli", "get", deck, f"/slide[{to_slide}]", "--json")
+    if not _has_morph_transition(out):
+        print(f"{RED}ERROR: Transition not set on slide {to_slide}!{NC}")
+        print(f"{RED}   This slide will not have morph animation.{NC}")
+        sys.exit(1)
+
+    print(f"{GREEN}Transition verified on slide {to_slide}{NC}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# morph_ghost_content
+# ---------------------------------------------------------------------------
+
+def morph_ghost_content(deck, slide, *shapes):
+    """Move shapes off-screen (x=36cm) to ghost them for morph animation.
+
+    Args:
+        deck:     path to .pptx file
+        slide:    slide number (1-based)
+        *shapes:  one or more shape indices to ghost
+    """
+    slide = int(slide)
+    shapes = [int(s) for s in shapes]
+
+    if not shapes:
+        print(f"{YELLOW}No shapes to ghost{NC}")
+        return
+
+    print(f"{BLUE}Ghosting {len(shapes)} content shape(s) on slide {slide}...{NC}")
+    for idx in shapes:
+        rc, _, _ = _run("officecli", "set", deck, f"/slide[{slide}]/shape[{idx}]", "--prop", "x=36cm")
+        if rc == 0:
+            print(f"{GREEN}  Ghosted shape[{idx}]{NC}")
+        else:
+            print(f"{RED}  Failed to ghost shape[{idx}]{NC}")
+
+    print(f"{GREEN}Ghosting complete{NC}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# morph_verify_slide
+# ---------------------------------------------------------------------------
+
+def _check_unghosted(data, prev_slide):
+    """Return list of shapes with #s{prev_slide}- prefix not yet ghosted."""
+    unghosted = []
+
+    def visit(child):
+        name = child.get("Format", {}).get("name", "")
+        x    = child.get("Format", {}).get("x", "")
+        path = child.get("Path", "")
+        if f"#s{prev_slide}-" in name and x != "36cm":
+            unghosted.append(f"{path}: name={name}, x={x}")
+
+    if "Children" in data:
+        _collect_shapes(data["Children"], visit)
+    return unghosted
+
+
+def _check_duplicates(prev_data, curr_data):
+    """Return list of shapes with identical text+position on adjacent slides (excluding ghost zone)."""
+    SCENE_KEYWORDS = ["ring", "dot", "line", "circle", "rect", "slash",
+                      "accent", "actor", "star", "triangle", "diamond"]
+
+    def extract(data):
+        boxes = []
+
+        def visit(child):
+            if child.get("Type") != "textbox":
+                return
+            name = child.get("Format", {}).get("name", "")
+            text = child.get("Text", "").strip()
+            x    = child.get("Format", {}).get("x", "")
+            y    = child.get("Format", {}).get("y", "")
+            path = child.get("Path", "")
+
+            if not text or len(text) < 6:
+                return
+
+            clean = name.replace("!!", "")
+            is_scene = any(kw in clean.lower() for kw in SCENE_KEYWORDS)
+            has_slide_pattern = any(f"s{i}-" in clean for i in range(1, 20))
+
+            if has_slide_pattern or not is_scene:
+                boxes.append({"path": path, "text": text[:50], "x": x, "y": y})
+
+        if "Children" in data:
+            _collect_shapes(data["Children"], visit)
+        return boxes
+
+    prev_boxes = extract(prev_data)
+    curr_boxes = extract(curr_data)
+
+    duplicates = []
+    for curr in curr_boxes:
+        for prev in prev_boxes:
+            if (curr["text"] == prev["text"]
+                    and curr["x"] == prev["x"]
+                    and curr["y"] == prev["y"]
+                    and curr["x"] != "36cm"):
+                duplicates.append(
+                    f"{curr['path']}: text='{curr['text']}...', pos=({curr['x']},{curr['y']})"
+                )
+                break
+    return duplicates
+
+
+def morph_verify_slide(deck, slide):
+    """Verify a slide has correct morph setup (transition + ghosting).
+
+    Uses two detection methods:
+      1. Name-based: shapes with #s{prev}- prefix must be at x=36cm
+      2. Duplicate text: same text+position on adjacent slides (catches missing # prefix)
+
+    Args:
+        deck:  path to .pptx file
+        slide: slide number (1-based)
+
+    Returns:
+        True if all checks pass, False otherwise.
+    """
+    slide = int(slide)
+    print(f"{BLUE}Verifying slide {slide}...{NC}")
+    has_error = False
+
+    # --- Check transition ---
+    rc, out, _ = _run("officecli", "get", deck, f"/slide[{slide}]", "--json")
+    curr_json_str = out
+
+    if not _has_morph_transition(curr_json_str):
+        print(f"{RED}  Missing transition=morph{NC}")
+        print(f"{RED}     Without this, slide will not animate!{NC}")
+        has_error = True
+    else:
+        print(f"{GREEN}  Transition OK{NC}")
+
+    # --- Checks against previous slide ---
+    prev_slide = slide - 1
+    if prev_slide >= 1:
+        try:
+            curr_data = json.loads(curr_json_str).get("data", {})
+
+            # Method 1: name-based unghosted detection
+            unghosted = _check_unghosted(curr_data, prev_slide)
+            if unghosted:
+                print(f"{YELLOW}  Warning: Found unghosted content from slide {prev_slide}:{NC}")
+                for item in unghosted:
+                    print(f"     {item}")
+                print(f"{YELLOW}     These shapes should be ghosted to x=36cm{NC}")
+                has_error = True
+            else:
+                print(f"{GREEN}  No unghosted content detected{NC}")
+        except Exception:
+            print(f"{GREEN}  No unghosted content detected{NC}")
+
+        # Method 2: duplicate text/position detection (backup for missing # prefix)
+        try:
+            rc2, out2, _ = _run("officecli", "get", deck, f"/slide[{prev_slide}]", "--json")
+            prev_data = json.loads(out2).get("data", {})
+            curr_data = json.loads(curr_json_str).get("data", {})
+
+            duplicates = _check_duplicates(prev_data, curr_data)
+            if duplicates:
+                print(f"{YELLOW}  Warning: Found duplicate content from slide {prev_slide} (same text at same position):{NC}")
+                for dup in duplicates:
+                    print(f"     {dup}")
+                print(f"{YELLOW}     This might indicate:{NC}")
+                print(f"{YELLOW}     1. Content shapes missing '#sN-' prefix (can't detect for ghosting){NC}")
+                print(f"{YELLOW}     2. Forgot to ghost previous slide's content{NC}")
+                print(f"{YELLOW}     3. Forgot to add new content for this slide{NC}")
+                has_error = True
+        except Exception:
+            pass
+
+    if not has_error:
+        print(f"{GREEN}Slide {slide} verification passed{NC}")
+    else:
+        print(f"{RED}Slide {slide} has issues - see above{NC}")
+
+    print()
+    return not has_error
+
+
+# ---------------------------------------------------------------------------
+# morph_final_check
+# ---------------------------------------------------------------------------
+
+def morph_final_check(deck):
+    """Verify the entire deck: all slides (2+) must pass morph_verify_slide.
+
+    Args:
+        deck: path to .pptx file
+
+    Returns:
+        True if all slides pass, False otherwise.
+    """
+    print(f"{BLUE}Final deck verification...{NC}")
+    print()
+
+    rc, out, _ = _run("officecli", "view", deck, "outline")
+    total_slides = 0
+    first_line = out.split("\n")[0] if out else ""
+    match = re.search(r"(\d+)", first_line)
+    if match:
+        total_slides = int(match.group(1))
+
+    if total_slides == 0:
+        print(f"{RED}No slides found in deck{NC}")
+        return False
+
+    print(f"Total slides: {total_slides}")
+    print()
+
+    error_count = 0
+    for i in range(2, total_slides + 1):
+        if not morph_verify_slide(deck, i):
+            error_count += 1
+
+    print("=========================================")
+    if error_count == 0:
+        print(f"{GREEN}All slides verified successfully!{NC}")
+        print(f"{GREEN}   Your morph animations should work correctly.{NC}")
+        return True
+    else:
+        print(f"{RED}Found issues in {error_count} slide(s){NC}")
+        print(f"{RED}   Please fix the issues above before delivering.{NC}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="morph-helpers.py",
+        description="Morph PPT Helper Functions — cross-platform (Mac / Windows / Linux)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+commands:
+  clone <deck> <from_slide> <to_slide>        Clone slide and set morph transition
+  ghost <deck> <slide> <idx> [idx ...]        Ghost multiple shapes off-screen (x=36cm)
+  verify <deck> <slide>                       Verify slide setup (transition + ghosting)
+  final-check <deck>                          Verify entire deck
+
+example:
+  python morph-helpers.py clone  deck.pptx 1 2
+  python morph-helpers.py ghost  deck.pptx 2 7 8 9
+  python morph-helpers.py verify deck.pptx 2
+  python morph-helpers.py final-check deck.pptx
+""",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    p = sub.add_parser("clone")
+    p.add_argument("deck")
+    p.add_argument("from_slide", type=int)
+    p.add_argument("to_slide",   type=int)
+
+    p = sub.add_parser("ghost")
+    p.add_argument("deck")
+    p.add_argument("slide",  type=int)
+    p.add_argument("shapes", nargs="+", type=int)
+
+    p = sub.add_parser("verify")
+    p.add_argument("deck")
+    p.add_argument("slide", type=int)
+
+    p = sub.add_parser("final-check")
+    p.add_argument("deck")
+
+    args = parser.parse_args()
+
+    if args.command == "clone":
+        morph_clone_slide(args.deck, args.from_slide, args.to_slide)
+    elif args.command == "ghost":
+        morph_ghost_content(args.deck, args.slide, *args.shapes)
+    elif args.command == "verify":
+        if not morph_verify_slide(args.deck, args.slide):
+            sys.exit(1)
+    elif args.command == "final-check":
+        if not morph_final_check(args.deck):
+            sys.exit(1)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/morph-ppt/reference/pptx-design.md
+++ b/skills/morph-ppt/reference/pptx-design.md
@@ -155,7 +155,7 @@ Define 6-8 actors on Slide 1:
 - Easy to debug: search for `#s1-` to find all slide 1 content
 - Backup verification (duplicate detection) exists but has edge cases
 
-**Note**: Always use single quotes to prevent shell interpretation of special characters.
+**Note**: In Python build scripts, `#` and `!!` require no special quoting — pass them as plain strings (e.g. `"--prop", "name=#s1-title"`).
 
 ### How Morph Pairing Works
 

--- a/skills/morph-ppt/reference/styles/dark--diagonal-cut/build.sh
+++ b/skills/morph-ppt/reference/styles/dark--diagonal-cut/build.sh
@@ -458,6 +458,6 @@ officecli set "$OUTPUT" '/slide[5]/shape[32]' --prop x=3cm --prop y=12.5cm
 # VALIDATE & COMPLETE
 # ============================================
 echo "Validating..."
-bash "$(dirname "$0")/../../morph-helpers.sh" validate "$OUTPUT"
+python3 "$(dirname "$0")/../../morph-helpers.py" final-check "$OUTPUT"
 
 echo "✅ Build complete: $OUTPUT"

--- a/skills/morph-ppt/reference/styles/dark--editorial-story/build.sh
+++ b/skills/morph-ppt/reference/styles/dark--editorial-story/build.sh
@@ -591,6 +591,6 @@ officecli set "$OUTPUT" '/slide[6]/shape[46]' --prop x=3cm
 # VALIDATE & COMPLETE
 # ============================================
 echo "Validating..."
-bash "$(dirname "$0")/../../morph-helpers.sh" validate "$OUTPUT"
+python3 "$(dirname "$0")/../../morph-helpers.py" final-check "$OUTPUT"
 
 echo "✅ Build complete: $OUTPUT"

--- a/skills/morph-ppt/reference/styles/dark--neon-productivity/build.sh
+++ b/skills/morph-ppt/reference/styles/dark--neon-productivity/build.sh
@@ -287,6 +287,6 @@ JSON
 
 # Validate
 echo "Validating..."
-bash "$(dirname "$0")/../../morph-helpers.sh" validate "$OUT"
+python3 "$(dirname "$0")/../../morph-helpers.py" final-check "$OUT"
 
 echo "✅ Build complete: $OUT"

--- a/skills/morph-ppt/reference/styles/dark--space-odyssey/build.sh
+++ b/skills/morph-ppt/reference/styles/dark--space-odyssey/build.sh
@@ -739,6 +739,6 @@ officecli set "$OUTPUT" '/slide[7]/shape[44]' --prop x=4cm --prop y=10cm
 # VALIDATE & COMPLETE
 # ============================================
 echo "Validating..."
-bash "$(dirname "$0")/../../morph-helpers.sh" validate "$OUTPUT"
+python3 "$(dirname "$0")/../../morph-helpers.py" final-check "$OUTPUT"
 
 echo "✅ Build complete: $OUTPUT"

--- a/skills/morph-ppt/reference/styles/light--minimal-product/build.sh
+++ b/skills/morph-ppt/reference/styles/light--minimal-product/build.sh
@@ -502,6 +502,6 @@ officecli set "$OUTPUT" '/slide[6]/shape[37]' --prop x=11cm
 # VALIDATE & COMPLETE
 # ============================================
 echo "Validating..."
-bash "$(dirname "$0")/../../morph-helpers.sh" validate "$OUTPUT"
+python3 "$(dirname "$0")/../../morph-helpers.py" final-check "$OUTPUT"
 
 echo "✅ Build complete: $OUTPUT"

--- a/skills/morph-ppt/reference/styles/light--watercolor-wash/build.sh
+++ b/skills/morph-ppt/reference/styles/light--watercolor-wash/build.sh
@@ -481,6 +481,6 @@ officecli set "$OUTPUT" '/slide[5]/shape[30]' --prop x=4cm --prop y=10cm
 # VALIDATE & COMPLETE
 # ============================================
 echo "Validating..."
-bash "$(dirname "$0")/../../morph-helpers.sh" validate "$OUTPUT"
+python3 "$(dirname "$0")/../../morph-helpers.py" final-check "$OUTPUT"
 
 echo "✅ Build complete: $OUTPUT"

--- a/skills/morph-ppt/reference/styles/mixed--duotone-split/build.sh
+++ b/skills/morph-ppt/reference/styles/mixed--duotone-split/build.sh
@@ -267,6 +267,6 @@ echo '[
 
 # Validate and review
 echo "Validating..."
-bash "$(dirname "$0")/../../morph-helpers.sh" validate "$DECK"
+python3 "$(dirname "$0")/../../morph-helpers.py" final-check "$DECK"
 
 echo "✅ Build complete: $DECK"

--- a/skills/morph-ppt/reference/styles/warm--playful-organic/build.sh
+++ b/skills/morph-ppt/reference/styles/warm--playful-organic/build.sh
@@ -381,6 +381,6 @@ officecli set "$OUTPUT" '/slide[6]/shape[29]' --prop x=3.9cm
 # VALIDATE & COMPLETE
 # ============================================
 echo "Validating..."
-bash "$(dirname "$0")/../../morph-helpers.sh" validate "$OUTPUT"
+python3 "$(dirname "$0")/../../morph-helpers.py" final-check "$OUTPUT"
 
 echo "✅ Build complete: $OUTPUT"

--- a/skills/officecli-pitch-deck/SKILL.md
+++ b/skills/officecli-pitch-deck/SKILL.md
@@ -61,7 +61,7 @@ officecli --version
 | Animation | Standard transitions (fade, push) | Morph (shape-matching across slides) |
 | Naming convention | No special naming | `!!actor` + `#sN-content` |
 | Data visualization | Charts, tables, stat callouts | None (text + shapes only) |
-| Helper scripts | None needed | morph-helpers.sh required |
+| Helper scripts | None needed | morph-helpers.py required |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `morph-helpers.py` — cross-platform replacement for `morph-helpers.sh`, supports Mac / Windows / Linux
- Update `SKILL.md` — build script template switched to Python, shell quoting notes removed
- Fix 8 `reference/styles/*/build.sh` files — replace non-existent `validate` subcommand with correct `final-check`

## Files changed (10)
- `skills/morph-ppt/SKILL.md`
- `skills/morph-ppt/reference/morph-helpers.py` (new)
- 8 × `skills/morph-ppt/reference/styles/*/build.sh`

cc @goworm

🤖 Generated with [Claude Code](https://claude.com/claude-code)