### PR TITLE
docs(skills): unify BEFORE YOU START install guidance + add manual-install fallback

### DIFF
--- a/skills/officecli-academic-paper/SKILL.md
+++ b/skills/officecli-academic-paper/SKILL.md
@@ -10,25 +10,31 @@ description: "Use this skill to build academic-style .docx output: journal / con
 
 When the docx base rules cover it, the text here says `→ see docx v2 §X`. Read docx v2 first if you have not.
 
-## BEFORE YOU START
+## BEFORE YOU START (CRITICAL)
 
-**Install check.** If `officecli --version` fails:
+**If `officecli` is not installed:**
+
+`macOS / Linux`
 
 ```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
+if ! command -v officecli >/dev/null 2>&1; then
+    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
+fi
 ```
+
+`Windows (PowerShell)`
 
 ```powershell
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
+    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+}
 ```
 
-`officecli --version` must report `1.0.63` or newer. If not, open a new terminal and retry.
+Verify: `officecli --version`
 
-**Shell quoting, incremental execution, `$FILE` convention** → see docx v2 §BEFORE YOU START. The same rules apply here verbatim — quote `[N]` paths, single-quote any value containing `$` (including `$2.8B` in a body paragraph or `@` DOIs), never hand-write `\$ \t \n` in executable examples, one command at a time. Academic-paper examples below use `$FILE` as a shell variable (`FILE="thesis.docx"`).
+If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 
-**Inherits docx v2.** You should have read `skills/officecli-docx/SKILL.md` first. This skill assumes you know how to add paragraphs, set styles, build tables, insert images, manage TOC/footer/headers, force page breaks, and run the Delivery Gate. If any of those are unfamiliar, open a second session on docx v2 before continuing.
+If the install command above fails (e.g. blocked by security policy, no network access, or insufficient permissions), install manually — download the binary for your platform from https://github.com/iOfficeAI/OfficeCLI/releases — then re-run the verify command.
 
 ## ⚠️ Help-First Rule
 
@@ -41,6 +47,14 @@ officecli help docx <element> --json         # Machine-readable
 ```
 
 Help is pinned to the installed CLI version. **When this skill and help disagree, help wins.** Every `--prop X=` in this file has been grep-verified against `officecli help docx <element>` — if help adds / renames a prop in a later version, trust help.
+
+## Mental Model & Inheritance
+
+**Inherits docx v2.** You should have read `skills/officecli-docx/SKILL.md` first. This skill assumes you know how to add paragraphs, set styles, build tables, insert images, manage TOC/footer/headers, force page breaks, and run the Delivery Gate. If any of those are unfamiliar, open a second session on docx v2 before continuing.
+
+## Shell & Execution Discipline
+
+**Shell quoting, incremental execution, `$FILE` convention** → see docx v2 §Shell & Execution Discipline. The same rules apply here verbatim — quote `[N]` paths, single-quote any value containing `$` (including `$2.8B` in a body paragraph or `@` DOIs), never hand-write `\$ \t \n` in executable examples, one command at a time. Academic-paper examples below use `$FILE` as a shell variable (`FILE="thesis.docx"`).
 
 ## What "academic" means here (identity)
 

--- a/skills/officecli-docx/SKILL.md
+++ b/skills/officecli-docx/SKILL.md
@@ -6,33 +6,31 @@ description: "Use this skill any time a .docx file is involved -- as input, outp
 
 # OfficeCLI DOCX Skill
 
-## BEFORE YOU START
+## BEFORE YOU START (CRITICAL)
 
-**Mental model.** A `.docx` is a ZIP of XML parts (`document.xml`, `styles.xml`, `numbering.xml`, `header*.xml`, `footer*.xml`, `comments.xml`, ...). Everything the user sees — headings, tables, page numbers, TOC, tracked changes — is XML inside that ZIP. `officecli` gives you a semantic-path API (`/body/p[1]/r[2]`) over it, so you almost never touch raw XML; when you must, use `raw-set`.
+**If `officecli` is not installed:**
 
-**Install check.** If `officecli --version` fails:
+`macOS / Linux`
 
 ```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
