### PR TITLE
Fix format-prefixed command routing, raw part indexing help, and Windows Git Bash path  guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,18 @@ officecli merge invoice-template.docx invoice-001.docx '{"client":"Acme","total"
 officecli validate report.docx && officecli view report.docx issues --json
 ```
 
+### Windows / Git Bash note
+
+On Windows, prefer **PowerShell** when passing OfficeCLI paths or parts that begin with `/`, such as `/document`, `/header[1]`, or `/body/p[3]`.
+
+Git Bash / MSYS may rewrite those values into filesystem paths before `officecli` sees them. If you must use Git Bash, prefix the command with:
+
+```bash
+MSYS_NO_PATHCONV=1 officecli raw doc.docx /document
+```
+
+The same caution applies to `raw-set`, `get`, `query`, `set`, `remove`, and similar commands that accept OfficeCLI document paths.
+
 ## Documentation
 
 The [Wiki](https://github.com/iOfficeAI/OfficeCLI/wiki) has detailed guides for every command, element type, and property:

--- a/README_zh.md
+++ b/README_zh.md
@@ -528,6 +528,18 @@ officecli merge invoice-template.docx invoice-001.docx '{"client":"Acme","total"
 officecli validate report.docx && officecli view report.docx issues --json
 ```
 
+### Windows / Git Bash 注意事项
+
+在 Windows 上，传入 `/document`、`/header[1]`、`/body/p[3]` 这类以 `/` 开头的 OfficeCLI 路径/part 参数时，优先使用 **PowerShell**。
+
+Git Bash / MSYS 可能会在 `officecli` 收到参数之前，把这些值自动改写成文件系统路径。若必须使用 Git Bash，请给命令加上：
+
+```bash
+MSYS_NO_PATHCONV=1 officecli raw doc.docx /document
+```
+
+同样的注意事项也适用于 `raw-set`、`get`、`query`、`set`、`remove` 等接受 OfficeCLI 文档路径参数的命令。
+
 ## 文档
 
 [Wiki](https://github.com/iOfficeAI/OfficeCLI/wiki) 提供了每个命令、元素类型和属性的详细指南：

--- a/SKILL.md
+++ b/SKILL.md
@@ -227,6 +227,7 @@ Run `officecli <format> raw` for available parts per format.
 | Guessing property names | ❌ Run `officecli <format> set <element>` to see exact names |
 | Modifying an open file | ❌ Close the file in PowerPoint/WPS first |
 | `\n` in shell strings | ❌ Use `\\n` for newlines in `--prop text="..."` |
+| Windows Git Bash with `/document` or `/body/...` | ❌ MSYS may rewrite OfficeCLI paths into filesystem paths. Prefer PowerShell on Windows, or run commands with `MSYS_NO_PATHCONV=1` |
 
 ---
 

--- a/src/officecli/CommandBuilder.cs
+++ b/src/officecli/CommandBuilder.cs
@@ -907,7 +907,7 @@ static class CommandBuilder
 
         // ==================== raw command ====================
         var rawFileArg = new Argument<FileInfo>("file") { Description = "Office document path (required even with open/close mode)" };
-        var rawPathArg = new Argument<string>("part") { Description = "Part path (e.g. /document, /styles, /header[0])" };
+        var rawPathArg = new Argument<string>("part") { Description = "Part path (e.g. /document, /styles, /header[1])" };
         rawPathArg.DefaultValueFactory = _ => "/document";
 
         var rawStartOpt = new Option<int?>("--start") { Description = "Start row number (Excel sheets only)" };

--- a/src/officecli/HelpCommands.cs
+++ b/src/officecli/HelpCommands.cs
@@ -8,6 +8,7 @@ namespace OfficeCli;
 /// <summary>
 /// Format-specific help: docx, xlsx, pptx with nested verb help (view, get, set, add, etc.).
 /// These are help-only commands — they do not execute any document operations.
+/// Real format-prefixed commands are rewritten in Program.cs before this handler runs.
 /// Args are intercepted before System.CommandLine parsing so --help works naturally.
 /// </summary>
 internal static class HelpCommands
@@ -49,10 +50,25 @@ internal static class HelpCommands
             break;
         }
 
-        // If extra args beyond element look like file paths or document paths,
-        // this is a real command — don't intercept for help
-        if (extraArg != null && (extraArg.Contains('.') || extraArg.Contains('/')))
-            return false;
+        static bool LooksLikeOfficeFilePath(string arg)
+        {
+            if (string.IsNullOrWhiteSpace(arg) || arg.StartsWith("--"))
+                return false;
+
+            var ext = System.IO.Path.GetExtension(arg).ToLowerInvariant();
+            return ext is ".doc" or ".docx" or ".xls" or ".xlsx" or ".ppt" or ".pptx";
+        }
+
+        if (verb is "add" or "set" or "get" or "query" or "remove" or "view" or "raw" or "raw-set")
+        {
+            if (elementArg != null && LooksLikeOfficeFilePath(elementArg))
+                return false;
+
+            // If extra args beyond element look like file paths or document paths,
+            // this is a real command — don't intercept for help
+            if (extraArg != null && (LooksLikeOfficeFilePath(extraArg) || extraArg.Contains('/') || extraArg.Contains('\\')))
+                return false;
+        }
 
         // Parse element.property syntax
         string? element = null;
@@ -570,8 +586,8 @@ Available parts:
   /styles        Style definitions
   /numbering     List/numbering definitions
   /settings      Document settings
