### PR TITLE
issue#87: Replace auto-install escalation with fail-fast checks in all skills

### DIFF
--- a/skills/morph-ppt/SKILL.md
+++ b/skills/morph-ppt/SKILL.md
@@ -105,9 +105,9 @@ For every morph transition, plan the slide pair BEFORE writing any code. Use a t
 - Do **not** click "Open with system app" during generation, to avoid file lock / write conflicts.
 - Use clear, direct language and make this a concrete warning, not an optional suggestion.
 
-**FIRST: Install `officecli` if needed**
+**FIRST: Verify `officecli` is installed**
 
-Follow the install section in `reference/officecli-pptx-min.md` section 0.
+Run `officecli --version`. If the command is not found, **stop immediately** and tell the user to install `officecli` before continuing. See installation instructions at: https://github.com/iOfficeAI/OfficeCLI/
 
 **IMPORTANT: Use morph-helpers for reliable workflow**
 

--- a/skills/morph-ppt/reference/officecli-pptx-min.md
+++ b/skills/morph-ppt/reference/officecli-pptx-min.md
@@ -7,27 +7,7 @@ description: OfficeCli Command Reference — PPT generation and validation comma
 
 ## 0) BEFORE YOU START (CRITICAL)
 
-**If `officecli` is not installed:**
-
-`macOS / Linux`
-
-```bash
-if ! command -v officecli >/dev/null 2>&1; then
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-fi
-```
-
-`Windows (PowerShell)`
-
-```powershell
-if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
-    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-}
-```
-
-Verify: `officecli --version`
-
-If `officecli` is still not found after first install, open a new terminal and run the verify command again.
+**Install check.** Run `officecli --version` before starting. If the command is not found, **stop immediately** and tell the user to install `officecli` before continuing. See installation instructions at: https://github.com/iOfficeAI/OfficeCLI/
 
 ---
 

--- a/skills/officecli-academic-paper/SKILL.md
+++ b/skills/officecli-academic-paper/SKILL.md
@@ -12,19 +12,7 @@ When the docx base rules cover it, the text here says `→ see docx v2 §X`. Rea
 
 ## BEFORE YOU START
 
-**Install check.** If `officecli --version` fails:
-
-```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-```
-
-```powershell
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-```
-
-`officecli --version` must report `1.0.63` or newer. If not, open a new terminal and retry.
+**Install check.** Run `officecli --version` before starting. The reported version **must be `1.0.63` or newer**. If the command is not found or reports a version older than `1.0.63`, **stop immediately** and tell the user to install or upgrade to `1.0.63` or newer before continuing. See installation instructions at: https://github.com/iOfficeAI/OfficeCLI/
 
 **Shell quoting, incremental execution, `$FILE` convention** → see docx v2 §BEFORE YOU START. The same rules apply here verbatim — quote `[N]` paths, single-quote any value containing `$` (including `$2.8B` in a body paragraph or `@` DOIs), never hand-write `\$ \t \n` in executable examples, one command at a time. Academic-paper examples below use `$FILE` as a shell variable (`FILE="thesis.docx"`).
 

--- a/skills/officecli-data-dashboard/SKILL.md
+++ b/skills/officecli-data-dashboard/SKILL.md
@@ -12,27 +12,7 @@ Create professional, formula-driven Excel dashboards from CSV or tabular data. T
 
 ## BEFORE YOU START (CRITICAL)
 
-**If `officecli` is not installed:**
-
-`macOS / Linux`
-
-```bash
-if ! command -v officecli >/dev/null 2>&1; then
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-fi
-```
-
-`Windows (PowerShell)`
-
-```powershell
-if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
-    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-}
-```
-
-Verify: `officecli --version`
-
-If `officecli` is still not found after first install, open a new terminal and run the verify command again.
+**Install check.** Run `officecli --version` before starting. If the command is not found, **stop immediately** and tell the user to install `officecli` before continuing. See installation instructions at: https://github.com/iOfficeAI/OfficeCLI/
 
 ---
 

--- a/skills/officecli-docx/SKILL.md
+++ b/skills/officecli-docx/SKILL.md
@@ -10,19 +10,7 @@ description: "Use this skill any time a .docx file is involved -- as input, outp
 
 **Mental model.** A `.docx` is a ZIP of XML parts (`document.xml`, `styles.xml`, `numbering.xml`, `header*.xml`, `footer*.xml`, `comments.xml`, ...). Everything the user sees — headings, tables, page numbers, TOC, tracked changes — is XML inside that ZIP. `officecli` gives you a semantic-path API (`/body/p[1]/r[2]`) over it, so you almost never touch raw XML; when you must, use `raw-set`.
 
-**Install check.** If `officecli --version` fails:
-
-```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-```
-
-```powershell
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-```
-
-If still not found, open a new terminal, then `officecli --version` should report `1.0.63` or newer.
+**Install check.** Run `officecli --version` before starting. The reported version **must be `1.0.63` or newer**. If the command is not found or reports a version older than `1.0.63`, **stop immediately** and tell the user to install or upgrade to `1.0.63` or newer before continuing. See installation instructions at: https://github.com/iOfficeAI/OfficeCLI/
 
 **Shell quoting (zsh / bash).** docx paths contain `[]`, some prop values contain `$`. Both are shell metacharacters. Rules:
 