+if ! command -v officecli >/dev/null 2>&1; then
+    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
+fi
 ```
+
+`Windows (PowerShell)`
 
 ```powershell
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
+    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+}
 ```
 
-If still not found, open a new terminal, then `officecli --version` should report `1.0.63` or newer.
+Verify: `officecli --version`
 
-**Shell quoting (zsh / bash).** docx paths contain `[]`, some prop values contain `$`. Both are shell metacharacters. Rules:
+If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 
-- ALWAYS quote element paths: `"/body/p[1]"`, not `/body/p[1]`.
-- Use **single quotes** for any prop value containing `$`: `--prop text='$50M'`.
-- NEVER hand-write `\$`, `\t`, `\n` inside executable examples. The CLI does not interpret backslash escapes; they will land in your file as literal characters. In a cell / paragraph text, a real newline goes through the JSON layer (`batch` heredoc with `"\n"` inside the JSON string).
-
-**Incremental execution.** Run commands one at a time and read each exit code. `officecli` mutates the file on every call; a 50-command script that fails at command 3 will cascade silently. One command → check output → continue. After any structural op (new style, table, TOC, section break) run `get` on it before stacking more on top.
-
-**File-name convention in this skill.** Fixed-command examples (Reading & Analysis, Creating & Editing) use the literal `doc.docx` — swap in your own filename. Copy-paste blocks and recipes that you will run *as-is* (Quick Start, Delivery Gate, Report-level recipes (a)-(f)) use `"$FILE"` — set once at the top of your script (`FILE="annual-review.docx"`) and every command picks it up. When in doubt, treat `$FILE` blocks as drop-in and `doc.docx` blocks as patterns.
+If the install command above fails (e.g. blocked by security policy, no network access, or insufficient permissions), install manually — download the binary for your platform from https://github.com/iOfficeAI/OfficeCLI/releases — then re-run the verify command.
 
 ## ⚠️ Help-First Rule
 
@@ -46,6 +44,22 @@ officecli help docx <element> --json        # Machine-readable schema
 ```
 
 Help is pinned to the installed CLI version. When this skill and help disagree, **help is authoritative**. Special-topic mini-sections below end with an explicit pointer back to help.
+
+## Mental Model & Inheritance
+
+**Mental model.** A `.docx` is a ZIP of XML parts (`document.xml`, `styles.xml`, `numbering.xml`, `header*.xml`, `footer*.xml`, `comments.xml`, ...). Everything the user sees — headings, tables, page numbers, TOC, tracked changes — is XML inside that ZIP. `officecli` gives you a semantic-path API (`/body/p[1]/r[2]`) over it, so you almost never touch raw XML; when you must, use `raw-set`.
+
+## Shell & Execution Discipline
+
+**Shell quoting (zsh / bash).** docx paths contain `[]`, some prop values contain `$`. Both are shell metacharacters. Rules:
+
+- ALWAYS quote element paths: `"/body/p[1]"`, not `/body/p[1]`.
+- Use **single quotes** for any prop value containing `$`: `--prop text='$50M'`.
+- NEVER hand-write `\$`, `\t`, `\n` inside executable examples. The CLI does not interpret backslash escapes; they will land in your file as literal characters. In a cell / paragraph text, a real newline goes through the JSON layer (`batch` heredoc with `"\n"` inside the JSON string).
+
+**Incremental execution.** Run commands one at a time and read each exit code. `officecli` mutates the file on every call; a 50-command script that fails at command 3 will cascade silently. One command → check output → continue. After any structural op (new style, table, TOC, section break) run `get` on it before stacking more on top.
+
+**File-name convention in this skill.** Fixed-command examples (Reading & Analysis, Creating & Editing) use the literal `doc.docx` — swap in your own filename. Copy-paste blocks and recipes that you will run *as-is* (Quick Start, Delivery Gate, Report-level recipes (a)-(f)) use `"$FILE"` — set once at the top of your script (`FILE="annual-review.docx"`) and every command picks it up. When in doubt, treat `$FILE` blocks as drop-in and `doc.docx` blocks as patterns.
 
 ## Requirements for Outputs
 

