### PR TITLE
fix: resolve named pipe deadlock on Windows for open/close commands

### DIFF
--- a/src/officecli/CommandBuilder.cs
+++ b/src/officecli/CommandBuilder.cs
@@ -46,7 +46,46 @@ static partial class CommandBuilder
                 return 0;
             }
 
-            // Fork a background process running the resident server
+            if (OperatingSystem.IsWindows())
+            {
+                // Windows: run the resident server in-process on a background thread.
+                // Forking a child process deadlocks on Windows due to .NET single-file
+                // host + redirected-pipe interactions. In-process avoids this while
+                // keeping the same named-pipe API.
+                //
+                // Readiness is detected via ManualResetEventSlim instead of connecting
+                // back through the named pipe (same-process pipe I/O via
+                // StreamReader/StreamWriter deadlocks on Windows).
+                var server = new ResidentServer(filePath);
+                var cts = new CancellationTokenSource();
+                var serverTask = Task.Run(() => server.RunAsync(cts.Token));
+
+                if (!server.WaitUntilReady(TimeSpan.FromSeconds(5)))
+                {
+                    if (serverTask.IsCompleted)
+                    {
+                        server.Dispose();
+                        if (serverTask.IsFaulted)
+                            throw new InvalidOperationException($"Resident server failed: {serverTask.Exception?.InnerException?.Message}");
+                        throw new InvalidOperationException("Resident server exited unexpectedly.");
+                    }
+                    cts.Cancel();
+                    server.Dispose();
+                    throw new InvalidOperationException("Resident server failed to start.");
+                }
+
+                var msg2 = $"Opened {file.Name} (remember to call close when done)";
+                if (json) Console.WriteLine(OutputFormatter.WrapEnvelopeText(msg2));
+                else Console.WriteLine(msg2);
+                // Block on the server task — keeps the process alive until
+                // close is called via the named pipe.
+                try { serverTask.GetAwaiter().GetResult(); } catch (OperationCanceledException) { }
+                server.Dispose();
+                return 0;
+            }
+
+            // Linux/macOS: fork a background process running the resident server.
+            // The open command returns immediately, leaving the child alive.
             var exePath = Environment.ProcessPath ?? Process.GetCurrentProcess().MainModule?.FileName;
             if (exePath == null)
                 throw new InvalidOperationException("Cannot determine executable path.");
@@ -71,9 +110,9 @@ static partial class CommandBuilder
                 Thread.Sleep(100);
                 if (ResidentClient.TryConnect(filePath, out _))
                 {
-                    var msg = $"Opened {file.Name} (remember to call close when done)";
-                    if (json) Console.WriteLine(OutputFormatter.WrapEnvelopeText(msg));
-                    else Console.WriteLine(msg);
+                    var msg2 = $"Opened {file.Name} (remember to call close when done)";
+                    if (json) Console.WriteLine(OutputFormatter.WrapEnvelopeText(msg2));
+                    else Console.WriteLine(msg2);
                     return 0;
                 }
                 if (process.HasExited)

--- a/src/officecli/Core/ResidentClient.cs
+++ b/src/officecli/Core/ResidentClient.cs
@@ -20,15 +20,12 @@ public static class ResidentClient
             using var client = new NamedPipeClientStream(".", pipeName + "-ping", PipeDirection.InOut);
             client.Connect(100); // 100ms timeout
 
-            using var reader = new StreamReader(client, Encoding.UTF8, leaveOpen: true);
-            using var writer = new StreamWriter(client, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
-
             // Ping to verify it's the right file
             var pingRequest = new ResidentRequest { Command = "__ping__" };
             var json = System.Text.Json.JsonSerializer.Serialize(pingRequest, ResidentJsonContext.Default.ResidentRequest);
-            writer.WriteLine(json);
+            PipeWriteLine(client, json);
 
-            var responseLine = reader.ReadLine();
+            var responseLine = PipeReadLine(client);
             if (responseLine == null) return false;
 
             var response = System.Text.Json.JsonSerializer.Deserialize<ResidentResponse>(responseLine, ResidentJsonContext.Default.ResidentResponse);
@@ -60,13 +57,10 @@ public static class ResidentClient
                 using var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut);
                 client.Connect(1000); // 1s timeout (was 200ms — too short under load)
 
