### PR TITLE
Fix Windows install path and PATH handling

### DIFF
--- a/src/officecli/Core/Installer.cs
+++ b/src/officecli/Core/Installer.cs
@@ -12,11 +12,12 @@ namespace OfficeCli.Core;
 /// </summary>
 internal static class Installer
 {
-    private static readonly string BinDir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-        ".local", "bin");
+    private static readonly string BinDir = OperatingSystem.IsWindows()
+        ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "OfficeCli")
+        : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "bin");
 
-    private static readonly string TargetPath = Path.Combine(BinDir, "officecli");
+    private static readonly string TargetPath = Path.Combine(BinDir,
+        OperatingSystem.IsWindows() ? "officecli.exe" : "officecli");
 
     /// <summary>
     /// MCP targets and the skill aliases that overlap with them.
@@ -258,9 +259,18 @@ internal static class Installer
         string profilePath;
         if (OperatingSystem.IsWindows())
         {
-            // Windows: just advise, don't auto-modify registry
-            if (!quiet)
-                Console.WriteLine($"  Add {BinDir} to your system PATH.");
+            // Windows: add to user PATH via registry
+            var currentPath = Environment.GetEnvironmentVariable("Path", EnvironmentVariableTarget.User) ?? "";
+            if (!currentPath.Split(Path.PathSeparator).Contains(BinDir, StringComparer.OrdinalIgnoreCase))
+            {
+                var newPath = string.IsNullOrEmpty(currentPath) ? BinDir : $"{currentPath}{Path.PathSeparator}{BinDir}";
+                Environment.SetEnvironmentVariable("Path", newPath, EnvironmentVariableTarget.User);
+                if (!quiet)
+                {
+                    Console.WriteLine($"  Added {BinDir} to PATH.");
+                    Console.WriteLine($"  Restart your terminal to apply changes.");
+                }
+            }
             return;
         }
 


### PR DESCRIPTION
This PR aligns the behavior of officecli install with install.ps1 on Windows.

Changes:
- Install directory: Changed from ~/.local/bin to %LOCALAPPDATA%\OfficeCli
- Binary name: Added .exe suffix for Windows executable  
- PATH handling: Auto-add to user PATH via registry

This fixes the issue where install.ps1 and officecli install used different paths, causing auto-install detection to fail and requiring manual PATH configuration on Windows.