--- a/skills/officecli-pitch-deck/SKILL.md
+++ b/skills/officecli-pitch-deck/SKILL.md
@@ -10,29 +10,31 @@ description: "Use this skill when the user is building a fundraising / investor 
 
 When the pptx base rules cover it, the text here says `→ see pptx v2 §X`. Read `skills/officecli-pptx/SKILL.md` first if you have not.
 
-## BEFORE YOU START
+## BEFORE YOU START (CRITICAL)
 
-**Install check.** If `officecli --version` fails:
+**If `officecli` is not installed:**
+
+`macOS / Linux`
 
 ```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
+if ! command -v officecli >/dev/null 2>&1; then
+    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
+fi
 ```
+
+`Windows (PowerShell)`
 
 ```powershell
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
+    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+}
 ```
 
-`officecli --version` must report `1.0.63` or newer. Open a new terminal after install.
+Verify: `officecli --version`
 
-**Shell quoting, incremental execution, `$FILE` convention** → see pptx v2 §BEFORE YOU START. Same rules verbatim — quote `[N]` paths, single-quote values containing `$` (including `$35M`, `$1.2B TAM` in a cover or ask slide), never hand-write `\$ \t \n` in executable examples, one command at a time. Examples below use `$FILE` (`FILE="deck.pptx"`).
+If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 
-**Single-quote every shape text containing `$`.** `--prop text="Series B · $35M"` (double quotes) is WRONG — zsh expands `$35M` → empty, deck renders `Series B · M` silently. `--prop text='Series B · $35M'` (single quotes) is right. This is the #1 pitch-deck shell-escape failure mode (`$35M`, `$18M ARR`, `$1.2B TAM` appear on cover/ask/financials/milestones). Gate 2 cannot detect a stripped `$35M` — no residue. Gate 2b catches common strip patterns; single-quoting PREVENTS them.
-
-**Inherits pptx v2.** You should have read `skills/officecli-pptx/SKILL.md` first. This skill assumes you know how to: add slides + shapes + charts + connectors; address by `@name=` / `@id=`; quote paths; use `batch` heredocs; write `--prop tailEnd=triangle` on every flow connector; and run the 5-gate Delivery Gate. If any of those are unfamiliar, open a pptx v2 session before continuing.
-
-**Pitch-deck identity.** Slides are consumed at ~3 seconds per slide in a live room — the pptx v2 rule. Pitch decks add a second constraint on top: **every slide carries one investable proposition**. If a slide is "interesting background" that doesn't move the ask forward, cut it. VCs will not.
+If the install command above fails (e.g. blocked by security policy, no network access, or insufficient permissions), install manually — download the binary for your platform from https://github.com/iOfficeAI/OfficeCLI/releases — then re-run the verify command.
 
 ## ⚠️ Help-First Rule
 
@@ -46,9 +48,19 @@ officecli help pptx <element> --json         # Machine-readable
 
 Help is pinned to the installed CLI version. When this skill and help disagree, **help wins.** Every `--prop X=` in this file has been grep-verified against `officecli help pptx <element>` on v1.0.63 — if help adds / renames a prop in a later version, trust help.
 
