### PR TITLE
chore: add .gitignore for build artifacts and IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Build outputs
+[Bb]in/
+[Oo]bj/
+
+# Visual Studio
+.vs/
+*.user
+*.suo
+
+# Rider / JetBrains
+.idea/
+
+# OS files
+Thumbs.db
+.DS_Store
+
+# NuGet
+*.nupkg


### PR DESCRIPTION
## Summary

Add a `.gitignore` file to exclude common build artifacts and IDE files from version control.

## Problem

The repository currently has no `.gitignore`, causing `bin/`, `obj/`, `.vs/`, and other build outputs (~240 files) to appear as untracked files. This is especially problematic for contributors who build locally.

## Changes

Added `.gitignore` with standard .NET/C# ignore patterns:

- `bin/` / `obj/` — build outputs
- `.vs/` / `*.user` / `*.suo` — Visual Studio files
- `.idea/` — JetBrains Rider files
- `Thumbs.db` / `.DS_Store` — OS files
- `*.nupkg` — NuGet packages

## Notes

- No existing tracked files are affected (these directories were never committed)
- Follows standard .NET gitignore conventions
