### PR TITLE
[codex] docs(skills): standardize officecli install guidance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -7,25 +7,33 @@ description: Create, analyze, proofread, and modify Office documents (.docx, .xl
 
 AI-friendly CLI for .docx, .xlsx, .pptx. Single binary, no dependencies, no Office installation needed.
 
-## Install & Update
+## Install
 
-Same command for both install and upgrade:
+**Install `officecli` if needed:**
+
+`macOS / Linux`
 
 ```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+if ! command -v officecli >/dev/null 2>&1; then
+    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
+fi
 ```
 
-After installation, run `source ~/.zshrc` (macOS) or `source ~/.bashrc` (Linux) to make the `officecli` command available.
+`Windows (PowerShell)`
 
-Running bare `officecli` (no arguments) also triggers auto-install.
+```powershell
+if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
+    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+}
+```
 
-Verify: `officecli --version`
+**Then verify installation:**
 
-officecli auto-updates daily in the background.
+```text
+officecli --version
+```
+
+If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,7 +9,7 @@ AI-friendly CLI for .docx, .xlsx, .pptx. Single binary, no dependencies, no Offi
 
 ## Install
 
-**Install `officecli` if needed:**
+If `officecli` is not installed:
 
 `macOS / Linux`
 
@@ -27,11 +27,7 @@ if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
 }
 ```
 
-**Then verify installation:**
-
-```text
-officecli --version
-```
+Verify: `officecli --version`
 
 If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 

--- a/skills/morph-ppt/SKILL.md
+++ b/skills/morph-ppt/SKILL.md
@@ -107,7 +107,7 @@ For every morph transition, plan the slide pair BEFORE writing any code. Use a t
 
 **FIRST: Install `officecli` if needed**
 
-Follow the installation check in `reference/officecli-pptx-min.md` section 0.
+Follow the install section in `reference/officecli-pptx-min.md` section 0.
 
 **IMPORTANT: Use morph-helpers for reliable workflow**
 

--- a/skills/morph-ppt/SKILL.md
+++ b/skills/morph-ppt/SKILL.md
@@ -105,9 +105,9 @@ For every morph transition, plan the slide pair BEFORE writing any code. Use a t
 - Do **not** click "Open with system app" during generation, to avoid file lock / write conflicts.
 - Use clear, direct language and make this a concrete warning, not an optional suggestion.
 
-**FIRST: Ensure latest officecli version**
+**FIRST: Install `officecli` if needed**
 
-Follow the installation check in `reference/officecli-pptx-min.md` section 0 (checks version and upgrades only if needed).
+Follow the installation check in `reference/officecli-pptx-min.md` section 0.
 
 **IMPORTANT: Use morph-helpers for reliable workflow**
 

--- a/skills/morph-ppt/reference/officecli-pptx-min.md
+++ b/skills/morph-ppt/reference/officecli-pptx-min.md
@@ -3,37 +3,35 @@ name: officecli-commands
 description: OfficeCli Command Reference — PPT generation and validation commands
 ---
 
-# OfficeCli PPT Command Reference
+# OfficeCLI PPT Command Reference
 
 ## 0) BEFORE YOU START (CRITICAL)
 
-**Every time before using officecli, run this check:**
+**Install `officecli` if needed:**
+
+`macOS / Linux`
 
 ```bash