+## Mental Model & Inheritance
+
+**Inherits pptx v2.** You should have read `skills/officecli-pptx/SKILL.md` first. This skill assumes you know how to: add slides + shapes + charts + connectors; address by `@name=` / `@id=`; quote paths; use `batch` heredocs; write `--prop tailEnd=triangle` on every flow connector; and run the 5-gate Delivery Gate. If any of those are unfamiliar, open a pptx v2 session before continuing.
+
+## Shell & Execution Discipline
+
+**Shell quoting, incremental execution, `$FILE` convention** → see pptx v2 §Shell & Execution Discipline. Same rules verbatim — quote `[N]` paths, single-quote values containing `$` (including `$35M`, `$1.2B TAM` in a cover or ask slide), never hand-write `\$ \t \n` in executable examples, one command at a time. Examples below use `$FILE` (`FILE="deck.pptx"`).
+
+**Single-quote every shape text containing `$`.** `--prop text="Series B · $35M"` (double quotes) is WRONG — zsh expands `$35M` → empty, deck renders `Series B · M` silently. `--prop text='Series B · $35M'` (single quotes) is right. This is the #1 pitch-deck shell-escape failure mode (`$35M`, `$18M ARR`, `$1.2B TAM` appear on cover/ask/financials/milestones). Gate 2 cannot detect a stripped `$35M` — no residue. Gate 2b catches common strip patterns; single-quoting PREVENTS them.
+
 ## What "pitch deck" means here (identity)
 
-A pitch deck is a pptx with a **fundraising layer** on top: VC-oriented narrative arc, verifiable metrics, stage-appropriate data density, founder-credibility surface. The base pptx rules still apply; pitch decks add six deltas:
+A pitch deck is a pptx with a **fundraising layer** on top: VC-oriented narrative arc, verifiable metrics, stage-appropriate data density, founder-credibility surface. Slides are consumed at ~3 seconds per slide in a live room — the pptx v2 rule. Pitch decks add a second constraint on top: **every slide carries one investable proposition**. If a slide is "interesting background" that doesn't move the ask forward, cut it. VCs will not. The base pptx rules still apply; pitch decks add six deltas:
 
 1. **Stage determines everything.** Series A / B / C each dictates slide count, narrative weight, which metrics are must-haves, and tolerance for unit-econ sophistication. A Series A deck with 6 pages of CAC/LTV math reads as over-packaged; a Series B deck missing unit econ reads as incomplete. Pick the stage first — everything downstream follows.
 2. **Narrative arc beats feature dump.** 10 essential slides in a fixed order: cover → problem → solution → market → product → model → traction → team → financials → ask. Out of order = VCs disengage.

--- a/skills/officecli-pptx/SKILL.md
+++ b/skills/officecli-pptx/SKILL.md
@@ -6,19 +6,31 @@ description: "Use this skill any time a .pptx file is involved -- as input, outp
 
 # OfficeCLI PPTX Skill
 
-## BEFORE YOU START
+## BEFORE YOU START (CRITICAL)
 
-**Mental model.** A `.pptx` is a ZIP of XML parts (`ppt/slides/*.xml`, `slideLayouts/`, `slideMasters/`, `theme*.xml`, `charts/`, `media/`, `notesSlides/`). `officecli` gives you a semantic-path API (`/slide[N]/shape[M]`, `/slide[N]/shape[@name=X]`) over it. Raw XML only via `raw-set`.
+**If `officecli` is not installed:**
 
-**Slides are consumed at ~3 seconds per slide in a live room.** Scanned, not read. Every design decision below serves that constraint.
+`macOS / Linux`
 
-**Install check.** If `officecli --version` fails, install then open a new terminal (should report `1.0.63` or newer):
-- macOS / Linux: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
-- Windows (PowerShell): `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
+```bash
+if ! command -v officecli >/dev/null 2>&1; then
+    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
+fi
+```
 
-**Shell quoting (zsh / bash).** ALWAYS quote element paths (`"/slide[1]/..."`). Single-quote values containing `$`. Never hand-write `\$` / `\t` / `\n` — CLI does not interpret them. Full rules in "Shell escape — three layers" below.
+`Windows (PowerShell)`
 
-**Incremental execution.** One command → check exit code → continue. A 50-command script that fails at command 3 cascades silently. After any structural op (new slide, chart, animation, connector) run `get` before stacking more.
+```powershell
+if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
+    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+}
+```
+
+Verify: `officecli --version`
+
+If `officecli` is still not found after first install, open a new terminal and run the verify command again.
+
+If the install command above fails (e.g. blocked by security policy, no network access, or insufficient permissions), install manually — download the binary for your platform from https://github.com/iOfficeAI/OfficeCLI/releases — then re-run the verify command.
 
 ## ⚠️ Help-First Rule
 
@@ -32,6 +44,18 @@ officecli help pptx <element> --json        # Machine-readable schema
 ```
 
 Help is pinned to the installed CLI version (v1.0.63). When skill and help disagree, **help is authoritative**. Triggers to run help immediately: `UNSUPPORTED props:` warning, unknown animation preset, `connector.shape=` enum (drifts — C-P-5), prop-vs-alias (`lineWidth` vs `line.width`, `color` vs `font.color`).