-                using var reader = new StreamReader(client, Encoding.UTF8, leaveOpen: true);
-                using var writer = new StreamWriter(client, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
-
                 var json = System.Text.Json.JsonSerializer.Serialize(request, ResidentJsonContext.Default.ResidentRequest);
-                writer.WriteLine(json);
+                PipeWriteLine(client, json);
 
-                var responseLine = reader.ReadLine();
+                var responseLine = PipeReadLine(client);
                 if (responseLine == null) continue;
 
                 var response = System.Text.Json.JsonSerializer.Deserialize<ResidentResponse>(responseLine, ResidentJsonContext.Default.ResidentResponse);
@@ -91,16 +85,13 @@ public static class ResidentClient
         try
         {
             using var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut);
-            client.Connect(200);
-
-            using var reader = new StreamReader(client, Encoding.UTF8, leaveOpen: true);
-            using var writer = new StreamWriter(client, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
+            client.Connect(2000);
 
             var request = new ResidentRequest { Command = "__close__" };
             var json = System.Text.Json.JsonSerializer.Serialize(request, ResidentJsonContext.Default.ResidentRequest);
-            writer.WriteLine(json);
+            PipeWriteLine(client, json);
 
-            var responseLine = reader.ReadLine();
+            var responseLine = PipeReadLine(client);
             if (responseLine == null) return false;
 
             var response = System.Text.Json.JsonSerializer.Deserialize<ResidentResponse>(responseLine, ResidentJsonContext.Default.ResidentResponse);
@@ -109,6 +100,41 @@ public static class ResidentClient
         catch
         {
             return false;
+        }
+    }
+
+    // ==================== Pipe I/O helpers ====================
+    //
+    // On Windows, StreamReader/StreamWriter deadlock on named pipes under .NET 11
+    // preview — the managed stream wrapper's internal buffering stalls reads even
+    // when bytes are available on the wire.  Raw byte I/O avoids the issue.
+    //
+    // On Linux/macOS, StreamReader/StreamWriter work fine, but raw byte I/O is
+    // equally correct and avoids any future cross-platform divergence, so we use
+    // the same path everywhere.
+
+    private static void PipeWriteLine(Stream pipe, string line)
+    {
+        var bytes = Encoding.UTF8.GetBytes(line + "\n");
+        pipe.Write(bytes, 0, bytes.Length);
+        pipe.Flush();
+    }
+
+    private static string? PipeReadLine(Stream pipe)
+    {
+        var buffer = new byte[1];
+        var lineBytes = new List<byte>(256);
+        while (true)
+        {
+            var bytesRead = pipe.Read(buffer, 0, 1);
+            if (bytesRead == 0) return lineBytes.Count > 0 ? Encoding.UTF8.GetString(lineBytes.ToArray()) : null;
+            if (buffer[0] == (byte)'\n')
+            {
+                if (lineBytes.Count > 0 && lineBytes[^1] == (byte)'\r')
+                    lineBytes.RemoveAt(lineBytes.Count - 1);
+                return Encoding.UTF8.GetString(lineBytes.ToArray());
+            }
+            lineBytes.Add(buffer[0]);
         }
     }
 }

--- a/src/officecli/Core/ResidentServer.cs
+++ b/src/officecli/Core/ResidentServer.cs
@@ -16,9 +16,17 @@ public class ResidentServer : IDisposable
     private readonly SemaphoreSlim _commandLock = new(1, 1);
     private readonly TimeSpan _idleTimeout = TimeSpan.FromMinutes(12);
     private CancellationTokenSource _idleCts = new();
+    private readonly ManualResetEventSlim _ready = new(false);
     private bool _disposed;
 
     public string PipeName => _pipeName;