-# Check if installed
-if ! command -v officecli &> /dev/null; then
-    echo "Installing officecli..."
-    # macOS/Linux
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    # Windows: irm https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.ps1 | iex
-else
-    # Check if update needed
-    CURRENT=$(officecli --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-    LATEST=$(curl -fsSL https://api.github.com/repos/iOfficeAI/OfficeCLI/releases/latest | grep '"tag_name"' | sed -E 's/.*"v?([0-9.]+)".*/\1/')
-
-    if [ "$CURRENT" != "$LATEST" ]; then
-        echo "Upgrading officecli $CURRENT → $LATEST..."
-        curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    else
-        echo "officecli $CURRENT is up to date"
-    fi
+if ! command -v officecli >/dev/null 2>&1; then
+    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
 fi
+```
 
-# Verify version
+`Windows (PowerShell)`
+
+```powershell
+if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
+    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+}
+```
+
+**Then verify installation:**
+
+```text
 officecli --version
 ```
 
-**Why:** This ensures you have the latest features and bug fixes before starting work.
+If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 
 ---
 
@@ -77,7 +75,7 @@ officecli set demo.pptx '/slide[1]/shape[1]' --prop gradient="linear:90:FF0000,0
 officecli validate demo.pptx
 ```
 
-**For comprehensive reference:** https://github.com/iOfficeAI/OfficeCli/wiki/agent-guide
+**For comprehensive reference:** https://github.com/iOfficeAI/OfficeCLI/wiki/agent-guide
 
 ---
 

--- a/skills/morph-ppt/reference/officecli-pptx-min.md
+++ b/skills/morph-ppt/reference/officecli-pptx-min.md
@@ -7,7 +7,7 @@ description: OfficeCli Command Reference — PPT generation and validation comma
 
 ## 0) BEFORE YOU START (CRITICAL)
 
-**Install `officecli` if needed:**
+**If `officecli` is not installed:**
 
 `macOS / Linux`
 
@@ -25,11 +25,7 @@ if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
 }
 ```
 
-**Then verify installation:**
-
-```text
-officecli --version
-```
+Verify: `officecli --version`
 
 If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 

--- a/skills/officecli-academic-paper/SKILL.md
+++ b/skills/officecli-academic-paper/SKILL.md
@@ -12,7 +12,7 @@ Create formally structured Word documents with Table of Contents, equations (LaT
 
 ## BEFORE YOU START (CRITICAL)
 
-**Install `officecli` if needed:**
+**If `officecli` is not installed:**
 
 `macOS / Linux`
 
@@ -30,11 +30,7 @@ if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
 }
 ```
 
-**Then verify installation:**
-
-```text
-officecli --version
-```
+Verify: `officecli --version`
 
 If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 

--- a/skills/officecli-academic-paper/SKILL.md
+++ b/skills/officecli-academic-paper/SKILL.md
@@ -12,25 +12,31 @@ Create formally structured Word documents with Table of Contents, equations (LaT
 
 ## BEFORE YOU START (CRITICAL)
 
-**Every time before using officecli, run this check:**
+**Install `officecli` if needed:**
+
+`macOS / Linux`
 
 ```bash
-if ! command -v officecli &> /dev/null; then
-    echo "Installing officecli..."
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    # Windows: irm https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.ps1 | iex
-else
-    CURRENT=$(officecli --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-    LATEST=$(curl -fsSL https://api.github.com/repos/iOfficeAI/OfficeCLI/releases/latest | grep '"tag_name"' | sed -E 's/.*"v?([0-9.]+)".*/\1/')
-    if [ "$CURRENT" != "$LATEST" ]; then
-        echo "Upgrading officecli $CURRENT -> $LATEST..."
-        curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    else
-        echo "officecli $CURRENT is up to date"
-    fi
+if ! command -v officecli >/dev/null 2>&1; then
+    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
 fi
+```
+
+`Windows (PowerShell)`
+
+```powershell
+if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
+    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+}
+```
+
+**Then verify installation:**
+
+```text
 officecli --version
 ```
+
+If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 
 ---
 

--- a/skills/officecli-data-dashboard/SKILL.md
+++ b/skills/officecli-data-dashboard/SKILL.md
@@ -12,7 +12,7 @@ Create professional, formula-driven Excel dashboards from CSV or tabular data. T
 
 ## BEFORE YOU START (CRITICAL)
 
-**Install `officecli` if needed:**
+**If `officecli` is not installed:**
 
 `macOS / Linux`
 
@@ -30,11 +30,7 @@ if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
 }
 ```
 
-**Then verify installation:**
-
-```text
-officecli --version
-```
+Verify: `officecli --version`
 
 If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 

--- a/skills/officecli-data-dashboard/SKILL.md
+++ b/skills/officecli-data-dashboard/SKILL.md
@@ -12,25 +12,31 @@ Create professional, formula-driven Excel dashboards from CSV or tabular data. T
 
 ## BEFORE YOU START (CRITICAL)
 
-**Every time before using officecli, run this check:**
+**Install `officecli` if needed:**
+
+`macOS / Linux`
 
 ```bash
