### PR TITLE
fix(pptx): skip inherited content placeholders in html preview

### DIFF
--- a/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.cs
@@ -471,15 +471,14 @@ public partial class PowerPointHandler
             var ph = shape.NonVisualShapeProperties?.ApplicationNonVisualDrawingProperties
                 ?.GetFirstChild<PlaceholderShape>();
 
-            // Skip title/body content placeholders (these are structural, not decorative)
+            // Only date/footer/header/slide-number placeholders are visible inherited
+            // placeholders. Content placeholders are structural layout slots and should
+            // not render their edit-prompt text.
+            if (ph != null && !IsVisibleInheritedPlaceholder(ph))
+                continue;
+
             if (ph?.Type?.HasValue == true)
             {
-                var t = ph.Type.Value;
-                if (t == PlaceholderValues.Title || t == PlaceholderValues.CenteredTitle ||
-                    t == PlaceholderValues.SubTitle || t == PlaceholderValues.Body ||
-                    t == PlaceholderValues.Object)
-                    continue;
-
                 // Skip if slide already has this placeholder type
                 if (skipIndices.Contains($"type:{ph.Type.InnerText}")) continue;
             }
@@ -507,6 +506,17 @@ public partial class PowerPointHandler
         {
             RenderPicture(sb, pic, part, themeColors);
         }
+    }
+
+    private static bool IsVisibleInheritedPlaceholder(PlaceholderShape ph)
+    {
+        if (ph.Type?.HasValue != true) return false;
+
+        var type = ph.Type.Value;
+        return type == PlaceholderValues.DateAndTime
+            || type == PlaceholderValues.Footer
+            || type == PlaceholderValues.Header
+            || type == PlaceholderValues.SlideNumber;
     }
 
 }


### PR DESCRIPTION
## Summary

- Skip inherited PPT layout/master content placeholders in HTML preview.
- Keep visible inherited metadata placeholders: date/time, footer, header, and slide number.
- Prevent placeholder edit-prompt text from rendering over real slide content.

Fixes #79

## Validation

- `dotnet build src/officecli/officecli.csproj`
- On the affected PPTX sample, inherited prompt text count changed from 29 to 0 in generated HTML.

Note: build still reports the existing `OpenMcdf` NU1902 advisory warning.

<img width="3600" height="2082" alt="Image" src="https://github.com/user-attachments/assets/44e931bb-f06f-4583-8388-740647834caf" />
<img width="3600" height="2086" alt="Clipboard_Screenshot_1777344160" src="https://github.com/user-attachments/assets/ab079bd7-d08d-4591-87c8-f0935655508f" />

