### PR TITLE
fix(pptx): suppress layout/master placeholder prompt text in html preview

### DIFF
--- a/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.Shapes.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.Shapes.cs
@@ -20,7 +20,7 @@ public partial class PowerPointHandler
     /// </summary>
     private static void RenderShape(StringBuilder sb, Shape shape, OpenXmlPart part,
         Dictionary<string, string> themeColors, (long x, long y, long cx, long cy)? overridePos = null,
-        string? dataPath = null)
+        string? dataPath = null, bool suppressText = false)
     {
         var dataPathAttr = string.IsNullOrEmpty(dataPath) ? "" : $" data-path=\"{HtmlEncode(dataPath)}\"";
         var xfrm = shape.ShapeProperties?.Transform2D;
@@ -323,8 +323,11 @@ public partial class PowerPointHandler
             sb.Append($"    <div class=\"{shapeClass}\"{dataPathAttr} style=\"{string.Join(";", styles)}\">");
         }
 
-        // Text content
-        if (shape.TextBody != null)
+        // Text content. `suppressText` is set by RenderInheritedShapes for layout/master
+        // content placeholders: their <p:txBody> holds edit-prompt text ("Click to add
+        // title") that belongs to the slide, not the layout. We still render the shape
+        // chrome (fill/outline/geometry) so themed placeholder backgrounds survive.
+        if (shape.TextBody != null && !suppressText)
         {
             // Counter-flip text so it remains readable when shape is flipped
             var flipStyle = "";

--- a/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.cs
@@ -459,6 +459,26 @@ public partial class PowerPointHandler
             RenderInheritedShapes(sb, masterPart.SlideMaster?.CommonSlideData?.ShapeTree, masterPart, slidePlaceholders, themeColors);
     }
 
+    // RenderInheritedShapes — render the layout/master shapes that the slide
+    // doesn't override. Two rules borrowed from Apache POI:
+    //
+    //   1. Layout/master placeholders never contribute TEXT — what's in their
+    //      <p:txBody> is edit-prompt boilerplate ("Click to add title", "单击
+    //      此处添加正文"). Real content always lives on the slide. The only
+    //      placeholders whose text IS legitimately layout/master-supplied are
+    //      the four metadata slots (date/footer/header/slide number); keep
+    //      those.
+    //
+    //   2. ECMA-376 §19.3.1.36: a <p:ph> with no `type` attribute defaults to
+    //      `obj`. Open XML SDK exposes this as `Type.HasValue == false`, so
+    //      type-based logic that hinges on HasValue silently misses these
+    //      shapes — that was the bug behind issue #79: a layout body
+    //      placeholder authored without an explicit type leaked its prompt
+    //      text onto the slide.
+    //
+    // Compare: POI's SlideShowExtractor.java:179-183 ("Ignoring boiler plate
+    // (placeholder) text on slide master") and XSLFShape.java:369-370 (the
+    // explicit `if (!ph.isSetType()) return INT_BODY;` default).
     private void RenderInheritedShapes(StringBuilder sb, ShapeTree? shapeTree, OpenXmlPart part,
         HashSet<string> skipIndices, Dictionary<string, string> themeColors)
     {
@@ -471,25 +491,26 @@ public partial class PowerPointHandler
             var ph = shape.NonVisualShapeProperties?.ApplicationNonVisualDrawingProperties
                 ?.GetFirstChild<PlaceholderShape>();
 
-            // Skip title/body content placeholders (these are structural, not decorative)
-            if (ph?.Type?.HasValue == true)
+            bool suppressText = false;
+            if (ph != null)
             {
-                var t = ph.Type.Value;
-                if (t == PlaceholderValues.Title || t == PlaceholderValues.CenteredTitle ||
-                    t == PlaceholderValues.SubTitle || t == PlaceholderValues.Body ||
-                    t == PlaceholderValues.Object)
+                // Slide already supplies this slot — slide content wins.
+                if (ph.Index?.HasValue == true && skipIndices.Contains($"idx:{ph.Index.Value}"))
+                    continue;
+                if (ph.Type?.HasValue == true && skipIndices.Contains($"type:{ph.Type.InnerText}"))
                     continue;
 
-                // Skip if slide already has this placeholder type
-                if (skipIndices.Contains($"type:{ph.Type.InnerText}")) continue;
+                // ECMA-376 default: absent type == obj. Without this, a body
+                // placeholder authored without an explicit type sneaks past
+                // every type-based check.
+                var type = ph.Type?.HasValue == true ? ph.Type.Value : PlaceholderValues.Object;
+                suppressText = !IsLayoutSuppliedTextPlaceholder(type);
             }
 
-            // Skip if slide already has a shape with this placeholder index
-            if (ph?.Index?.HasValue == true && skipIndices.Contains($"idx:{ph.Index.Value}"))
-                continue;
-
-            // Skip shapes with no visual content (empty text, no fill, no picture)
-            var text = GetShapeText(shape);
+            // Skip shapes with no visual content. When text is suppressed, treat
+            // it as empty: a content placeholder with only prompt text and no
+            // fill/outline isn't worth an empty box on the slide.
+            var text = suppressText ? "" : GetShapeText(shape);
             var hasFill = shape.ShapeProperties?.GetFirstChild<Drawing.SolidFill>() != null
                 || shape.ShapeProperties?.GetFirstChild<Drawing.GradientFill>() != null
                 || shape.ShapeProperties?.GetFirstChild<Drawing.BlipFill>() != null;
@@ -498,8 +519,7 @@ public partial class PowerPointHandler
             if (string.IsNullOrWhiteSpace(text) && !hasFill && !hasLine)
                 continue;
 
-            // Render this inherited shape
-            RenderShape(sb, shape, part, themeColors);
+            RenderShape(sb, shape, part, themeColors, suppressText: suppressText);
         }
 
         // Also render pictures from layout/master (logos, decorative images)