-if ! command -v officecli &> /dev/null; then
-    echo "Installing officecli..."
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    # Windows: irm https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.ps1 | iex
-else
-    CURRENT=$(officecli --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-    LATEST=$(curl -fsSL https://api.github.com/repos/iOfficeAI/OfficeCLI/releases/latest | grep '"tag_name"' | sed -E 's/.*"v?([0-9.]+)".*/\1/')
-    if [ "$CURRENT" != "$LATEST" ]; then
-        echo "Upgrading officecli $CURRENT -> $LATEST..."
-        curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    else
-        echo "officecli $CURRENT is up to date"
-    fi
+if ! command -v officecli >/dev/null 2>&1; then
+    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
 fi
+```
+
+`Windows (PowerShell)`
+
+```powershell
+if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
+    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+}
+```
+
+**Then verify installation:**
+
+```text
 officecli --version
 ```
+
+If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 
 ---
 

--- a/skills/officecli-docx/SKILL.md
+++ b/skills/officecli-docx/SKILL.md
@@ -9,7 +9,7 @@ description: "Use this skill any time a .docx file is involved -- as input, outp
 
 ## BEFORE YOU START (CRITICAL)
 
-**Install `officecli` if needed:**
+**If `officecli` is not installed:**
 
 `macOS / Linux`
 
@@ -27,11 +27,7 @@ if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
 }
 ```
 
-**Then verify installation:**
-
-```text
-officecli --version
-```
+Verify: `officecli --version`
 
 If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 

--- a/skills/officecli-docx/SKILL.md
+++ b/skills/officecli-docx/SKILL.md
@@ -9,25 +9,31 @@ description: "Use this skill any time a .docx file is involved -- as input, outp
 
 ## BEFORE YOU START (CRITICAL)
 
-**Every time before using officecli, run this check:**
+**Install `officecli` if needed:**
+
+`macOS / Linux`
 
 ```bash
-if ! command -v officecli &> /dev/null; then
-    echo "Installing officecli..."
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    # Windows: irm https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.ps1 | iex
-else
-    CURRENT=$(officecli --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-    LATEST=$(curl -fsSL https://api.github.com/repos/iOfficeAI/OfficeCLI/releases/latest | grep '"tag_name"' | sed -E 's/.*"v?([0-9.]+)".*/\1/')
-    if [ "$CURRENT" != "$LATEST" ]; then
-        echo "Upgrading officecli $CURRENT → $LATEST..."
-        curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    else
-        echo "officecli $CURRENT is up to date"
-    fi
+if ! command -v officecli >/dev/null 2>&1; then
+    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
 fi
+```
+
+`Windows (PowerShell)`
+
+```powershell
+if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
+    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+}
+```
+
+**Then verify installation:**
+
+```text
 officecli --version
 ```
+
+If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 
 ---
 # officecli: v1.0.23

--- a/skills/officecli-financial-model/SKILL.md
+++ b/skills/officecli-financial-model/SKILL.md
@@ -20,25 +20,31 @@ Build formula-driven, multi-sheet financial models from scratch in Excel. Every 
 
 ## BEFORE YOU START (CRITICAL)
 
-**Every time before using officecli, run this check:**
+**Install `officecli` if needed:**
+
+`macOS / Linux`
 
 ```bash
-if ! command -v officecli &> /dev/null; then
-    echo "Installing officecli..."
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    # Windows: irm https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.ps1 | iex
-else
-    CURRENT=$(officecli --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-    LATEST=$(curl -fsSL https://api.github.com/repos/iOfficeAI/OfficeCLI/releases/latest | grep '"tag_name"' | sed -E 's/.*"v?([0-9.]+)".*/\1/')
-    if [ "$CURRENT" != "$LATEST" ]; then
-        echo "Upgrading officecli $CURRENT -> $LATEST..."
-        curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    else
-        echo "officecli $CURRENT is up to date"
-    fi
+if ! command -v officecli >/dev/null 2>&1; then
+    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
 fi
+```
+
+`Windows (PowerShell)`
+
+```powershell
+if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
+    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+}
+```
+
+**Then verify installation:**
+
+```text
 officecli --version
 ```
+
+If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 
 ---
 

--- a/skills/officecli-financial-model/SKILL.md
+++ b/skills/officecli-financial-model/SKILL.md
@@ -20,7 +20,7 @@ Build formula-driven, multi-sheet financial models from scratch in Excel. Every 
 
 ## BEFORE YOU START (CRITICAL)
 
-**Install `officecli` if needed:**
+**If `officecli` is not installed:**
 
 `macOS / Linux`
 
@@ -38,11 +38,7 @@ if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
 }
 ```
 
-**Then verify installation:**
-
-```text
-officecli --version
-```
+Verify: `officecli --version`
 
 If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 

--- a/skills/officecli-pitch-deck/SKILL.md
+++ b/skills/officecli-pitch-deck/SKILL.md
@@ -12,7 +12,7 @@ Create professional pitch presentations from scratch -- investor decks, product 
 
 ## BEFORE YOU START (CRITICAL)
 
-**Install `officecli` if needed:**
+**If `officecli` is not installed:**
 
 `macOS / Linux`
 
@@ -30,11 +30,7 @@ if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
 }
 ```
 
