### PR TITLE
Fix Windows install: .exe suffix, correct path, PATH registration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,25 @@ jobs:
           publish/${{ matrix.name }} close test_smoke.docx
           rm -f test_smoke.docx
 
+      - name: Smoke test - install
+        if: >-
+          (matrix.rid == 'osx-arm64' && runner.arch == 'ARM64') ||
+          (matrix.rid == 'osx-x64' && runner.arch == 'X64') ||
+          (matrix.rid == 'linux-x64' && runner.os == 'Linux') ||
+          (matrix.rid == 'win-x64' && runner.os == 'Windows')
+        env:
+          MSYS_NO_PATHCONV: '1'
+          MSYS2_ARG_CONV_EXCL: '*'
+        run: |
+          publish/${{ matrix.name }} install
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            test -f "$LOCALAPPDATA/OfficeCli/officecli.exe" || { echo "FAIL: officecli.exe not found in %LOCALAPPDATA%\\OfficeCli"; exit 1; }
+            "$LOCALAPPDATA/OfficeCli/officecli.exe" --version
+          else
+            test -f "$HOME/.local/bin/officecli" || { echo "FAIL: officecli not found in ~/.local/bin"; exit 1; }
+            "$HOME/.local/bin/officecli" --version
+          fi
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - dev
 
 permissions:
   contents: read

--- a/src/officecli/Core/Installer.cs
+++ b/src/officecli/Core/Installer.cs
@@ -12,11 +12,12 @@ namespace OfficeCli.Core;
 /// </summary>
 internal static class Installer
 {
-    private static readonly string BinDir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-        ".local", "bin");
+    private static readonly string BinDir = OperatingSystem.IsWindows()
+        ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "OfficeCli")
+        : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "bin");
 
-    private static readonly string TargetPath = Path.Combine(BinDir, "officecli");
+    private static readonly string TargetPath = Path.Combine(BinDir,
+        OperatingSystem.IsWindows() ? "officecli.exe" : "officecli");
 
     /// <summary>
     /// MCP targets and the skill aliases that overlap with them.
@@ -71,7 +72,8 @@ internal static class Installer
             return false;
 
         // Already at target location — record version and skip the copy
-        if (string.Equals(Path.GetFullPath(src), Path.GetFullPath(TargetPath), StringComparison.Ordinal))
+        var pathComparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        if (string.Equals(Path.GetFullPath(src), Path.GetFullPath(TargetPath), pathComparison))
         {
             RecordInstalledVersion();
             return false;
@@ -165,7 +167,8 @@ internal static class Installer
             if (string.IsNullOrEmpty(src)) return;
 
             // Already running from target — nothing to do (RecordInstalledVersion is handled by explicit `install`)
-            if (string.Equals(Path.GetFullPath(src), Path.GetFullPath(TargetPath), StringComparison.Ordinal))
+            var pathComparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            if (string.Equals(Path.GetFullPath(src), Path.GetFullPath(TargetPath), pathComparison))
                 return;
 
             // Dev-build filter: framework-dependent / dotnet run binaries are <5MB

--- a/src/officecli/Core/Installer.cs
+++ b/src/officecli/Core/Installer.cs
@@ -261,9 +261,18 @@ internal static class Installer
         string profilePath;
         if (OperatingSystem.IsWindows())
         {
-            // Windows: just advise, don't auto-modify registry
-            if (!quiet)
-                Console.WriteLine($"  Add {BinDir} to your system PATH.");
+            // Windows: add to user PATH via registry (same as install.ps1)
+            var currentPath = Environment.GetEnvironmentVariable("Path", EnvironmentVariableTarget.User) ?? "";
+            if (!currentPath.Split(Path.PathSeparator).Contains(BinDir, StringComparer.OrdinalIgnoreCase))
+            {
+                var newPath = string.IsNullOrEmpty(currentPath) ? BinDir : $"{currentPath}{Path.PathSeparator}{BinDir}";
+                Environment.SetEnvironmentVariable("Path", newPath, EnvironmentVariableTarget.User);
+                if (!quiet)
+                {
+                    Console.WriteLine($"  Added {BinDir} to PATH.");
+                    Console.WriteLine($"  Restart your terminal to apply changes.");
+                }
+            }
             return;
         }
 

--- a/src/officecli/Core/Watch/WatchServer.cs
+++ b/src/officecli/Core/Watch/WatchServer.cs
@@ -1688,7 +1688,8 @@ internal class WatchServer : IDisposable
             var path = root.GetProperty("path").GetString() ?? "";
 
             // Spawn officecli set as child process
-            var exe = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName ?? "officecli";
+            var exe = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName
+                ?? (OperatingSystem.IsWindows() ? "officecli.exe" : "officecli");
             var psi = new System.Diagnostics.ProcessStartInfo
             {
                 FileName = exe,

--- a/src/officecli/McpInstaller.cs
+++ b/src/officecli/McpInstaller.cs
@@ -11,7 +11,7 @@ namespace OfficeCli;
 public static class McpInstaller
 {
     private static string OfficecliPath =>
-        Environment.ProcessPath ?? "officecli";
+        Environment.ProcessPath ?? (OperatingSystem.IsWindows() ? "officecli.exe" : "officecli");
 
     public static void Install(string target)
     {


### PR DESCRIPTION
## Summary
- Install directory: `~/.local/bin` → Windows uses `%LOCALAPPDATA%\OfficeCli`
- Binary name: `officecli` → Windows uses `officecli.exe`
- Path comparison: `Ordinal` → Windows uses `OrdinalIgnoreCase`
- Fallback binary name in `McpInstaller` and `WatchServer`: add `.exe` on Windows
- Windows PATH: auto-add to user PATH via registry (align with `install.ps1`)
- CI: add install smoke test for Windows/macOS/Linux

**Draft PR for CI monitoring only. Merge via feature branch.**