+
+## Mental Model & Inheritance
+
+**Mental model.** A `.pptx` is a ZIP of XML parts (`ppt/slides/*.xml`, `slideLayouts/`, `slideMasters/`, `theme*.xml`, `charts/`, `media/`, `notesSlides/`). `officecli` gives you a semantic-path API (`/slide[N]/shape[M]`, `/slide[N]/shape[@name=X]`) over it. Raw XML only via `raw-set`.
+
+**Slides are consumed at ~3 seconds per slide in a live room.** Scanned, not read. Every design decision below serves that constraint.
+
+## Shell & Execution Discipline
+
+**Shell quoting (zsh / bash).** ALWAYS quote element paths (`"/slide[1]/..."`). Single-quote values containing `$`. Never hand-write `\$` / `\t` / `\n` — CLI does not interpret them. Full rules in "Shell escape — three layers" below.
+
+**Incremental execution.** One command → check exit code → continue. A 50-command script that fails at command 3 cascades silently. After any structural op (new slide, chart, animation, connector) run `get` before stacking more.
 
 ## Requirements for Outputs
 

--- a/skills/officecli-xlsx/SKILL.md
+++ b/skills/officecli-xlsx/SKILL.md
@@ -6,30 +6,31 @@ description: "Use this skill any time a .xlsx file is involved -- as input, outp
 
 # OfficeCLI XLSX Skill
 
-## BEFORE YOU START
+## BEFORE YOU START (CRITICAL)
 
-**Install check.** If `officecli --version` fails:
+**If `officecli` is not installed:**
+
+`macOS / Linux`
 
 ```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
+if ! command -v officecli >/dev/null 2>&1; then
+    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
+fi
 ```
+
+`Windows (PowerShell)`
 
 ```powershell
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
+    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+}
 ```
 
-If still not found, open a new terminal, then `officecli --version` should report `1.0.63`.
+Verify: `officecli --version`
 
-**Shell quoting (zsh / bash).** Excel paths contain `[]`, and number formats contain `$`. Both are shell metacharacters. Rules:
+If `officecli` is still not found after first install, open a new terminal and run the verify command again.
 
-- ALWAYS quote element paths: `"/Sheet1/row[1]"`, not `/Sheet1/row[1]`.
-- Use **single quotes** for any prop value containing `$`: `numFmt='$#,##0'`.
-- For formulas with cross-sheet `!` references, use `batch` with a `<<'EOF'` heredoc (see Known Issues).
-- NEVER hand-write `\$`, `\t`, `\n` inside executable examples. The CLI does not interpret backslash escapes; they will land in your file as literal characters.
-
-**Incremental execution.** Run commands one at a time and read each exit code. `officecli` mutates the file on every call; a 50-command script that fails at command 3 will cascade silently. One command → check output → continue.
+If the install command above fails (e.g. blocked by security policy, no network access, or insufficient permissions), install manually — download the binary for your platform from https://github.com/iOfficeAI/OfficeCLI/releases — then re-run the verify command.
 
 ## ⚠️ Help-First Rule
 