-**Then verify installation:**
-
-```text
-officecli --version
-```
+Verify: `officecli --version`
 
 If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 

--- a/skills/officecli-pitch-deck/SKILL.md
+++ b/skills/officecli-pitch-deck/SKILL.md
@@ -12,25 +12,31 @@ Create professional pitch presentations from scratch -- investor decks, product 
 
 ## BEFORE YOU START (CRITICAL)
 
-**Every time before using officecli, run this check:**
+**Install `officecli` if needed:**
+
+`macOS / Linux`
 
 ```bash
-if ! command -v officecli &> /dev/null; then
-    echo "Installing officecli..."
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    # Windows: irm https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.ps1 | iex
-else
-    CURRENT=$(officecli --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-    LATEST=$(curl -fsSL https://api.github.com/repos/iOfficeAI/OfficeCLI/releases/latest | grep '"tag_name"' | sed -E 's/.*"v?([0-9.]+)".*/\1/')
-    if [ "$CURRENT" != "$LATEST" ]; then
-        echo "Upgrading officecli $CURRENT -> $LATEST..."
-        curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    else
-        echo "officecli $CURRENT is up to date"
-    fi
+if ! command -v officecli >/dev/null 2>&1; then
+    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
 fi
+```
+
+`Windows (PowerShell)`
+
+```powershell
+if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
+    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+}
+```
+
+**Then verify installation:**
+
+```text
 officecli --version
 ```
+
+If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 
 ---
 

--- a/skills/officecli-pptx/SKILL.md
+++ b/skills/officecli-pptx/SKILL.md
@@ -19,7 +19,7 @@ description: "Use this skill any time a .pptx file is involved -- as input, outp
 > ```
 > 如果看到 `no matches found`，说明引号缺失。
 
-**Install `officecli` if needed:**
+**If `officecli` is not installed:**
 
 `macOS / Linux`
 
@@ -37,11 +37,7 @@ if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
 }
 ```
 
-**Then verify installation:**
-
-```text
-officecli --version
-```
+Verify: `officecli --version`
 
 If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 

--- a/skills/officecli-pptx/SKILL.md
+++ b/skills/officecli-pptx/SKILL.md
@@ -19,25 +19,31 @@ description: "Use this skill any time a .pptx file is involved -- as input, outp
 > ```
 > 如果看到 `no matches found`，说明引号缺失。
 
-**Every time before using officecli, run this check:**
+**Install `officecli` if needed:**
+
+`macOS / Linux`
 
 ```bash