-  /header[N]     Header N (0-based)
-  /footer[N]     Footer N (0-based)
+  /header[N]     Header N (1-based)
+  /footer[N]     Footer N (1-based)
 
 raw-set actions: append, prepend, insertbefore, insertafter, replace, remove, setattr
 No xmlns declarations needed -- prefixes auto-registered: w, a, r, mc, wp, wps, v, wp14

--- a/src/officecli/Program.cs
+++ b/src/officecli/Program.cs
@@ -116,30 +116,43 @@ if (args.Length == 0)
     return 0;
 }
 
+static bool LooksLikeOfficeFilePath(string arg)
+{
+    if (string.IsNullOrWhiteSpace(arg) || arg.StartsWith("--"))
+        return false;
+
+    var ext = System.IO.Path.GetExtension(arg).ToLowerInvariant();
+    return ext is ".doc" or ".docx" or ".xls" or ".xlsx" or ".ppt" or ".pptx";
+}
+
+// Rewrite real format-prefixed commands before help interception.
+// Examples:
+//   officecli docx view file.docx outline   -> officecli view file.docx outline
+//   officecli docx raw file.docx /document  -> officecli raw file.docx /document
+//   officecli xlsx add chart file.xlsx /    -> officecli add file.xlsx / --type chart
+if (args.Length >= 3 && args[0].ToLowerInvariant() is "docx" or "xlsx" or "pptx")
+{
+    var verb = args[1].ToLowerInvariant();
+    if (verb == "add")
+    {
+        if (args.Length >= 5 && LooksLikeOfficeFilePath(args[3]))
+        {
+            var newArgs = new List<string> { "add", args[3], args[4], "--type", args[2] };
+            newArgs.AddRange(args.Skip(5));
+            args = newArgs.ToArray();
+        }
+    }
+    else if (verb is "set" or "get" or "query" or "remove" or "view" or "raw" or "raw-set")
+    {
+        if (LooksLikeOfficeFilePath(args[2]))
+            args = new[] { verb }.Concat(args.Skip(2)).ToArray();
+    }
+}
+
 // Handle help commands (docx/xlsx/pptx) before System.CommandLine parsing
 // so that --help also shows our custom output instead of the default help
 if (OfficeCli.HelpCommands.TryHandle(args))
     return 0;
-
-// Rewrite format-prefixed commands: "xlsx add cell <file> <path> ..." → "add <file> <path> --type cell ..."
-// This allows users to type "officecli xlsx add cell file.xlsx /Sheet1 --prop ..."
-// instead of "officecli add file.xlsx /Sheet1 --type cell --prop ..."
-if (args.Length >= 4 && args[0].ToLowerInvariant() is "docx" or "xlsx" or "pptx"
-    && args[1].ToLowerInvariant() is "add" or "set" or "get" or "query" or "remove" or "view" or "raw")
-{
-    var verb = args[1];
-    var elementType = args[2];
-    var rest = args.Skip(3).ToList();
-    // Only rewrite if the next arg looks like a file path (not a flag)
-    if (rest.Count > 0 && !rest[0].StartsWith("--"))
-    {
-        var newArgs = new List<string> { verb };
-        newArgs.AddRange(rest);
-        if (verb.Equals("add", StringComparison.OrdinalIgnoreCase))
-            newArgs.InsertRange(2, ["--type", elementType]);
-        args = newArgs.ToArray();
-    }
-}
 
 var parseResult = rootCommand.Parse(args);
 return parseResult.Invoke();


### PR DESCRIPTION
## Summary
 
 This PR fixes two real usability issues found during Windows-based AI usage, and adds a 
small documentation guardrail for a common shell pitfall.
 
 ## Problems
 
 1. Real format-prefixed commands could be mistaken for help navigation.
    - Example:
      - `officecli docx view file.docx outline`
      - `officecli docx raw file.docx /document`
      - `officecli xlsx add chart file.xlsx /Sheet1`
    - In these cases, OfficeCLI could show help or mis-handle arguments instead of 
executing the command.
 
 2. The help text for `/header[n]` and `/footer[n]` was inconsistent with the 
implementation.
    - Help described them as 0-based.
    - Actual runtime behavior is 1-based.
 
 3. On Windows, Git Bash / MSYS may rewrite OfficeCLI paths like `/document` or 
`/body/p[1]` into filesystem paths before OfficeCLI receives them.
    - This caused confusing failures during AI-driven runs.
 
 ## Changes
 
 - `src/officecli/Program.cs`
   - Rewrite real format-prefixed commands before help interception.
   - Support correct routing for:
     - `view`
     - `get`
     - `query`
     - `set`
     - `remove`
     - `raw`
     - `raw-set`
     - `add <type> <file> <path> ...`
 
 - `src/officecli/HelpCommands.cs`
   - Avoid intercepting real commands as help when the arguments clearly look like file 
paths or OfficeCLI document paths.
   - Keep the guard scoped to the relevant verbs.
   - Update `/header[n]` and `/footer[n]` help text to 1-based.
 
 - `src/officecli/CommandBuilder.cs`
   - Update the raw part example from `/header[0]` to `/header[1]`.
 
 - `README.md`
 - `README_zh.md`
 - `SKILL.md`
   - Add a Windows / Git Bash / MSYS note for `/document`-style OfficeCLI paths.
   - Recommend PowerShell on Windows or `MSYS_NO_PATHCONV=1` when using Git Bash.
 
 ## Why this matters
 
 These changes reduce false help-routing, fix misleading raw-part guidance, and make 
Windows AI usage much more predictable.
 
 ## Validation
 
 - `git diff --check` passed.
 - Logic-level rewrite checks confirmed expected routing behavior for representative 
inputs.
 - Full build/runtime validation is currently blocked in this environment because the 
machine does not have a .NET 10 SDK (`NETSDK1045`).