### PR TITLE
fix: refresh excel watch when row patches change columns

### DIFF
--- a/src/officecli/Resources/watch-sse-core.js
+++ b/src/officecli/Resources/watch-sse-core.js
@@ -17,6 +17,84 @@
         if (typeof window._watchReapplyHook === 'function') window._watchReapplyHook();
     }
 
+    function _replaceDocumentBody(msg) {
+        fetch('/').then(function(r) { return r.text(); }).then(function(html) {
+            var doc = new DOMParser().parseFromString(html, 'text/html');
+            var oldStyles = document.querySelectorAll('head style');
+            var newStyles = doc.querySelectorAll('head style');
+            oldStyles.forEach(function(s) { s.remove(); });
+            newStyles.forEach(function(s) { document.head.appendChild(s.cloneNode(true)); });
+            var scripts = document.body.querySelectorAll('script');
+            var sseScript = null;
+            scripts.forEach(function(s) { if (s.textContent.indexOf('EventSource') >= 0) sseScript = s; });
+            var targetSheetIdx = -1;
+            if (msg.scrollTo && msg.scrollTo.indexOf('data-sheet') >= 0) {
+                var m = msg.scrollTo.match(/data-sheet="(\d+)"/);
+                if (m) targetSheetIdx = parseInt(m[1]);
+            }
+            // Preserve current active sheet if no explicit target
+            if (targetSheetIdx < 0) {
+                var curActive = document.querySelector('.sheet-tab.active');
+                if (curActive) targetSheetIdx = parseInt(curActive.getAttribute('data-sheet')) || 0;
+            }
+            if (targetSheetIdx >= 0) {
+                doc.querySelectorAll('.sheet-content').forEach(function(s) {
+                    var idx = parseInt(s.getAttribute('data-sheet'));
+                    if (idx === targetSheetIdx) s.classList.add('active');
+                    else s.classList.remove('active');
+                });
+                doc.querySelectorAll('.sheet-tab').forEach(function(t) {
+                    var idx = parseInt(t.getAttribute('data-sheet'));
+                    if (idx === targetSheetIdx) t.classList.add('active');
+                    else t.classList.remove('active');
+                });
+            }
+            var savedScrollY = window.scrollY;
+            document.body.innerHTML = doc.body.innerHTML;
+            if (sseScript) document.body.appendChild(sseScript);
+            window.scrollTo(0, savedScrollY);
+            doc.body.querySelectorAll('script').forEach(function(s) {
+                if (s.textContent.indexOf('EventSource') >= 0) return;
+                var ns = document.createElement('script');
+                ns.textContent = s.textContent;
+                document.body.appendChild(ns);
+            });
+            if (msg.scrollTo && targetSheetIdx < 0) {
+                window._pendingScrollTo = msg.scrollTo;
+            }
+            // Re-apply selection + marks after the body swap
+            _callReapplyHook();
+        });
+    }
+
+    function _excelPatchChangesStructure(msg) {
+        if (!msg.patches) return false;
+        for (var i = 0; i < msg.patches.length; i++) {
+            var patch = msg.patches[i];
+            if (patch.op === 'style' || patch.op === 'remove') continue;
+            if (!patch.html) return true;
+
+            var tmp = document.createElement('tbody');
+            tmp.innerHTML = patch.html;
+            var newRow = tmp.firstElementChild;
+            if (!newRow) return true;
+
+            var newCellCount = newRow.children.length;
+            var existing = document.querySelector('tr[data-row="' + patch.row + '"]');
+            if (existing) {
+                if (existing.children.length !== newCellCount) return true;
+                continue;
+            }
+
+            var parts = patch.row.split('-');
+            var sheetDiv = document.querySelector('.sheet-content[data-sheet="' + parts[0] + '"]');
+            var referenceRow = sheetDiv ? sheetDiv.querySelector('tbody tr[data-row]') : null;
+            if (!referenceRow) return true;
+            if (referenceRow.children.length !== newCellCount) return true;
+        }
+        return false;
+    }
+
     function scrollToSlide(num) {
         clearTimeout(_scrollTimer);
         _scrollTimer = setTimeout(function() {
@@ -253,6 +331,14 @@
                 location.reload();
                 return;
             }
+            // Row-level patching only updates <tr> nodes. If a patch changes row
+            // shape, then table chrome such as <colgroup>, <thead>, or table
+            // width also changed. Fall back to a full body swap so new columns
+            // and widths appear without requiring a manual refresh.
+            if (_excelPatchChangesStructure(msg)) {
+                _replaceDocumentBody(msg);
+                return;
+            }
             // Apply style patch if present
             msg.patches.forEach(function(patch) {
                 if (patch.op === 'style') {
@@ -323,53 +409,7 @@
                 return;
             }
             // Non-Word (PPT/Excel): full body replacement
-            fetch('/').then(function(r) { return r.text(); }).then(function(html) {
-                var doc = new DOMParser().parseFromString(html, 'text/html');
-                var oldStyles = document.querySelectorAll('head style');
-                var newStyles = doc.querySelectorAll('head style');
-                oldStyles.forEach(function(s) { s.remove(); });
-                newStyles.forEach(function(s) { document.head.appendChild(s.cloneNode(true)); });
-                var scripts = document.body.querySelectorAll('script');
-                var sseScript = null;
-                scripts.forEach(function(s) { if (s.textContent.indexOf('EventSource') >= 0) sseScript = s; });
-                var targetSheetIdx = -1;
-                if (msg.scrollTo && msg.scrollTo.indexOf('data-sheet') >= 0) {
-                    var m = msg.scrollTo.match(/data-sheet="(\d+)"/);
-                    if (m) targetSheetIdx = parseInt(m[1]);
-                }
-                // Preserve current active sheet if no explicit target
-                if (targetSheetIdx < 0) {
-                    var curActive = document.querySelector('.sheet-tab.active');
-                    if (curActive) targetSheetIdx = parseInt(curActive.getAttribute('data-sheet')) || 0;
-                }
-                if (targetSheetIdx >= 0) {
-                    doc.querySelectorAll('.sheet-content').forEach(function(s) {
-                        var idx = parseInt(s.getAttribute('data-sheet'));
-                        if (idx === targetSheetIdx) s.classList.add('active');
-                        else s.classList.remove('active');
-                    });
-                    doc.querySelectorAll('.sheet-tab').forEach(function(t) {
-                        var idx = parseInt(t.getAttribute('data-sheet'));
-                        if (idx === targetSheetIdx) t.classList.add('active');
-                        else t.classList.remove('active');
-                    });
-                }
-                var savedScrollY = window.scrollY;
-                document.body.innerHTML = doc.body.innerHTML;
-                if (sseScript) document.body.appendChild(sseScript);
-                window.scrollTo(0, savedScrollY);
-                doc.body.querySelectorAll('script').forEach(function(s) {
-                    if (s.textContent.indexOf('EventSource') >= 0) return;
-                    var ns = document.createElement('script');
-                    ns.textContent = s.textContent;
-                    document.body.appendChild(ns);
-                });
-                if (msg.scrollTo && targetSheetIdx < 0) {
-                    window._pendingScrollTo = msg.scrollTo;
-                }
-                // Re-apply selection + marks after the body swap
-                _callReapplyHook();
-            });
+            _replaceDocumentBody(msg);
             return;
         }
         var slideNum = msg.slide;


### PR DESCRIPTION
## Summary
Fix `xlsx watch` so Excel column structure changes refresh live without requiring a manual browser reload.

## Repro
Reproduced on the released `v1.0.51` binary on April 18, 2026.

1. Create a blank workbook and start `officecli watch`.
2. Open the watch page.
3. Write data that expands the sheet from one visible column to two columns.
4. Observe that new row content appears immediately, but the second column header/width does not appear until pressing `F5`.

I also verified that the server HTML was already correct during the stale state, so the bug is on the browser incremental patch path rather than the server renderer.

## Root Cause
`watch-sse-core.js` handles `excel-patch` by updating only `<tr>` nodes.

That works for row-only edits, but when a patch changes row shape it also changes table structure such as:
- `<colgroup>`
- `<thead>`
- table width

Because those parts were not refreshed, the browser could show new cell content while still keeping the old one-column table chrome until a full reload.

## Fix
- Extract the existing non-Word full body replacement into `_replaceDocumentBody(msg)`.
- Detect when an `excel-patch` changes row structure.
- Fall back to `_replaceDocumentBody(msg)` only for structure-changing Excel patches.
- Keep the existing lightweight row patch path for same-shape row updates.

## Validation
Validation performed in this environment:

- Real released binary repro on `v1.0.51`: bug reproduced.
- Local rebuilt patched binary repro on Linux: fix verified end-to-end on the real `watch + set` path.
  - built a self-contained `linux-x64` binary from this patch
  - started `officecli watch` on an empty workbook and opened the page before editing
  - ran the official `officecli set` commands to write `A1=Name`, `A2=Alice`, `B1=Score`, `B2=95`
  - observed the watched page update without manual refresh to show headers `A` and `B` plus the `Name/Score` and `Alice/95` rows
- Browser simulation with the current `main` script: column-add case still leaves headers stale.
- Browser simulation with this patch:
  - column-add case updates headers and table width immediately
  - row-add-only case still uses the lightweight path and behaves the same as before

Concrete simulation results:
- original `main`, column-add: `headerCount=1`, `hasBHeader=false`, `tableWidth=width:61.51pt`
- patched, column-add: `headerCount=2`, `hasBHeader=true`, `tableWidth=width:103.52pt`
- original and patched, row-add-only: both keep `headerCount=1`, add the new row, and avoid the full refresh path

## Notes
I later installed a temporary local `.NET 10 SDK` and completed a local rebuild for validation, so this PR now has both:
- live repro against the released `v1.0.51` binary
- direct end-to-end validation on a rebuilt patched binary
- direct validation of the browser patch logic on the exact script being changed

I did not validate Windows or macOS packaging in this environment, but the code change is confined to the browser-side watch script.