-if ! command -v officecli &> /dev/null; then
-    echo "Installing officecli..."
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    # Windows: irm https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.ps1 | iex
-else
-    CURRENT=$(officecli --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-    LATEST=$(curl -fsSL https://api.github.com/repos/iOfficeAI/OfficeCLI/releases/latest | grep '"tag_name"' | sed -E 's/.*"v?([0-9.]+)".*/\1/')
-    if [ "$CURRENT" != "$LATEST" ]; then
-        echo "Upgrading officecli $CURRENT → $LATEST..."
-        curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    else
-        echo "officecli $CURRENT is up to date"
-    fi
+if ! command -v officecli >/dev/null 2>&1; then
+    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
 fi
+```
+
+`Windows (PowerShell)`
+
+```powershell
+if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
+    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+}
+```
+
+**Then verify installation:**
+
+```text
 officecli --version
 ```
+
+If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 
 ---
 

--- a/skills/officecli-xlsx/SKILL.md
+++ b/skills/officecli-xlsx/SKILL.md
@@ -8,25 +8,31 @@ description: "Use this skill any time a .xlsx file is involved -- as input, outp
 
 ## BEFORE YOU START (CRITICAL)
 
-**Every time before using officecli, run this check:**
+**Install `officecli` if needed:**
+
+`macOS / Linux`
 
 ```bash
-if ! command -v officecli &> /dev/null; then
-    echo "Installing officecli..."
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    # Windows: irm https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.ps1 | iex
-else
-    CURRENT=$(officecli --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-    LATEST=$(curl -fsSL https://api.github.com/repos/iOfficeAI/OfficeCLI/releases/latest | grep '"tag_name"' | sed -E 's/.*"v?([0-9.]+)".*/\1/')
-    if [ "$CURRENT" != "$LATEST" ]; then
-        echo "Upgrading officecli $CURRENT → $LATEST..."
-        curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh | bash
-    else
-        echo "officecli $CURRENT is up to date"
-    fi
+if ! command -v officecli >/dev/null 2>&1; then
+    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
 fi
+```
+
+`Windows (PowerShell)`
+
+```powershell
+if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
+    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+}
+```
+
+**Then verify installation:**
+
+```text
 officecli --version
 ```
+
+If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 
 ---
 

--- a/skills/officecli-xlsx/SKILL.md
+++ b/skills/officecli-xlsx/SKILL.md
@@ -8,7 +8,7 @@ description: "Use this skill any time a .xlsx file is involved -- as input, outp
 
 ## BEFORE YOU START (CRITICAL)
 
-**Install `officecli` if needed:**
+**If `officecli` is not installed:**
 
 `macOS / Linux`
 
@@ -26,11 +26,7 @@ if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
 }
 ```
 
-**Then verify installation:**
-
-```text
-officecli --version
-```
+Verify: `officecli --version`
 
 If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 


### PR DESCRIPTION
This PR standardizes the OfficeCLI skill installation guidance in the root skill and the specialized skill docs under `skills/`.

Before this change, the skill docs used a mix of installation and manual version-check logic. Some docs compared the local version against GitHub releases and instructed agents to upgrade before use, while other docs used a single shell snippet that was not a correct native path for Windows users. That inconsistency made the install flow noisy and, in practice, easier to get wrong.

The root cause was duplicated install guidance spread across multiple skill documents. As the wording drifted, the docs picked up per-task upgrade checks even though `officecli` already performs its own background update checks during normal use. The duplicated snippets also mixed bootstrap and verification into a single flow, which could fail immediately after first install because the current shell session might not have refreshed `PATH` yet.

This change replaces those duplicated sections with a single simpler pattern:
- the root `SKILL.md` now presents `install if needed` guidance instead of install-plus-upgrade language
- macOS and Linux use the official `install.sh` bootstrap script
- Windows uses the official PowerShell `install.ps1` bootstrap script
- verification is split into a separate `officecli --version` step
- the docs now tell users to open a new terminal and rerun the verify step if `officecli` is still not found after the first install
- the `morph-ppt` skill now references the simplified install section without telling users to ensure the latest version before every task

The user-facing effect is a shorter and more accurate bootstrap flow. Users are guided to download OfficeCLI when needed, without redundant release comparisons or manual upgrade checks before every task, and Windows users get a native PowerShell path instead of being implied to use the Unix shell snippet.

Validation for this PR was limited to documentation checks because the diff is docs-only. I verified that this branch only changes the root `SKILL.md` plus the targeted files under `skills/`, and I ran `git diff --check --cached` before committing to confirm there are no whitespace or patch-format issues.