@@ -508,5 +528,11 @@ public partial class PowerPointHandler
             RenderPicture(sb, pic, part, themeColors);
         }
     }
+
+    private static bool IsLayoutSuppliedTextPlaceholder(PlaceholderValues type) =>
+        type == PlaceholderValues.DateAndTime
+        || type == PlaceholderValues.Footer
+        || type == PlaceholderValues.Header
+        || type == PlaceholderValues.SlideNumber;
 
 }


### PR DESCRIPTION
## Summary

- Stop layout/master content placeholders from leaking their edit-prompt text ("Click to add title", "单击此处添加正文") onto the rendered HTML slide.
- Apply ECMA-376 §19.3.1.36 default explicitly: `<p:ph>` with no `type` attribute defaults to `obj`. Open XML SDK reports `Type.HasValue == false` here, which is the root cause behind #79 — the previous denylist never matched the very common "type-less body placeholder" shape and let its prompt text through.
- Keep the chrome (fill / outline / geometry) of suppressed placeholders so layout-themed backgrounds still render.

Fixes #79.
Supersedes #80 — same intent, narrower fix that aligns with how Apache POI handles inheritance ([`SlideShowExtractor.java:179-183`](https://github.com/apache/poi/blob/trunk/poi/src/main/java/org/apache/poi/sl/extractor/SlideShowExtractor.java#L179-L183) skips boiler-plate placeholder text on master sheets; [`XSLFShape.java:369-370`](https://github.com/apache/poi/blob/trunk/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFShape.java#L369-L370) handles the missing-type default).

## Why this differs from #80

#80 takes an allowlist approach (only render date/footer/header/slide-number), which:

1. Drops the entire `<p:sp>` for content placeholders — losing themed background fills and outlines that legitimate layouts carry.
2. Doesn't make the root cause visible — the fix works only as a side effect of `IsVisibleInheritedPlaceholder` returning `false` when `Type.HasValue == false`. A future reader has to re-derive the ECMA default rule.
3. Leaves the existing `skipIndices` `type:` check after the early continue as effectively dead code without explaining why.

This PR splits text from chrome: a layout's placeholder still contributes its visual frame, only its `<p:txBody>` is suppressed. The ECMA default is written as `?? PlaceholderValues.Object` with a comment pointing at the spec section.

## Test plan

Validated locally with a regression test that:

- Builds a presentation with a real slide (title + body textbox).
- Injects a `<p:sp>` into every `<p:spTree>` in the slide layouts. Three variants:
  - `<p:ph idx="9999"/>` — **no `type` attribute** (the #79 trigger).
  - `<p:ph type="body" idx="1"/>` (was previously caught by the denylist; verifies we didn't lose that case).
  - `<p:ph type="pic" idx="2"/>` (previously leaked because Picture wasn't in the denylist).
- Calls `PowerPointHandler.ViewAsHtml()` and asserts the prompt text is **not** in the rendered HTML.
- Counter-tests: a `Footer`-type placeholder's text **does** appear; a `SlideNumber`-type placeholder's text **does** appear; a Body-type placeholder with a themed `solidFill` keeps its fill in the rendered HTML even though its text is suppressed.

All 6 cases pass. The 9 existing `HtmlPreviewBugTests_Round1` tests also pass.

- [x] `dotnet build src/officecli/officecli.csproj` clean
- [x] `dotnet test --filter HtmlPreviewBugTests_Round1` — 9/9 pass
- [x] Local regression suite for this PR — 6/6 pass