--- a/skills/officecli-financial-model/SKILL.md
+++ b/skills/officecli-financial-model/SKILL.md
@@ -20,27 +20,7 @@ Build formula-driven, multi-sheet financial models from scratch in Excel. Every 
 
 ## BEFORE YOU START (CRITICAL)
 
-**If `officecli` is not installed:**
-
-`macOS / Linux`
-
-```bash
-if ! command -v officecli >/dev/null 2>&1; then
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-fi
-```
-
-`Windows (PowerShell)`
-
-```powershell
-if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
-    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-}
-```
-
-Verify: `officecli --version`
-
-If `officecli` is still not found after first install, open a new terminal and run the verify command again.
+**Install check.** Run `officecli --version` before starting. If the command is not found, **stop immediately** and tell the user to install `officecli` before continuing. See installation instructions at: https://github.com/iOfficeAI/OfficeCLI/
 
 ---
 

--- a/skills/officecli-pitch-deck/SKILL.md
+++ b/skills/officecli-pitch-deck/SKILL.md
@@ -12,19 +12,7 @@ When the pptx base rules cover it, the text here says `→ see pptx v2 §X`. Rea
 
 ## BEFORE YOU START
 
-**Install check.** If `officecli --version` fails:
-
-```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-```
-
-```powershell
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-```
-
-`officecli --version` must report `1.0.63` or newer. Open a new terminal after install.
+**Install check.** Run `officecli --version` before starting. The reported version **must be `1.0.63` or newer**. If the command is not found or reports a version older than `1.0.63`, **stop immediately** and tell the user to install or upgrade to `1.0.63` or newer before continuing. See installation instructions at: https://github.com/iOfficeAI/OfficeCLI/
 
 **Shell quoting, incremental execution, `$FILE` convention** → see pptx v2 §BEFORE YOU START. Same rules verbatim — quote `[N]` paths, single-quote values containing `$` (including `$35M`, `$1.2B TAM` in a cover or ask slide), never hand-write `\$ \t \n` in executable examples, one command at a time. Examples below use `$FILE` (`FILE="deck.pptx"`).
 

--- a/skills/officecli-pptx/SKILL.md
+++ b/skills/officecli-pptx/SKILL.md
@@ -12,9 +12,7 @@ description: "Use this skill any time a .pptx file is involved -- as input, outp
 
 **Slides are consumed at ~3 seconds per slide in a live room.** Scanned, not read. Every design decision below serves that constraint.
 
-**Install check.** If `officecli --version` fails, install then open a new terminal (should report `1.0.63` or newer):
-- macOS / Linux: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
-- Windows (PowerShell): `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
+**Install check.** Run `officecli --version` before starting. The reported version **must be `1.0.63` or newer**. If the command is not found or reports a version older than `1.0.63`, **stop immediately** and tell the user to install or upgrade to `1.0.63` or newer before continuing. See installation instructions at: https://github.com/iOfficeAI/OfficeCLI/
 
 **Shell quoting (zsh / bash).** ALWAYS quote element paths (`"/slide[1]/..."`). Single-quote values containing `$`. Never hand-write `\$` / `\t` / `\n` — CLI does not interpret them. Full rules in "Shell escape — three layers" below.
 

--- a/skills/officecli-xlsx/SKILL.md
+++ b/skills/officecli-xlsx/SKILL.md
@@ -8,19 +8,7 @@ description: "Use this skill any time a .xlsx file is involved -- as input, outp
 
 ## BEFORE YOU START
 
-**Install check.** If `officecli --version` fails:
-
-```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
-```
-
-```powershell
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
-```
-
-If still not found, open a new terminal, then `officecli --version` should report `1.0.63`.
+**Install check.** Run `officecli --version` before starting. The reported version **must be `1.0.63` or newer**. If the command is not found or reports a version older than `1.0.63`, **stop immediately** and tell the user to install or upgrade to `1.0.63` or newer before continuing. See installation instructions at: https://github.com/iOfficeAI/OfficeCLI/
 
 **Shell quoting (zsh / bash).** Excel paths contain `[]`, and number formats contain `$`. Both are shell metacharacters. Rules:
 


### PR DESCRIPTION
Remove `curl | bash` and `irm | iex` install escalation patterns from all skill SKILL.md files (issue #87). Replace with a declarative fail-fast check:

- Run `officecli --version` before starting
- If the command is not found (or is older than `1.0.63` in versioned skills), stop immediately and tell the user to install or upgrade before continuing — with a link to https://github.com/iOfficeAI/OfficeCLI/

**Why:** Piping remote scripts directly into a shell (`curl … | bash`) bypasses integrity verification and silently elevates privileges.

Skills should never auto-install software on behalf of the user; that decision belongs to the user.
The fail-fast pattern makes the requirement clear and keeps the agent's responsibility bounded to verification only.

Skills updated:
- officecli-docx
- officecli-pptx
- officecli-xlsx,
- officecli-pitch-deck
- officecli-academic-paper
- officecli-data-dashboard,
- officecli-financial-model
- morph-ppt