### PR TITLE
feat: extend LaTeX-to-OMML converter for math/stats education

### DIFF
--- a/src/officecli/Core/FormulaParser.cs
+++ b/src/officecli/Core/FormulaParser.cs
@@ -1213,11 +1213,11 @@ public static class FormulaParser
                 var cancelArg = ParseBracedArg(tokens, ref pos);
                 var bbPr = new M.BorderBoxProperties();
                 if (cmd is "bcancel")
-                    bbPr.AppendChild(new M.StrikeBLTR { Val = M.BooleanValues.True });
+                    bbPr.AppendChild(new M.StrikeBottomLeftToTopRight { Val = M.BooleanValues.True });
                 else if (cmd is "xcancel")
                 {
                     bbPr.AppendChild(new M.StrikeHorizontal { Val = M.BooleanValues.True });
-                    bbPr.AppendChild(new M.StrikeBLTR { Val = M.BooleanValues.True });
+                    bbPr.AppendChild(new M.StrikeBottomLeftToTopRight { Val = M.BooleanValues.True });
                 }
                 else
                     bbPr.AppendChild(new M.StrikeHorizontal { Val = M.BooleanValues.True });


### PR DESCRIPTION
## Summary

Extends the `FormulaParser.cs` LaTeX→OMML converter to handle constructs commonly used in math and statistics education that currently fall through to literal text output.

**Problem:** When a math teacher writes `\boxed{x=5}`, `\underbrace{...}_{n}`, `\color{red}{x}`, `\pmod{n}`, `\arctan`, `\begin{align}`, or `\left\langle ... \right\rangle`, the current parser doesn't recognize these and outputs literal backslash-prefixed text.

**Solution:** 278 lines of new OMML generation covering:

- **\boxed** → `m:borderBox`
- **\underbrace/\overbrace** → `m:groupChr` with labels
- **\color{name}{}** → `m:r` with `w:color` run property (20+ named colors)
- **\cancel** → proper `m:borderBox` with `m:strikeH` (replaces Unicode combining overlay)
- **\pmod{n}** → `m:d` delimiter with upright "mod"
- **\arcsin/\arccos/\arctan** etc → upright function names
- **\operatorname{name}** → custom upright operators with limit support
- **\begin{align/aligned/gathered/split}** → `m:m` matrix for multi-line equations
- **\begin{array}{cc}** → matrix with column spec handling
- **\left\langle ... \right\rangle** → proper `m:d` delimiters
- **Set notation** → `\emptyset`, `\setminus`, `\complement`, `\cap`, `\cup`
- **Math spacing** → `\,` `\;` `\!`

## Test plan

- [ ] `\boxed{x=5}` → bordered box
- [ ] `\underbrace{x+\cdots+x}_{n}` → brace with label
- [ ] `\color{red}{x} + \color{blue}{y}` → colored runs
- [ ] `\cancel{3}` → strikethrough via borderBox
- [ ] `\pmod{n}` → (mod n)
- [ ] `\arctan(\frac{y}{x})` → upright arctan
- [ ] `\left\langle a,b \right\rangle` → angle brackets
- [ ] `\begin{align}` → aligned multi-line
- [ ] `officecli validate` passes on all outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)