@@ -43,6 +44,17 @@ officecli help xlsx <element> --json        # Machine-readable schema
 ```
 
 Help is pinned to the installed CLI version (v1.0.63). When this skill and help disagree, **help is authoritative**.
+
+## Shell & Execution Discipline
+
+**Shell quoting (zsh / bash).** Excel paths contain `[]`, and number formats contain `$`. Both are shell metacharacters. Rules:
+
+- ALWAYS quote element paths: `"/Sheet1/row[1]"`, not `/Sheet1/row[1]`.
+- Use **single quotes** for any prop value containing `$`: `numFmt='$#,##0'`.
+- For formulas with cross-sheet `!` references, use `batch` with a `<<'EOF'` heredoc (see Known Issues).
+- NEVER hand-write `\$`, `\t`, `\n` inside executable examples. The CLI does not interpret backslash escapes; they will land in your file as literal characters.
+
+**Incremental execution.** Run commands one at a time and read each exit code. `officecli` mutates the file on every call; a 50-command script that fails at command 3 will cascade silently. One command → check output → continue.
 
 ## Requirements for Outputs
 


### PR DESCRIPTION
## Summary

- Five skills (xlsx, pptx, docx, pitch-deck, academic-paper) had drifted in their BEFORE YOU START install guidance — different layouts, wording, version-gate phrasing. This PR collapses them to one shared install block.
- Adds a **manual-install fallback** pointing users to the GitHub Releases page when the `curl | bash` one-liner fails (e.g. blocked by security policy, no network access, insufficient permissions). Responds to a community request from users whose security posture disallows scripts that auto-download binaries.
- Non-install content that had accumulated in BEFORE YOU START (Mental model, shell quoting, incremental execution, scene-layer inherit notes) is relocated — **not deleted** — to new `Mental Model & Inheritance` and `Shell & Execution Discipline` sections placed after Help-First Rule.

## What changed per file

| File | BEFORE YOU START | New sections after Help-First | Other |
|---|---|---|---|
| `officecli-xlsx` | unified install block + fallback | Shell & Execution Discipline | — |
| `officecli-pptx` | unified install block + fallback | Mental Model & Inheritance; Shell & Execution Discipline | — |
| `officecli-docx` | unified install block + fallback | Mental Model & Inheritance; Shell & Execution Discipline | removed one duplicate `# officecli: v1.0.63` line outside frontmatter |
| `officecli-pitch-deck` | unified install block + fallback | Mental Model & Inheritance; Shell & Execution Discipline | pitch-deck identity sentence merged into existing "What pitch deck means here (identity)" |
| `officecli-academic-paper` | unified install block + fallback | Mental Model & Inheritance; Shell & Execution Discipline | removed one duplicate `# officecli: v1.0.63` line outside frontmatter |

Scene-layer pointers also updated: `→ see pptx v2 §BEFORE YOU START` → `§Shell & Execution Discipline`.

## Sample of the unified block

```markdown
## BEFORE YOU START (CRITICAL)

**If `officecli` is not installed:**

`macOS / Linux`

    if ! command -v officecli >/dev/null 2>&1; then
        curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
    fi

`Windows (PowerShell)`

    if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
        irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
    }

Verify: `officecli --version`

If `officecli` is still not found after first install, open a new terminal and run the verify command again.

If the install command above fails (e.g. blocked by security policy, no network access, or insufficient permissions), install manually — download the binary for your platform from https://github.com/iOfficeAI/OfficeCLI/releases — then re-run the verify command.
```

The block is byte-identical across all 5 files.

## Test plan

- [x] `diff` between 5 files' BEFORE YOU START blocks returns empty (byte-identical)
- [x] All `§BEFORE YOU START` pointers in scene-layer files retargeted to `§Shell & Execution Discipline`
- [x] Install URLs reachable: `install.sh` / `install.ps1` / `/releases` all return HTTP 200
- [x] Authoritative repo casing `iOfficeAI/OfficeCLI` used in all skill URLs
- [ ] Reviewer: render one SKILL.md in a markdown previewer and sanity-check section flow

cc @goworm

🤖 Generated with [Claude Code](https://claude.com/claude-code)