### PR TITLE
fix(watch): skip HTML rendering when no watch session exists

### DIFF
--- a/src/officecli/CommandBuilder.cs
+++ b/src/officecli/CommandBuilder.cs
@@ -1078,6 +1078,8 @@ static partial class CommandBuilder
     /// </summary>
     private static void NotifyWatch(IDocumentHandler handler, string filePath, string? changedPath)
     {
+        if (!WatchServer.IsWatching(filePath)) return;
+
         if (handler is OfficeCli.Handlers.ExcelHandler excel)
         {
             string? scrollTo = null;
@@ -1115,6 +1117,8 @@ static partial class CommandBuilder
 
     private static void NotifyWatchRoot(IDocumentHandler handler, string filePath, int oldSlideCount)
     {
+        if (!WatchServer.IsWatching(filePath)) return;
+
         if (handler is OfficeCli.Handlers.ExcelHandler excel)
         {
             WatchNotifier.NotifyIfWatching(filePath, new WatchMessage { Action = "full", FullHtml = excel.ViewAsHtml() });

--- a/src/officecli/Core/Watch/WatchServer.cs
+++ b/src/officecli/Core/Watch/WatchServer.cs
@@ -168,6 +168,11 @@ internal class WatchServer : IDisposable
         }
     }
 
+    public static bool IsWatching(string filePath)
+    {
+        return GetExistingWatchPort(filePath).HasValue;
+    }
+
     public async Task RunAsync(CancellationToken externalToken = default)
     {
         // Prevent duplicate watch processes for the same file

--- a/src/officecli/ResidentServer.cs
+++ b/src/officecli/ResidentServer.cs
@@ -664,6 +664,8 @@ public class ResidentServer : IDisposable
 
     private void NotifyWatchSlideChanged(string? changedPath)
     {
+        if (!WatchServer.IsWatching(_filePath)) return;
+
         if (_handler is OfficeCli.Handlers.ExcelHandler excel)
         {
             string? scrollTo = null;
@@ -698,6 +700,8 @@ public class ResidentServer : IDisposable
 
     private void NotifyWatchRootChanged(int oldSlideCount)
     {
+        if (!WatchServer.IsWatching(_filePath)) return;
+
         if (_handler is OfficeCli.Handlers.WordHandler word)
         {
             var html = word.ViewAsHtml();
@@ -732,6 +736,8 @@ public class ResidentServer : IDisposable
 
     private void NotifyWatchFullRefresh()
     {
+        if (!WatchServer.IsWatching(_filePath)) return;
+
         string? fullHtml = null;
         if (_handler is OfficeCli.Handlers.PowerPointHandler ppt)
             fullHtml = ppt.ViewAsHtml();


### PR DESCRIPTION
## Summary

This PR fixes one watch-path bug: mutation commands were rendering full HTML previews even when no watch process existed for the target file.

The change is intentionally narrow:
- add a small `WatchServer.IsWatching(filePath)` helper
- early-return from mutation-side watch notification helpers when no watch exists
- keep existing watch behavior unchanged when a watch session is active

## Why

On large Excel workbooks, `ViewAsHtml()` can dominate the whole mutation path. In my repro, ordinary `officecli set` / `officecli batch` calls looked like save hangs or long timeouts even though the underlying OpenXML save path itself was fine.

The problem was not the workbook write itself. The mutation path was eagerly building preview HTML before `NotifyIfWatching(...)` had even established whether a watch process existed.

## Validation method

Bug-fix validation using an officecli command sequence on a large `.xlsx` with no active `officecli watch` session:

```bash
# No watch process running for the file

# Before this fix on the reproduced workbook class:
officecli set workbook.xlsx '/Operating Assumptions/J27' --prop value=0.031 --json
# -> can hang for minutes / hit timeout

officecli batch workbook.xlsx --input one-cell-set.json --json
# -> can also hang / time out

# Direct preview path on the same workbook class:
officecli view workbook.xlsx html
# -> also extremely slow / hanging
```

After this fix on the same workbook class:

```bash
officecli set workbook.xlsx '/Operating Assumptions/J27' --prop value=0.031 --json
# -> returned in about 6s in my repro

officecli batch workbook.xlsx --input one-cell-set.json --json
# -> returned in under 1s in my repro
```

I also verified separately with a direct OpenXML SDK repro that opening, mutating, and saving the same workbook class succeeds quickly outside OfficeCLI, which is what narrowed the issue down to the watch/preview path rather than the workbook save itself.