+
+    /// <summary>
+    /// Blocks until the server is accepting connections, or the timeout expires.
+    /// For use by in-process callers that cannot connect through the named pipe
+    /// without deadlocking (same-process pipe read/write buffering issue on Windows).
+    /// </summary>
+    public bool WaitUntilReady(TimeSpan timeout) => _ready.Wait(timeout);
 
     public ResidentServer(string filePath, bool editable = true)
     {
@@ -46,6 +54,9 @@ public class ResidentServer : IDisposable
 
         // Start idle watchdog
         var idleTask = RunIdleWatchdogAsync(token);
+
+        // Signal that pipe listeners are up and the server is ready for connections
+        _ready.Set();
 
         // Main command loop - accept connections concurrently, serialize command execution
         while (!token.IsCancellationRequested)
@@ -118,22 +129,24 @@ public class ResidentServer : IDisposable
             try
             {
                 await server.WaitForConnectionAsync(token);
-                using var reader = new StreamReader(server, Encoding.UTF8, leaveOpen: true);
-                using var writer = new StreamWriter(server, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
 
-                var requestLine = await reader.ReadLineAsync(token);
+                // Use raw byte I/O instead of StreamReader/StreamWriter.
+                // StreamReader.ReadLineAsync(CancellationToken) can deadlock on
+                // Windows named pipes under .NET 11 preview — the cancellation-aware
+                // overload uses a different code path that never completes the read.
+                var requestLine = await ReadLineFromPipeAsync(server, token);
                 if (requestLine != null)
                 {
                     var request = System.Text.Json.JsonSerializer.Deserialize<ResidentRequest>(requestLine, ResidentJsonContext.Default.ResidentRequest);
                     if (request?.Command == "__ping__")
                     {
                         var response = MakeResponse(0, _filePath, "");
-                        await writer.WriteLineAsync(response.AsMemory(), token);
+                        await WriteLineToPipeAsync(server, response, token);
                     }
                     else if (request?.Command == "__close__")
                     {
                         var response = MakeResponse(0, "Closing resident.", "");
-                        await writer.WriteLineAsync(response.AsMemory(), token);
+                        await WriteLineToPipeAsync(server, response, token);
                         _cts.Cancel();
                         // Kick the main pipe listener out of WaitForConnectionAsync
                         try
@@ -190,14 +203,11 @@ public class ResidentServer : IDisposable
 
     private async Task HandleClientAsync(NamedPipeServerStream server, CancellationToken token)
     {
-        using var reader = new StreamReader(server, Encoding.UTF8, leaveOpen: true);
-        using var writer = new StreamWriter(server, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
-
-        var requestLine = await reader.ReadLineAsync(token);
+        var requestLine = await ReadLineFromPipeAsync(server, token);
         if (requestLine == null) return;
 
         var response = ProcessRequest(requestLine);
-        await writer.WriteLineAsync(response.AsMemory(), token);
+        await WriteLineToPipeAsync(server, response, token);
     }
 
     private string ProcessRequest(string requestLine)
@@ -696,6 +706,41 @@ public class ResidentServer : IDisposable
         return System.Text.Json.JsonSerializer.Serialize(response, ResidentJsonContext.Default.ResidentResponse);
     }
 
+    /// <summary>
+    /// Read a single newline-terminated line from a pipe using raw byte I/O.
+    /// Avoids StreamReader.ReadLineAsync(CancellationToken) which deadlocks on
+    /// Windows named pipes under certain .NET versions.  Safe cross-platform;
+    /// used on all OSes to avoid divergent code paths.
+    /// </summary>
+    private static async Task<string?> ReadLineFromPipeAsync(Stream pipe, CancellationToken token)
+    {
+        var buffer = new byte[1];
+        var lineBytes = new List<byte>(256);
+        while (true)
+        {
+            var bytesRead = await pipe.ReadAsync(buffer.AsMemory(0, 1), token);
+            if (bytesRead == 0) return lineBytes.Count > 0 ? Encoding.UTF8.GetString(lineBytes.ToArray()) : null;
+            if (buffer[0] == (byte)'\n')
+            {
+                // Strip trailing \r if present
+                if (lineBytes.Count > 0 && lineBytes[^1] == (byte)'\r')
+                    lineBytes.RemoveAt(lineBytes.Count - 1);
+                return Encoding.UTF8.GetString(lineBytes.ToArray());
+            }
+            lineBytes.Add(buffer[0]);
+        }
+    }
+
+    /// <summary>
+    /// Write a line to a pipe using raw byte I/O (avoids StreamWriter buffering issues).
+    /// </summary>
+    private static async Task WriteLineToPipeAsync(Stream pipe, string line, CancellationToken token)
+    {
+        var bytes = Encoding.UTF8.GetBytes(line + "\n");
+        await pipe.WriteAsync(bytes, token);
+        await pipe.FlushAsync(token);
+    }
+
     public void Dispose()
     {
         if (!_disposed)
@@ -731,6 +776,7 @@ public class ResidentServer : IDisposable
 
             _cts.Dispose();
             _idleCts.Dispose();
+            _ready.Dispose();
         }
     }
 


### PR DESCRIPTION
## Summary

- `officecli open` and `officecli close` were completely broken on Windows — the process hung indefinitely with no output
- Root cause: `StreamReader`/`StreamWriter` deadlock on Windows named pipes under .NET 11 preview. The managed stream wrapper's internal buffering stalls reads even when bytes are available on the wire.
- Affects both in-process and cross-process pipe communication

## Changes

- **ResidentServer**: Replace `StreamReader.ReadLineAsync`/`StreamWriter.WriteLineAsync` with raw byte I/O helpers (`ReadLineFromPipeAsync`/`WriteLineToPipeAsync`)
- **ResidentClient**: Replace `StreamReader`/`StreamWriter` with raw byte I/O helpers (`PipeReadLine`/`PipeWriteLine`)  
- **CommandBuilder (open)**: On Windows, run resident server in-process via `Task.Run` + `ManualResetEventSlim` readiness signal instead of forking a child process (which also deadlocked on the single-file host). Linux/macOS keeps the original `Process.Start` fork behavior unchanged.

Raw byte I/O is used on all platforms for the pipe protocol to avoid divergent code paths.

## Test plan

- [x] `officecli open` + `close` (text mode, .docx)
- [x] `officecli open` + `close` (JSON mode, .pptx)
- [x] `officecli open` + `view` + `close` (commands via resident)
- [x] Already-running detection (second `open` detects existing resident)
- [x] `__resident-serve__` out-of-process + `close` (.xlsx)
- [x] Self-contained published binary (PublishSingleFile + PublishTrimmed)
- [x] Linux/macOS code path preserved (Process.Start fork, no behavioral change)