### PR TITLE
docs(skills): dedupe version pin in academic-paper and docx SKILL.md

### DIFF
--- a/skills/officecli-academic-paper/SKILL.md
+++ b/skills/officecli-academic-paper/SKILL.md
@@ -3,7 +3,6 @@
 name: officecli-academic-paper
 description: "Use this skill to build academic-style .docx output: journal / conference / thesis chapters carrying formal citation style (APA, Chicago, IEEE, MLA), numbered equations, figure & table cross-references, footnotes/endnotes, bibliography, or multi-column journal layout. Trigger on: 'research paper', 'journal paper', 'conference paper', 'manuscript', 'thesis', 'APA', 'MLA', 'Chicago', 'IEEE two-column', 'bibliography', 'hanging indent', 'citation style', 'abstract + keywords', 'equation numbering', 'cross-reference', paper with footnotes/endnotes. Output is a single .docx."
 ---
-# officecli: v1.0.63
 
 # OfficeCLI Academic Paper Skill
 

--- a/skills/officecli-docx/SKILL.md
+++ b/skills/officecli-docx/SKILL.md
@@ -3,7 +3,6 @@
 name: officecli-docx
 description: "Use this skill any time a .docx file is involved -- as input, output, or both. This includes: creating Word documents, reports, letters, memos, or proposals; reading, parsing, or extracting text from any .docx file; editing, modifying, or updating existing documents; working with templates, tracked changes, comments, headers/footers, or tables of contents. Trigger whenever the user mentions 'Word doc', 'document', 'report', 'letter', 'memo', or references a .docx filename."
 ---
-# officecli: v1.0.63
 
 # OfficeCLI DOCX Skill
 


### PR DESCRIPTION
## Summary

- Same fix as a075ba15 — \`# officecli: v1.0.63\` appeared both inside frontmatter (line 2) and as a stray H1 right below (line 6), producing a phantom H1 ahead of each skill's real title.
- a075ba15 only cleaned one side of docx; academic-paper had the same issue and survived PR #85.
- After this PR, all 5 SKILL.md files (academic-paper / docx / pitch-deck / pptx / xlsx) carry exactly one version pin, inside frontmatter.

## Test plan

- [x] \`grep -c '^# officecli: v' skills/officecli-*/SKILL.md\` → 1 per file
- [x] Frontmatter still parses (lines 1–5 closed by \`---\`)