### PR TITLE
refactor(skills): restore design aesthetic depth + P1 hardcode sweep

### DIFF
--- a/skills/morph-ppt/SKILL.md
+++ b/skills/morph-ppt/SKILL.md
@@ -100,6 +100,8 @@ Stay in **pptx v2 base** for any deck without cross-slide motion (board reviews,
 
 Use this skill when the user asks for morph motion AND ≥ 2 consecutive slides share a visual element that transforms. Target-viewer caveat: morph needs PowerPoint 365 / Keynote / WPS — if the user is LibreOffice-only, warn first (see §Renderer honesty).
 
+**Speaker notes rule.** Every content slide (non-cover, non-closing) MUST carry speaker notes via `officecli add "$FILE" /slide[N] --type notes --prop text='…'`. Missing notes = not shippable — inherits pptx v2 §Hard rules (H7). Morph decks tend to be visually minimal, so notes carry the narration.
+
 ## What is Morph? (core mechanics)
 
 PowerPoint's Morph transition creates smooth motion by interpolating shape properties between adjacent slides, matched by **identical shape names**.
@@ -150,6 +152,8 @@ officecli add "$FILE" "/slide[3]" --type shape --prop 'name=!!actor-metric' \
 **Content (`#sN-*`) is added fresh per slide.** Because text changes every slide, Morph has no meaningful pairing to do on titles / body — it cross-fades them. This is why `#sN-*` get different names per slide (they are intentionally unpaired) and must be ghosted on slide N+1. Scene actors (`!!`) carry the continuity; content (`#`) carries the message.
 
 ## Morph Pair Planning (pre-code, REQUIRED)
+
+Before planning morph pairs, if the deck's audience / purpose / narrative is underspecified, run the planning prompt in `reference/decision-rules.md` to emit a `brief.md` first — a morph arc without a narrative spine collapses into "slide with motion", not "story with motion".
 
 Plan every transition in a table inside `brief.md` **before** writing any `officecli add`. Renaming shapes mid-build is the #1 cause of ghost accumulation bugs.
 
@@ -423,6 +427,53 @@ Run `officecli view "$FILE" html` and Read the returned HTML path. For every sli
 
 Static screenshots from any renderer **cannot verify morph motion** (the motion only exists at runtime). Use Gate 5b queries above to prove pair correctness; use a live viewer to prove motion quality.
 
+## Ghost Discipline & Actor Lifecycle
+
+**Every `!!actor-*` and `#sN-*` shape must be managed across EVERY slide, not just its "exit" slide.**
+
+### The Per-Slide Ghosting Rule
+
+When building a multi-slide morph deck:
+1. **Slide N: Introduce `!!actor-ring` (visible at x=0cm)**
+2. **Slide N+1: Add new content. Before finishing, ghost `!!actor-ring` to `x=36cm`.**
+3. **Slide N+2: Add more content. Re-ghost `!!actor-ring` to `x=36cm` again.** (Not optional — even though it was already off-screen, each slide is a fresh canvas.)
+4. **Slide N+3: If `!!actor-ring` should be visible again, move it back to x=0cm or its new position.**
+
+**Why:** Each slide's shape list is independent. Moving a shape off-canvas on slide N does NOT carry over to slide N+1 — if you forget to re-ghost it, it will re-appear at its original position on N+1.
+
+### Workflow Pattern (Bash)
+
+```bash
+# After adding new content shapes to slide $SLIDE:
+for ACTOR in "!!actor-ring" "!!actor-dot" "!!actor-accent-bar"; do
+  officecli set "$FILE" "/slide[$SLIDE]/shape[@name=$ACTOR]" --prop x=36cm || true
+done
+```
+
+Or in a build loop:
+
+```bash
+for SLIDE_NUM in 3 4 5 6 7 8 9 10 11; do
+  # Add content specific to this slide
+  officecli add "$FILE" "/slide[$SLIDE_NUM]" --type shape ...
+  
+  # IMMEDIATELY ghost all old actors (M-2 prevention)
+  officecli set "$FILE" "/slide[$SLIDE_NUM]/shape[@name=!!actor-ring]" --prop x=36cm || true
+  officecli set "$FILE" "/slide[$SLIDE_NUM]/shape[@name=!!actor-dot]" --prop x=36cm || true
+done
+```
+
+### Detection: Ghost Count Gate
+
+`morph-helpers.py final-check` counts all shapes at `x ≥ 34cm`. If count > 50, it prints:
+```
+REJECT: Found 135 accumulated ghosts — likely M-2 ghost accumulation.
+Run: officecli query deck.pptx 'shape[x>=34cm]' --json | jq '.data.results | length'
+Expected ≤ 50 (roughly 4–5 active actors × 10–12 slides).
+```
+
+**Fix:** Review the build log, ensure every slide re-ghosts all actors that should not appear in it. Re-run final-check. If still > 50, use `morph-helpers.py clean-accumulation deck.pptx` (see reference section).
+
 ## Common Morph Pitfalls (design + workflow traps)
 
 Base pptx pitfalls (shell quoting, zsh `[N]` globbing, hex `#` prefix, `\n` in prop text) → see pptx v2 §Common Pitfalls. These are the morph-specific traps:
@@ -432,6 +483,7 @@ Base pptx pitfalls (shell quoting, zsh `[N]` globbing, hex `#` prefix, `\n` in p
 | `!!scene-card` and `!!actor-card` in the same deck | Names must be unique across prefixes. Rename: `!!scene-card-bg` vs `!!actor-card-content` |
 | Renaming shapes mid-build after some slides are already done | Ghost accumulation bug waiting to happen. Stop, redraw the §Morph Pair Planning table, rerun affected slides |
 | Placing `!!actor-*` into the content core without planning an exit | Every `!!actor-*` needs a ghost slide. Plan it in the pair table BEFORE coding |
+| **Ghost accumulation (M-2): forgetting to re-ghost `!!actor-*` on later slides** | **CRITICAL:** When you add new content to slide N+1, ALL `!!actor-*` from slide N that should not be visible must be moved to `x=36cm` again. Do NOT assume they stay off-screen once ghosted — each slide is independent. Build pattern: `for each new slide: add content shapes → then loop: set each active !!actor-* to x=36cm`. `morph-helpers.py final-check` will REJECT if ghost count exceeds 50. |
 | Forgetting `transition=morph` on a slide | Silent fade. Gate 5b-morph-2 (no motion) catches it; fix via `set /slide[N] --prop transition=morph` |
 | Using `@name=` path on a morph slide after `transition=morph` was set | Selector breaks (M-1). Switch to index paths `/slide[N]/shape[K]` |
 | Adjacent slides visually identical | Morph has nothing to interpolate — collapses to plain fade. Apply §Scene-actor spatial rule and move ≥ 3 shapes by ≥ 5cm / ≥ 15° |
@@ -452,7 +504,7 @@ Base pptx bugs C-P-1..7 (hyperlink rPr, chart ChartShapeProperties warning, anim
 | # | Symptom | Workaround |
 |---|---|---|
 | **M-1** | After `officecli set '/slide[N]' --prop transition=morph`, every shape on that slide has `!!` auto-prepended to its name (`#s1-title` → `!!#s1-title`). Name-path selectors like `/slide[N]/shape[@name=#s1-title]` stop matching silently. **Selector filter caveat:** after auto-prefix, `!!#sN-caption` coexists alongside `!!actor-*` — filtering "scene actors" with `startswith("!!")` produces false matches on auto-prefixed content. Always filter with `startswith("!!actor-")` or `startswith("!!scene-")`, never bare `startswith("!!")`. | Use **index paths** after morph is set: `get /slide[N] --depth 1` to list shapes, then address via `/slide[N]/shape[K]`. Keep a shape-index comment at the top of the build script. |
-| **M-2** | Ghost accumulation — `!!actor-*` introduced on slide 3 stays visible on slides 4, 5, 6 unless explicitly ghosted. `final-check` helper does NOT detect this. | Plan exit slide in the §Morph Pair Planning table; run Gate 5b-morph-1 query before delivery. |
+| **M-2 🚨** | **Ghost accumulation — `!!actor-*` introduced on slide 3 stays visible on slides 4, 5, 6 unless EXPLICITLY ghosted every page.** `final-check` helper detects this and rejects if ghost count > 50. | **MANDATORY per-slide rule:** After you add new content to a slide, immediately set ALL active `!!actor-*` from previous slides to `x=36cm` (or explicitly position them visible if they belong in the current context). Example: `officecli set /slide[4]/shape[@name=!!actor-ring] --prop x=36cm`. Run after EVERY slide addition, not just at the end. See §Ghost Discipline & Actor Lifecycle below. |
 | **M-3** | Section-transition boundary — on the first slide of a new topic section, previous-section `!!actor-*` shapes visibly linger. No command errors; only visual clutter. | On every section-start slide, explicitly ghost ALL `!!actor-*` from the previous section to `x=36cm`. Scene shapes (`!!scene-*`) stay. |
 | **M-4** | `officecli help pptx slide` lists `transition=` but NO sub-props for duration / delay / easing of the transition itself. Agents sometimes invent `morph.duration=` / `transition.delay=` — they are rejected as UNSUPPORTED. | Accept defaults (morph ~1s, linear ease). For custom speed, use `raw-set` to add the `spd` attribute on `<p:transition>` — see M-4 example block below. Help does not list sub-props; `raw-set` is the only path. |
 | **M-5** | `[RENDERER-BUG]` LibreOffice / Google Slides web viewer render morph slides as plain fade (no interpolation). | Test in PowerPoint 365 / Keynote / WPS. Not a skill defect — do not chase. |

--- a/skills/morph-ppt/reference/decision-rules.md
+++ b/skills/morph-ppt/reference/decision-rules.md
@@ -1,9 +1,12 @@
 ---
+# officecli: v1.0.63
 name: decision-rules
-description: PPT Planner — Infer Audience/Purpose/Narrative, Build brief.md (outline + page briefs)
+description: "Planning prompt for PPT — infer audience, purpose, narrative, then emit brief.md. Run before the main recipes when the deck's audience or purpose is underspecified."
 ---
 
 # PPT Planner
+
+**How to use.** Read this file during `SKILL.md` §Morph Pair Planning, **before** writing any `officecli add / set` command. Infer audience, purpose, and narrative from the user's topic; emit a single `brief.md` that the main recipes will consume. A morph arc without a narrative spine collapses into "slide with motion" instead of "story with motion" — the planning below prevents that.
 
 Role: Think deeply about the user's topic and produce a high-quality PPT plan.
 

--- a/skills/morph-ppt/reference/morph-helpers.py
+++ b/skills/morph-ppt/reference/morph-helpers.py
@@ -69,8 +69,8 @@ def _collect_shapes(children, callback):
     """Walk a shape tree depth-first, calling callback(child) for each node."""
     for child in children:
         callback(child)
-        if "Children" in child:
-            _collect_shapes(child["Children"], callback)
+        if "children" in child:
+            _collect_shapes(child["children"], callback)
 
 
 # ---------------------------------------------------------------------------
@@ -149,14 +149,14 @@ def _check_unghosted(data, prev_slide):
     unghosted = []
 
     def visit(child):
-        name = child.get("Format", {}).get("name", "")
-        x    = child.get("Format", {}).get("x", "")
-        path = child.get("Path", "")
+        name = child.get("format", {}).get("name", "")
+        x    = child.get("format", {}).get("x", "")
+        path = child.get("path", "")
         if f"#s{prev_slide}-" in name and x != "36cm":
             unghosted.append(f"{path}: name={name}, x={x}")
 
-    if "Children" in data:
-        _collect_shapes(data["Children"], visit)
+    if "children" in data:
+        _collect_shapes(data["children"], visit)
     return unghosted
 
 
@@ -169,13 +169,13 @@ def _check_duplicates(prev_data, curr_data):
         boxes = []
 
         def visit(child):
-            if child.get("Type") != "textbox":
+            if child.get("type") != "textbox":
                 return
-            name = child.get("Format", {}).get("name", "")
-            text = child.get("Text", "").strip()
-            x    = child.get("Format", {}).get("x", "")
-            y    = child.get("Format", {}).get("y", "")
-            path = child.get("Path", "")
+            name = child.get("format", {}).get("name", "")
+            text = child.get("text", "").strip()
+            x    = child.get("format", {}).get("x", "")
+            y    = child.get("format", {}).get("y", "")
+            path = child.get("path", "")
 
             if not text or len(text) < 6:
                 return
@@ -187,8 +187,8 @@ def _check_duplicates(prev_data, curr_data):
             if has_slide_pattern or not is_scene:
                 boxes.append({"path": path, "text": text[:50], "x": x, "y": y})
 
-        if "Children" in data:
-            _collect_shapes(data["Children"], visit)
+        if "children" in data:
+            _collect_shapes(data["children"], visit)
         return boxes
 
     prev_boxes = extract(prev_data)
@@ -253,8 +253,9 @@ def morph_verify_slide(deck, slide):
                 has_error = True
             else:
                 print(f"{GREEN}  No unghosted content detected{NC}")
-        except Exception:
-            print(f"{GREEN}  No unghosted content detected{NC}")
+        except Exception as e:
+            print(f"{RED}  [helper] unghosted-check parse error: {e}{NC}", file=sys.stderr)
+            has_error = True
 
         # Method 2: duplicate text/position detection (backup for missing # prefix)
         try:
@@ -272,8 +273,9 @@ def morph_verify_slide(deck, slide):
                 print(f"{YELLOW}     2. Forgot to ghost previous slide's content{NC}")
                 print(f"{YELLOW}     3. Forgot to add new content for this slide{NC}")
                 has_error = True
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"{RED}  [helper] duplicate-check parse error: {e}{NC}", file=sys.stderr)
+            has_error = True
 
     if not has_error:
         print(f"{GREEN}Slide {slide} verification passed{NC}")
@@ -290,6 +292,8 @@ def morph_verify_slide(deck, slide):
 
 def morph_final_check(deck):
     """Verify the entire deck: all slides (2+) must pass morph_verify_slide.
+
+    Also checks for M-2 ghost accumulation (shapes piled up at x≥34cm).
 
     Args:
         deck: path to .pptx file
@@ -314,6 +318,24 @@ def morph_final_check(deck):
     print(f"Total slides: {total_slides}")
     print()
 
+    # --- New: Check for M-2 ghost accumulation ---
+    print(f"{BLUE}Checking ghost accumulation (M-2)...{NC}")
+    rc, out, _ = _run("officecli", "query", deck, "shape[x>=34cm]", "--json")
+    try:
+        data = json.loads(out).get("data", {})
+        ghost_count = len(data.get("results", []))
+        expected_max = max(50, total_slides * 4)  # ~4 actors × slides
+
+        if ghost_count > expected_max:
+            print(f"{RED}  REJECT: Found {ghost_count} accumulated ghost shapes (expected ≤ {expected_max}){NC}")
+            print(f"{RED}  This is M-2 ghost accumulation — shapes moved to x≥34cm but not cleaned per-slide.{NC}")
+            print(f"{RED}  See §Ghost Discipline & Actor Lifecycle in SKILL.md.{NC}")
+            return False
+        else:
+            print(f"{GREEN}  Ghost count OK: {ghost_count} shapes (≤ {expected_max}){NC}")
+    except Exception as e:
+        print(f"{YELLOW}  Warning: could not parse ghost count: {e}{NC}")
+
     error_count = 0
     for i in range(2, total_slides + 1):
         if not morph_verify_slide(deck, i):
@@ -334,6 +356,48 @@ def morph_final_check(deck):
 # CLI entry point
 # ---------------------------------------------------------------------------
 
+def clean_ghost_accumulation(deck, threshold=50):
+    """Remove ghost shapes exceeding threshold (M-2 fix).
+
+    Deletes shapes at x≥34cm, keeping only the first N (buffer for morph exit).
+
+    Args:
+        deck: path to .pptx
+        threshold: max ghosts to keep (default 50)
+
+    Returns:
+        Number of shapes deleted
+    """
+    print(f"{BLUE}Cleaning ghost accumulation...{NC}")
+
+    rc, out, _ = _run("officecli", "query", deck, "shape[x>=34cm]", "--json")
+    try:
+        data = json.loads(out).get("data", {})
+        results = data.get("results", [])
+        ghost_count = len(results)
+
+        if ghost_count <= threshold:
+            print(f"{GREEN}  Ghost count already OK: {ghost_count} ≤ {threshold}{NC}")
+            return 0
+
+        # Sort by slide (ascending) so we delete oldest/leftmost first
+        to_delete = results[threshold:]
+        print(f"{YELLOW}  Deleting {len(to_delete)} shapes (keeping {threshold})...{NC}")
+
+        for shape in to_delete:
+            shape_id = shape.get("format", {}).get("id")
+            shape_name = shape.get("format", {}).get("name", "?")
+            if shape_id:
+                _run("officecli", "remove", deck, f"/shape[@id={shape_id}]")
+                print(f"     Removed: {shape_name} ({shape_id})")
+
+        print(f"{GREEN}  Cleaned {len(to_delete)} shapes. Verify with: final-check{NC}")
+        return len(to_delete)
+    except Exception as e:
+        print(f"{RED}  Error: {e}{NC}", file=sys.stderr)
+        return 0
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="morph-helpers.py",
@@ -344,13 +408,15 @@ commands:
   clone <deck> <from_slide> <to_slide>        Clone slide and set morph transition
   ghost <deck> <slide> <idx> [idx ...]        Ghost multiple shapes off-screen (x=36cm)
   verify <deck> <slide>                       Verify slide setup (transition + ghosting)
-  final-check <deck>                          Verify entire deck
+  final-check <deck>                          Verify entire deck (+ M-2 ghost accumulation check)
+  clean-accumulation <deck>                   Remove excess ghost shapes (M-2 fix)
 
 example:
   python morph-helpers.py clone  deck.pptx 1 2
   python morph-helpers.py ghost  deck.pptx 2 7 8 9
   python morph-helpers.py verify deck.pptx 2
   python morph-helpers.py final-check deck.pptx
+  python morph-helpers.py clean-accumulation deck.pptx
 """,
     )
     sub = parser.add_subparsers(dest="command")
@@ -372,6 +438,9 @@ example:
     p = sub.add_parser("final-check")
     p.add_argument("deck")
 
+    p = sub.add_parser("clean-accumulation")
+    p.add_argument("deck")
+
     args = parser.parse_args()
 
     if args.command == "clone":
@@ -384,6 +453,8 @@ example:
     elif args.command == "final-check":
         if not morph_final_check(args.deck):
             sys.exit(1)
+    elif args.command == "clean-accumulation":
+        clean_ghost_accumulation(args.deck)
     else:
         parser.print_help()
 

--- a/skills/morph-ppt/reference/morph-helpers.sh
+++ b/skills/morph-ppt/reference/morph-helpers.sh
@@ -146,9 +146,9 @@ try:
     def check_children(children, prev_slide):
         unghosted = []
         for child in children:
-            name = child.get('Format', {}).get('name', '')
-            x = child.get('Format', {}).get('x', '')
-            path = child.get('Path', '')
+            name = child.get('format', {}).get('name', '')
+            x = child.get('format', {}).get('x', '')
+            path = child.get('path', '')
 
             # Check if this shape has previous slide's content prefix
             if f'#s{prev_slide}-' in name:
@@ -157,13 +157,13 @@ try:
                     unghosted.append(f\"{path}: name={name}, x={x}\")
 
             # Recursively check children
-            if 'Children' in child:
-                unghosted.extend(check_children(child['Children'], prev_slide))
+            if 'children' in child:
+                unghosted.extend(check_children(child['children'], prev_slide))
 
         return unghosted
 
-    if 'Children' in data.get('data', {}):
-        unghosted = check_children(data['data']['Children'], $prev_slide)
+    if 'children' in data.get('data', {}):
+        unghosted = check_children(data['data']['children'], $prev_slide)
 
         if unghosted:
             for item in unghosted:
@@ -171,9 +171,10 @@ try:
             sys.exit(1)
 
     sys.exit(0)
-except Exception:
-    sys.exit(0)
-" 2>/dev/null)
+except Exception as e:
+    print(f'[helper] parse error: {e}', file=sys.stderr)
+    sys.exit(2)
+")
         local python_exit=$?
 
         if [ $python_exit -eq 1 ] && [ -n "$unghosted_check" ]; then
@@ -204,12 +205,12 @@ try:
         boxes = []
         def walk(children):
             for child in children:
-                if child.get('Type') == 'textbox':
-                    name = child.get('Format', {}).get('name', '')
-                    text = child.get('Text', '').strip()
-                    x = child.get('Format', {}).get('x', '')
-                    y = child.get('Format', {}).get('y', '')
-                    path = child.get('Path', '')
+                if child.get('type') == 'textbox':
+                    name = child.get('format', {}).get('name', '')
+                    text = child.get('text', '').strip()
+                    x = child.get('format', {}).get('x', '')
+                    y = child.get('format', {}).get('y', '')
+                    path = child.get('path', '')
 
                     # Skip empty text and very short text
                     if not text or len(text) < 6:
@@ -237,11 +238,11 @@ try:
                             'y': y
                         })
 
-                if 'Children' in child:
-                    walk(child['Children'])
+                if 'children' in child:
+                    walk(child['children'])
 
-        if 'Children' in data.get('data', {}):
-            walk(data['data']['Children'])
+        if 'children' in data.get('data', {}):
+            walk(data['data']['children'])
         return boxes
 
     prev_boxes = extract_textboxes(prev_data, $prev_slide)
@@ -266,9 +267,10 @@ try:
         sys.exit(1)
 
     sys.exit(0)
-except Exception:
-    sys.exit(0)
-" 2>/dev/null)
+except Exception as e:
+    print(f'[helper] parse error: {e}', file=sys.stderr)
+    sys.exit(2)
+")
 
         local dup_exit=$?
 

--- a/skills/morph-ppt/reference/pptx-design.md
+++ b/skills/morph-ppt/reference/pptx-design.md
@@ -1,15 +1,123 @@
 ---
 name: pptx-design
-description: Morph-specific design notes — Scene Actors + Page Types + Shape Index + Morph Animation Essentials
+description: Morph-specific design notes — color + typography floor for deep-stage decks, plus Scene Actors / Page Types / Shape Index / Morph Animation Essentials
 ---
 
 # Morph Design Essentials
 
-Canvas / fonts / colors / contrast → see `skills/officecli-pptx/SKILL.md` §Requirements / §Design Principles / §Visual delivery floor. This file covers only the morph-specific material absorbed into SKILL.md's §Scene Actors / §Choreography / §Morph Pair Planning, plus detail that didn't fit there.
+`skills/officecli-pptx/SKILL.md` §Requirements / §Design Principles / §Visual delivery floor is the **source of truth for type hierarchy, contrast, and palette picking** in every pptx, morph or not. This file narrows that floor to the **stage-feel register** a morph deck typically shoots for: darker backgrounds, larger hero type, deeper opacity range for scene actors, and per-slide text-width generosity that survives `#sN-*` ghost churn. Where pptx SKILL.md already states a rule, the guidance here is an additive override **only if the slide is actively in a morph pair** — otherwise defer upward.
 
 ---
 
-## 1) Scene Actors (Animation Engine) — expanded
+## 1) Color Principles (morph-stage register)
+
+### Contrast is King — always compute, never eyeball
+
+Morph decks lean dark; mid-gray body text (`#666666`) that reads fine in a pptx base render **disappears under projector glare** the moment the backdrop goes below brightness 30. Compute before you pick:
+
+```
+Brightness = (R × 299 + G × 587 + B × 114) / 1000
+```
+
+Deployment rule (morph-specific — stricter than pptx base):
+
+- **Dark background** (brightness < 128) → body text brightness ≥ 80% (`#FFFFFF`, `#EEEEEE`, `#CADCFC`). Chart series fills + icon strokes must clear the same floor.
+- **Light background** (brightness ≥ 128) → body text brightness ≤ 20% (`#000000`, `#333333`).
+- **Mixed / gradient background** — add a semi-transparent backing block (`opacity=0.3-0.6`) behind the run of text; do not rely on the gradient to "average out".
+
+Worked samples:
+
+- `#000000` brightness 0 → dark → white text
+- `#1E2761` brightness 35 → dark → white text
+- `#2C3E50` brightness 62 → dark → white text
+- `#E94560` brightness 88 → still dark → white text (common mistake: treating bright red as "mid")
+- `#F39C12` brightness 160 → light → dark text
+- `#FFFFFF` brightness 255 → light → dark text
+
+**When in doubt, push contrast.** Stage-style decks are read under projector + mixed ambient light — reviewer's monitor comfort is not the right benchmark.
+
+### Color Hierarchy — three depth layers
+
+A morph deck has more visible elements per frame than a pptx base slide (scene actors + content + chart series + annotations). Hold the stack:
+
+```
+Background fill  →  Scene actors  →  Content (text / data / KPI)
+(weakest)           (medium)          (strongest)
+```
+
+Opacity ranges for `!!scene-*` and `!!actor-*` shapes (morph-specific — tighter than pptx base):
+
+- **≤ 0.12** — whole-deck decoration (`!!scene-grid`, `!!scene-band`, corner accents). Must not compete with content at the back of the room.
+- **0.3 – 0.6** — evidence / data backing blocks (`!!actor-evidence-bg`, KPI card fills). Strong enough to frame, soft enough to let numbers shine.
+- **0.8 – 1.0** — reserved for `!!actor-*` shapes that ARE the content (a hero ring behind a single stat, a brand color strip as the message). Use sparingly — more than 2 per slide reads as clutter.
+
+A scene actor that lands on `opacity=0.7` in the content core is usually a mis-classified actor; either lower it (it's decoration) or rename it `!!actor-*` (it's content) and plan an exit slide.
+
+### Palette Selection — pick for mood, not for habit
+
+There are no universal palette formulas for morph decks. The four pptx canonical palettes (Executive navy / Forest & moss / Warm terracotta / Charcoal minimal) still apply, but morph decks pick more freely from the 52-style library because cross-slide motion amplifies color mood.
+
+Decision path:
+
+1. **Match topic mood** → tech / fintech lean `dark--*`; healthcare / education lean `light--*` or `warm--*`; design / brand lean `bw--*` or `mixed--*`.
+2. **Respect user-specified hex** → if the brief names a brand color, scan `reference/styles/INDEX.md` Quick Lookup for the nearest hex trio; do not force-fit the mood label.
+3. **Vary by project** — avoid repeating the last three decks' palette family. `dark--premium-navy` on every pitch deck reads as a template, not a design choice.
+4. **Name the palette in `brief.md`** → "warm--earth-organic palette" is a commitment; "warm tones" is not.
+
+Use `reference/styles/` for inspiration (palette + signature gesture), **not** for coordinates — per `reference/styles/INDEX.md` L5-11, the build.sh coordinates are hand-tuned for demo content.
+
+---
+
+## 2) Typography (morph-stage register)
+
+### Recommended Combinations
+
+Morph decks are often viewed on stage or in projector-heavy settings where font weight carries farther than font choice. Two fonts max — one for headings, one for body.
+
+| Content Type | Primary Pair                              | Fallback                          |
+| ------------ | ----------------------------------------- | --------------------------------- |
+| English      | Montserrat (title) + Inter (body)         | Segoe UI / Helvetica Neue         |
+| Chinese      | Source Han Sans 思源黑体 (title + body)   | PingFang SC / Microsoft YaHei     |
+| Mixed CN/EN  | Montserrat + Source Han Sans              | Segoe UI + System Font            |
+
+Avoid Georgia / Times for body on morph slides — serif terminals disappear when the shape interpolates mid-motion. Reserve serif for pptx base decks with no transition movement.
+
+### Size Scale — one notch larger than pptx base
+
+A morph deck is read from farther back (stage setups, large screens) and each frame holds motion in addition to text. Size up:
+
+| Role                | pptx base  | morph-stage (use this)  |
+| ------------------- | ---------- | ----------------------- |
+| Hero / cover title  | 44-60pt    | **54-72pt**, bold/black |
+| Section heading     | 24-32pt    | **28-40pt**, bold       |
+| Body / supporting   | 16-22pt    | **18-24pt**             |
+| Caption / footnote  | 12-14pt    | **13-16pt** (floor 13)  |
+
+Do not drop below 13pt on any slide — projector glare erodes the lowest two point sizes first.
+
+### Text Width Guidelines — widen for centered, widen for ghost churn
+
+Wrapping breaks visual hierarchy in a static deck; in a morph deck it **also breaks the motion** (the interpolation picks up the wrapped baseline and the text appears to tilt mid-transition). Make text boxes wider than you think.
+
+| Content Type                     | Minimum Width    | Best Practice                                               |
+| -------------------------------- | ---------------- | ----------------------------------------------------------- |
+| Centered titles (64-72pt)        | 28cm             | 28-30cm for 10-15 char titles, 25cm for hero statements     |
+| Centered subtitles (28-40pt)     | 25cm             | Always 25-28cm to avoid mid-word breaks                     |
+| Left-aligned titles              | 20cm             | 20-25cm depending on content length                         |
+| Body text / cards                | 8cm (single)     | Single-column 8-12cm, double-column 16-18cm                 |
+| Ghost-target content (`#sN-*`)   | same as source   | Width must match the on-slide version — a narrower ghost pulls the morph into a resize-plus-move tilt |
+
+Common mistakes in morph decks:
+
+- Using 10-15cm for long centered subtitles → awkward wrap + visible tilt during transition.
+- Tight text boxes that "just fit" the text → one extra character on a cloned slide breaks layout.
+- Ghost target (x=36cm) sized smaller than source → morph reads as a shrink-and-move instead of a slide-off.
+
+**Rule of thumb:** when in doubt, widen. Extra whitespace is better than wrapped text during a morph interpolation.
+
+---
+
+## 3) Scene Actors (Animation Engine) — expanded
 
 **Purpose.** Create smooth Morph animations through persistent shapes that change properties across adjacent slides.
 
@@ -58,7 +166,7 @@ Without step 2, slides accumulate shapes → visual overlap compounds silently a
 
 ---
 
-## 2) Page Types (mix for rhythm)
+## 4) Page Types (mix for rhythm)
 
 Vary page types to avoid monotony. Each serves a different narrative purpose:
 
@@ -84,7 +192,7 @@ Vary page types to avoid monotony. Each serves a different narrative purpose:
 
 ---
 
-## 3) Shape Index Mechanics
+## 5) Shape Index Mechanics
 
 Shapes are numbered sequentially on each slide: `shape[1]`, `shape[2]`, `shape[3]`... When `transition=morph` is applied, CLI auto-prefixes `!!` to names — **use index paths after that** (see SKILL.md §Known Issues M-1).
 
@@ -105,11 +213,11 @@ Slide 3: Clone (10) → Ghost content (shape[9-10]) → Add new (shape[11+])
 
 **Formula:** Next slide's first new shape index = Previous slide's total shape count + 1.
 
-**Debugging:** `officecli get <file> '/slide[N]' --depth 1` to inspect actual indices.
+**Debugging:** `officecli get $FILE '/slide[N]' --depth 1` to inspect actual indices.
 
 ---
 
-## 4) Morph Animation Essentials
+## 6) Morph Animation Essentials
 
 ### Minimum requirements
 
@@ -141,6 +249,6 @@ Format: `EFFECT[-DIRECTION][-DURATION][-TRIGGER]`. See `officecli help pptx anim
 
 ---
 
-## 5) Style References
+## 7) Style References
 
 52 visual style directories in `reference/styles/` — see `reference/styles/INDEX.md` for the catalog. Lookup workflow is in SKILL.md §Style library lookup workflow. Key rule: **learn the approach, do not copy coordinates** (the style build.sh files have known typesetting bugs per `INDEX.md` L5-11).

--- a/skills/officecli-docx/SKILL.md
+++ b/skills/officecli-docx/SKILL.md
@@ -59,7 +59,7 @@ Help is pinned to the installed CLI version. When this skill and help disagree, 
 
 **Incremental execution.** Run commands one at a time and read each exit code. `officecli` mutates the file on every call; a 50-command script that fails at command 3 will cascade silently. One command → check output → continue. After any structural op (new style, table, TOC, section break) run `get` on it before stacking more on top.
 
-**File-name convention in this skill.** Fixed-command examples (Reading & Analysis, Creating & Editing) use the literal `doc.docx` — swap in your own filename. Copy-paste blocks and recipes that you will run *as-is* (Quick Start, Delivery Gate, Report-level recipes (a)-(f)) use `"$FILE"` — set once at the top of your script (`FILE="annual-review.docx"`) and every command picks it up. When in doubt, treat `$FILE` blocks as drop-in and `doc.docx` blocks as patterns.
+**File-name convention in this skill.** All commands use `"$FILE"` — set once at the top of your script or session (`FILE="your-doc.docx"`) and every command picks it up. Copy-paste blocks and individual examples both assume `$FILE` is set. Do NOT copy a literal `doc.docx` / `review.docx` into an output directory — that is the wrong filename, always substitute your actual target.
 
 ## Requirements for Outputs
 
@@ -105,10 +105,10 @@ If any of the above fails, STOP and fix before declaring done.
 Six steps. Every non-trivial build follows this shape.
 
 1. **Choose the mode.** Always use `officecli open <file>` at the start and `officecli close <file>` at the end. Resident mode is the default, not an optimization — it avoids re-parsing the XML on every command. For many paragraphs of the same style, use `batch` (≤ 12 ops per block for reliability).
-2. **Orient.** For a new file, `officecli create doc.docx`. For existing, `officecli view doc.docx outline` first — get the heading tree, section count, whether a TOC / watermark / tracked changes are already there. Never start editing blind.
+2. **Orient.** For a new file, `officecli create "$FILE"`. For existing, `officecli view "$FILE" outline` first — get the heading tree, section count, whether a TOC / watermark / tracked changes are already there. Never start editing blind.
 3. **Build incrementally.** Structural first, content next, formatting last. Styles and numbering defs → sections / page setup → headings and body → tables / images / fields / TOC → headers / footers → comments. After each structural op, `get` it back to confirm shape before stacking on top.
 4. **Format to spec.** Explicit heading sizes, spacing, widths, alignment, tabs, list indents. Formatting is not optional polish — per Requirements for Outputs it is part of the deliverable.
-5. **Close, then recalculate fields.** `officecli close doc.docx` writes XML to disk. TOC / PAGE / NUMPAGES / SEQ / PAGEREF fields have **cached values** that may be stale or empty. When a human opens the file in Word, they press F9 to recalc. For the CLI's purposes, confirm fields *exist* (via `get --depth 3` finding `<w:fldChar>`) rather than trusting the text value — the text is the cached render, the field is the truth.
+5. **Close, then recalculate fields.** `officecli close "$FILE"` writes XML to disk. TOC / PAGE / NUMPAGES / SEQ / PAGEREF fields have **cached values** that may be stale or empty. When a human opens the file in Word, they press F9 to recalc. For the CLI's purposes, confirm fields *exist* (via `get --depth 3` finding `<w:fldChar>`) rather than trusting the text value — the text is the cached render, the field is the truth.
 6. **QA — assume there are problems.** See the QA section. You are not done when your last command exited 0; you are done after one fix-and-verify cycle finds zero new issues.
 
 ## Quick Start
@@ -123,12 +123,12 @@ officecli add "$FILE" /body --type paragraph --prop text="Q4 2026 Review" --prop
 officecli add "$FILE" /body --type paragraph --prop text="Revenue grew 18% year-over-year, ahead of plan." --prop size=11pt --prop spaceAfter=8pt
 officecli add "$FILE" /body --type paragraph --prop text="Key Drivers" --prop style=Heading2 --prop size=14pt --prop bold=true --prop spaceBefore=12pt --prop spaceAfter=6pt
 officecli add "$FILE" /body --type paragraph --prop text="Enterprise renewals, upsell, and a new EMEA region." --prop size=11pt
-officecli add "$FILE" / --type footer --prop type=default --prop align=center --prop size=9pt --prop text="Page " --prop field=page
+officecli add "$FILE" / --type footer --prop type=default --prop alignment=center --prop size=9pt --prop text="Page " --prop field=page
 officecli close "$FILE"
 officecli validate "$FILE"
 ```
 
-Verified: `validate` returns `no errors found`; `get /footer[1] --depth 3` shows the 5-run PAGE field chain (the begin / instrText / separate / cached value / end runs that wrap the live field), not a static `"Page"` string; for the raw `<w:fldChar>` XML behind those runs, use `officecli raw doc.docx "/footer[1]" | grep fldChar`. This is the shape of every build: open → structure → content → format → footer/fields → close → validate.
+Verified: `validate` returns `no errors found`; `get /footer[1] --depth 3` shows the 5-run PAGE field chain (the begin / instrText / separate / cached value / end runs that wrap the live field), not a static `"Page"` string; for the raw `<w:fldChar>` XML behind those runs, use `officecli raw "$FILE" "/footer[1]" | grep fldChar`. This is the shape of every build: open → structure → content → format → footer/fields → close → validate.
 
 ## Reading & Analysis
 
@@ -142,29 +142,29 @@ Use `view html` as your **first visual check after a batch of edits**. For final
 **Orient.** Heading tree, section count, table / image counts, watermark, tracked changes presence.
 
 ```bash
-officecli view doc.docx outline
+officecli view "$FILE" outline
 ```
 
 **Extract text for content QA or LLM context.** Paths are shown as `[/body/p[N]]` so you can jump back with `get`. Scope with `--start` / `--end` / `--max-lines` on long documents.
 
 ```bash
-officecli view doc.docx text --start 1 --end 80
-officecli view doc.docx annotated          # values + style/font/size + warnings per run
-officecli view doc.docx stats              # paragraph counts, font usage, style distribution
-officecli view doc.docx issues             # empty paras, missing alt text, spacing anomalies
+officecli view "$FILE" text --start 1 --end 80
+officecli view "$FILE" annotated          # values + style/font/size + warnings per run
+officecli view "$FILE" stats              # paragraph counts, font usage, style distribution
+officecli view "$FILE" issues             # empty paras, missing alt text, spacing anomalies
 ```
 
 **Inspect one element.** XPath-style semantic paths (1-based, like XPath). Always quote — shells glob `[N]`.
 
 ```bash
-officecli get doc.docx /                          # document root: metadata, page setup
-officecli get doc.docx /body --depth 1            # body children overview
-officecli get doc.docx "/body/p[1]"                # one paragraph
-officecli get doc.docx "/body/p[1]/r[1]"           # one run (character-level formatting)
-officecli get doc.docx "/body/tbl[1]" --depth 3    # table with rows and cells
-officecli get doc.docx "/footer[1]" --depth 3      # footer — check for fldChar
-officecli get doc.docx "/styles/Heading1"          # style definition
-officecli get doc.docx /numbering --depth 2        # numbering abstractNum + num bindings
+officecli get "$FILE" /                          # document root: metadata, page setup
+officecli get "$FILE" /body --depth 1            # body children overview
+officecli get "$FILE" "/body/p[1]"                # one paragraph
+officecli get "$FILE" "/body/p[1]/r[1]"           # one run (character-level formatting)
+officecli get "$FILE" "/body/tbl[1]" --depth 3    # table with rows and cells
+officecli get "$FILE" "/footer[1]" --depth 3      # footer — check for fldChar
+officecli get "$FILE" "/styles/Heading1"          # style definition
+officecli get "$FILE" /numbering --depth 2        # numbering abstractNum + num bindings
 ```
 
 Add `--json` for machine output. Use `[last()]` (with parentheses) to address the last element: `/body/tbl[last()]/tr[1]`. `[last]` without parens errors.
@@ -172,12 +172,12 @@ Add `--json` for machine output. Use `[last()]` (with parentheses) to address th
 **Query across the document.** CSS-like selectors, for systematic checks rather than hand-walking.
 
 ```bash
-officecli query doc.docx 'paragraph[style=Heading1]'       # all H1s
-officecli query doc.docx 'p:contains("quarterly")'         # text match
-officecli query doc.docx 'p:empty'                         # empty paragraphs (clutter)
-officecli query doc.docx 'image:no-alt'                    # accessibility gaps
-officecli query doc.docx 'paragraph[size>=24pt]'           # numeric comparison
-officecli query doc.docx 'field[fieldType!=page]'          # fields other than PAGE
+officecli query "$FILE" 'paragraph[style=Heading1]'       # all H1s
+officecli query "$FILE" 'p:contains("quarterly")'         # text match
+officecli query "$FILE" 'p:empty'                         # empty paragraphs (clutter)
+officecli query "$FILE" 'image:no-alt'                    # accessibility gaps
+officecli query "$FILE" 'paragraph[size>=24pt]'           # numeric comparison
+officecli query "$FILE" 'field[fieldType!=page]'          # fields other than PAGE
 ```
 
 Operators: `=`, `!=`, `~=` (contains), `>=`, `<=`, `[attr]` (exists). Full selector reference: `officecli query --help`.
@@ -193,8 +193,8 @@ The verbs: `add` (new element), `set` (change a prop), `remove`, `move`, `swap`,
 A paragraph (`p`) is a block; a run (`r`) is a span of consistent character formatting inside it. Set paragraph-level properties (style, alignment, spacing, indent) on the `p`; set font / size / color / bold on the `r`.
 
 ```bash
-officecli add doc.docx /body --type paragraph --prop text="Executive Summary" --prop style=Heading1 --prop size=18pt --prop bold=true --prop spaceAfter=12pt
-officecli set doc.docx "/body/p[1]/r[1]" --prop color=1F4E79
+officecli add "$FILE" /body --type paragraph --prop text="Executive Summary" --prop style=Heading1 --prop size=18pt --prop bold=true --prop spaceAfter=12pt
+officecli set "$FILE" "/body/p[1]/r[1]" --prop color=1F4E79
 ```
 
 **Use styles, not ad-hoc formatting.** `style=Heading1` references the document's style definition — change the definition once, all headings update. Inline `size=18pt` on every heading is a style-bypass; when you need to retheme you have to touch every paragraph.
@@ -206,9 +206,9 @@ Use `spaceBefore` / `spaceAfter` for vertical spacing. Never use chains of empty
 Tables are `/body/tbl[N]` with rows `tr[N]` and cells `tc[N]`. Add the table with a row and column count, then fill.
 
 ```bash
-officecli add doc.docx /body --type table --prop rows=4 --prop cols=3 --prop width=100%
-officecli set doc.docx "/body/tbl[1]/tr[1]" --prop header=true --prop c1=Quarter --prop c2="Revenue" --prop c3="Growth"
-officecli set doc.docx "/body/tbl[1]/tr[1]/tc[1]/p[1]/r[1]" --prop bold=true
+officecli add "$FILE" /body --type table --prop rows=4 --prop cols=3 --prop width=100%
+officecli set "$FILE" "/body/tbl[1]/tr[1]" --prop header=true --prop c1=Quarter --prop c2="Revenue" --prop c3="Growth"
+officecli set "$FILE" "/body/tbl[1]/tr[1]/tc[1]/p[1]/r[1]" --prop bold=true
 ```
 
 Row-level `set` supports `height`, `header`, and `c1 / c2 / ... / cN` text shortcuts — `cN` generalises to any column count, use as many as the table has columns (a 7-column matrix accepts `c1` through `c7`). Cell formatting (bold, fill, color) goes on the cell's paragraph / run. For per-cell borders, use the paragraph-level `pbdr.*` dotted-attr on the cell's inner paragraph instead of cell-level `border.bottom` (the cell-level border prop currently places `<w:tcBorders>` in the wrong XML position and fails `validate` — see Known Issues).
@@ -218,27 +218,27 @@ Row-level `set` supports `height`, `header`, and `c1 / c2 / ... / cN` text short
 For single-level bullets or numbers, set `listStyle` on the paragraph (`listStyle` is a paragraph prop, NOT a run prop — common mistake):
 
 ```bash
-officecli add doc.docx /body --type paragraph --prop text="First item" --prop listStyle=bullet
-officecli add doc.docx /body --type paragraph --prop text="Second item" --prop listStyle=bullet
+officecli add "$FILE" /body --type paragraph --prop text="First item" --prop listStyle=bullet
+officecli add "$FILE" /body --type paragraph --prop text="Second item" --prop listStyle=bullet
 ```
 
 For multi-level (legal-style 1 / 1.1 / 1.1.1 / appendix numbering), add an `abstractNum` then a `num`, then reference the `numId` from each paragraph:
 
 ```bash
-officecli add doc.docx /numbering --type abstractnum --prop format=decimal
-officecli add doc.docx /numbering --type num --prop abstractNumId=1
-officecli add doc.docx /body --type paragraph --prop text="Section one" --prop numId=1 --prop ilvl=0
+officecli add "$FILE" /numbering --type abstractnum --prop format=decimal
+officecli add "$FILE" /numbering --type num --prop abstractNumId=1
+officecli add "$FILE" /body --type paragraph --prop text="Section one" --prop numId=1 --prop ilvl=0
 ```
 
-After adding, verify with `officecli query doc.docx 'paragraph[numId>0]'` that every `numId` reference points at a real `<w:num>`. See `officecli help docx abstractnum` and `officecli help docx num` for all level and format options.
+After adding, verify with `officecli query "$FILE" 'paragraph[numId>0]'` that every `numId` reference points at a real `<w:num>`. See `officecli help docx abstractnum` and `officecli help docx num` for all level and format options.
 
 ### Tab stops (dot leaders, right-aligned page numbers)
 
 Used for positional layout — a signature line, a TOC-entry-style "Chapter 1 ........ 12" row, a form field slot. Tab stops are a first-class `tab` element added as a child of the paragraph:
 
 ```bash
-officecli add doc.docx "/body/p[1]" --type tab --prop pos=6in --prop val=right --prop leader=dot
-officecli add doc.docx "/body/p[2]" --type tab --prop pos=3cm --prop val=left --prop leader=underscore
+officecli add "$FILE" "/body/p[1]" --type tab --prop pos=6in --prop val=right --prop leader=dot
+officecli add "$FILE" "/body/p[2]" --type tab --prop pos=3cm --prop val=left --prop leader=underscore
 ```
 
 `pos` accepts `6in` / `6cm` / twips. `val` ∈ `left` / `center` / `right`. `leader` ∈ `none` / `dot` / `hyphen` / `underscore`. Paths are 1-based: `/body/p[N]/tab[K]`. See `officecli help docx tab` for the full grammar.
@@ -264,15 +264,13 @@ The full `fieldType` enum (30+ values: `page`, `pagenum`, `pagenumber`, `numpage
 For a standalone MERGEFIELD inside a paragraph:
 
 ```bash
-officecli add doc.docx "/body/p[3]" --type field --prop fieldType=mergefield --prop name=customer_name
+officecli add "$FILE" "/body/p[3]" --type field --prop fieldType=mergefield --prop name=customer_name
 # Renders as «customer_name» — visible placeholder, replaced in Word at mail-merge time.
 ```
 
-Verified: canonical form passes `validate` and renders `«customer_name»` on open. Confirm all MERGEFIELDs exist with `officecli query doc.docx 'field[fieldType=mergefield]'`.
+Verified: canonical form passes `validate` and renders `«customer_name»` on open. Confirm all MERGEFIELDs exist with `officecli query "$FILE" 'field[fieldType=mergefield]'`.
 
 **MERGEFIELD templates: do NOT render placeholder literals.** If a template shows `{{customer_name}}` or `$NAME$` as body text, a human recipient sees the literal token — that is a failed template. Either (a) insert a real MERGEFIELD via the `field` type above, which Word replaces at mail-merge time, or (b) put literal tokens only inside an obvious instruction paragraph ("Replace `{{customer_name}}` before sending"). See Requirements for Outputs → Visual delivery floor.
-
-**Forms / fillable documents.** For interactive or fillable forms (SDT content controls, legacy FormField checkbox/text/dropdown, `protection=forms`, role-gated locks, MERGEFIELD-driven contracts and SOWs), use the dedicated `officecli-word-form` skill — it covers Path A/B/C, raw-set bridges for SDT items, and per-field lock inventory.
 
 ### Headers & Footers (page numbering)
 
@@ -280,10 +278,10 @@ The single-command pattern — the CLI injects `<w:fldChar>` so you do not compo
 
 ```bash
 # Empty first-page footer — auto-enables differentFirstPage so the cover has no page number
-officecli add doc.docx / --type footer --prop type=first --prop text=""
+officecli add "$FILE" / --type footer --prop type=first --prop text=""
 
 # Default footer with live page number
-officecli add doc.docx / --type footer --prop type=default --prop align=center --prop size=9pt --prop text="Page " --prop field=page
+officecli add "$FILE" / --type footer --prop type=default --prop alignment=center --prop size=9pt --prop text="Page " --prop field=page
 ```
 
 When both a first-page footer and a default footer exist, the default footer is `/footer[2]`. If only a default footer, it is `/footer[1]`. **Verify**: `get --depth 3` must show `fldChar` children, not just a run with literal text `"Page"`. `view outline` prints "Footer: Page" for both live fields AND static text — do not rely on it.
@@ -297,7 +295,7 @@ For composite footers like "Page X of Y" (PAGE + NUMPAGES in one paragraph), see
 For any document with 3+ headings (Requirements):
 
 ```bash
-officecli add doc.docx /body --type toc --prop levels="1-3" --prop title="Table of Contents" --prop hyperlinks=true --index 0
+officecli add "$FILE" /body --type toc --prop levels="1-3" --prop title="Table of Contents" --prop hyperlinks=true --index 0
 ```
 
 The TOC is a live field — when a human opens the file, the viewer either populates it on open or shows it after the user recalculates (F9 in Word). Do NOT pass `--prop pagenumbers=true` — UNSUPPORTED; page numbers render automatically.
@@ -305,8 +303,8 @@ The TOC is a live field — when a human opens the file, the viewer either popul
 **Addressing the TOC (1.0.60+).** Direct paths `/toc[1]` or `/tableofcontents` resolve to the first TOC field without hand-walking XPath — use these as the primary path for `get` / `set` / `remove`:
 
 ```bash
-officecli get doc.docx "/toc[1]" --depth 2            # primary path — no raw-set needed to locate
-officecli get doc.docx "/tableofcontents" --depth 2   # alias, same target
+officecli get "$FILE" "/toc[1]" --depth 2            # primary path — no raw-set needed to locate
+officecli get "$FILE" "/tableofcontents" --depth 2   # alias, same target
 ```
 
 **TOC delivery step — treat this as mandatory before handing the file off.** **The live TOC field is a placeholder until recalculated.** Some viewers show the real heading list on first open; others show the literal string `Update field to see table of contents` until the reader recalculates. Two workarounds — pick one based on who reads the file:
@@ -321,18 +319,18 @@ Ship-check: `officecli query "$FILE" 'p:contains("Update field to see")'` must r
 Pictures go inside a run. Alt text is mandatory for accessibility, but **add rejects `alt` at create time** (CLI bug C-D-3): add first, then `set`.
 
 ```bash
-officecli add doc.docx "/body/p[5]" --type picture --prop src=chart.png --prop width=4in
-officecli set doc.docx "/body/p[5]/r[last()]" --prop alt="Q4 revenue by region, bar chart"
+officecli add "$FILE" "/body/p[5]" --type picture --prop src=chart.png --prop width=4in
+officecli set "$FILE" "/body/p[5]/r[last()]" --prop alt="Q4 revenue by region, bar chart"
 ```
 
-Confirm with `officecli query doc.docx 'image:no-alt'` — output should be empty before delivery.
+Confirm with `officecli query "$FILE" 'image:no-alt'` — output should be empty before delivery.
 
 ### Hyperlinks and bookmarks
 
 External links go via `hyperlink`:
 
 ```bash
-officecli add doc.docx "/body/p[2]" --type hyperlink --prop uri="https://example.com" --prop text="our site"
+officecli add "$FILE" "/body/p[2]" --type hyperlink --prop uri="https://example.com" --prop text="our site"
 ```
 
 **Internal links (to a bookmark within the document) are NOT supported by the high-level `hyperlink` command** — it rejects fragment URLs. Use `raw-set` with `<w:hyperlink w:anchor="bookmarkName">`, or pair a `PAGEREF` field with visible text. See `officecli help docx hyperlink` and `officecli help docx bookmark`.
@@ -342,7 +340,7 @@ officecli add doc.docx "/body/p[2]" --type hyperlink --prop uri="https://example
 Document root `/` carries page setup (`pageWidth`, `pageHeight`, margins). Multi-section documents (landscape insert, column layout) add a `section` break; use `officecli help docx section` for the section prop list.
 
 ```bash
-officecli set doc.docx / --prop pageWidth=12240 --prop pageHeight=15840 --prop marginTop=1440 --prop marginLeft=1440
+officecli set "$FILE" / --prop pageWidth=12240 --prop pageHeight=15840 --prop marginTop=1440 --prop marginLeft=1440
 ```
 
 Section accepts both camelCase (`pageWidth`, canonical) and lowercase alias (`pagewidth`). Prefer camelCase.
@@ -354,13 +352,13 @@ Four patterns that come up on every long-form report and aren't covered by the Q
 **(a) Rich cover page — hit the ≥ 60% filled floor.** A bare title + date cover reads as unfinished. Stack a confidentiality banner, title, subtitle, client/project/date block, and a 3-line key-themes strip:
 
 ```bash
-officecli add "$FILE" /body --type paragraph --prop text="CONFIDENTIAL — CLIENT USE ONLY" --prop align=center --prop size=9pt --prop color=C00000 --prop spaceAfter=24pt
-officecli add "$FILE" /body --type paragraph --prop text="Strategic Growth Review" --prop style=Title --prop size=32pt --prop bold=true --prop align=center --prop font=Cambria --prop spaceAfter=8pt
-officecli add "$FILE" /body --type paragraph --prop text="FY26 Outlook and Scenario Planning" --prop italic=true --prop size=16pt --prop align=center --prop spaceAfter=36pt
-officecli add "$FILE" /body --type paragraph --prop text='Prepared for: Acme Corp. Leadership Team' --prop align=center --prop size=11pt
-officecli add "$FILE" /body --type paragraph --prop text='Engagement: 2026-04 — 2026-06' --prop align=center --prop size=11pt
-officecli add "$FILE" /body --type paragraph --prop text='Author: Advisory Partners' --prop align=center --prop size=11pt --prop spaceAfter=36pt
-officecli add "$FILE" /body --type paragraph --prop text="Key themes: 1) margin resilience, 2) EMEA expansion, 3) capital allocation." --prop align=center --prop italic=true --prop size=10pt
+officecli add "$FILE" /body --type paragraph --prop text="CONFIDENTIAL — CLIENT USE ONLY" --prop alignment=center --prop size=9pt --prop color=C00000 --prop spaceAfter=24pt
+officecli add "$FILE" /body --type paragraph --prop text="Strategic Growth Review" --prop style=Title --prop size=32pt --prop bold=true --prop alignment=center --prop font=Cambria --prop spaceAfter=8pt
+officecli add "$FILE" /body --type paragraph --prop text="FY26 Outlook and Scenario Planning" --prop italic=true --prop size=16pt --prop alignment=center --prop spaceAfter=36pt
+officecli add "$FILE" /body --type paragraph --prop text='Prepared for: Acme Corp. Leadership Team' --prop alignment=center --prop size=11pt
+officecli add "$FILE" /body --type paragraph --prop text='Engagement: 2026-04 — 2026-06' --prop alignment=center --prop size=11pt
+officecli add "$FILE" /body --type paragraph --prop text='Author: Advisory Partners' --prop alignment=center --prop size=11pt --prop spaceAfter=36pt
+officecli add "$FILE" /body --type paragraph --prop text="Key themes: 1) margin resilience, 2) EMEA expansion, 3) capital allocation." --prop alignment=center --prop italic=true --prop size=10pt
 # Force the next section to start on a new page — belt-and-suspenders for cross-viewer reliability
 # (pageBreakBefore alone is unreliable across viewers; --type pagebreak alone also flakes)
 officecli add "$FILE" /body --type pagebreak
@@ -370,7 +368,7 @@ officecli set "$FILE" "/body/p[last()]" --prop pageBreakBefore=true
 **(b) Page X of Y footer — composite PAGE + NUMPAGES.** Add the footer paragraph first, then three child ops build `Page <X> of <Y>` in one paragraph. Visual outcome: footer reads `Page 3 of 12` with both numbers live. This is the official `officecli help docx footer` recipe.
 
 ```bash
-officecli add "$FILE" / --type footer --prop type=default --prop text="Page " --prop align=center --prop size=9pt
+officecli add "$FILE" / --type footer --prop type=default --prop text="Page " --prop alignment=center --prop size=9pt
 officecli add "$FILE" "/footer[1]/p[1]" --type field --prop fieldType=page
 officecli add "$FILE" "/footer[1]/p[1]" --type run --prop text=" of "
 officecli add "$FILE" "/footer[1]/p[1]" --type field --prop fieldType=numpages
@@ -402,7 +400,7 @@ Verified: without step 1, step 2's run-level `set` errors because empty cells ha
 ```bash
 # Right-align number columns (cols 2-4), paragraph-level
 for row in 2 3 4 5; do for col in 2 3 4; do
-  officecli set "$FILE" "/body/tbl[1]/tr[$row]/tc[$col]/p[1]" --prop align=right
+  officecli set "$FILE" "/body/tbl[1]/tr[$row]/tc[$col]/p[1]" --prop alignment=right
 done; done
 # Total row (row 5) bold + bottom border on the data paragraphs
 for col in 1 2 3 4; do
@@ -463,10 +461,10 @@ Apply to every H1, the TOC heading, and the cover-closing paragraph. Preview via
 
 HR / legal / vendor templates commonly carry internal-only guidance ("replace `{{CompanyName}}`", "list of expected merge columns") that must NOT ship to the end recipient. Two working patterns:
 
-- **Trailing "Template Notes" section with a clear heading.** Add a `Heading 1` titled "Template Notes for HR Users" (or similar) at the bottom of the document, then all instruction paragraphs underneath. Before distribution, `officecli remove doc.docx /body/p[N]` every paragraph from the heading downward, or `officecli query doc.docx 'paragraph[style=Heading1]:contains("Template Notes")'` to locate the boundary. A visible heading makes the section unmistakable at review time and scriptable at delivery time.
+- **Trailing "Template Notes" section with a clear heading.** Add a `Heading 1` titled "Template Notes for HR Users" (or similar) at the bottom of the document, then all instruction paragraphs underneath. Before distribution, `officecli remove "$FILE" /body/p[N]` every paragraph from the heading downward, or `officecli query "$FILE" 'paragraph[style=Heading1]:contains("Template Notes")'` to locate the boundary. A visible heading makes the section unmistakable at review time and scriptable at delivery time.
 - **Bookmark-bounded internal section.** Wrap the guidance between two bookmarks (`add --type bookmark --prop name=__template_notes_start` / `_end`) on the paragraphs before and after the internal content. At delivery, `raw-set` removes everything between the two anchors in one pass. Slightly more fragile but more robust to accidental heading edits.
 
-Either way, the ship-check is: after removal, `officecli query doc.docx 'p:contains("Template Notes")'` returns empty AND `query 'p:contains("{{")` (literal tokens the guide referenced) also returns empty. If the template notes paragraph survives, a downstream employee will read internal HR language. Treat this as a delivery gate for template builds.
+Either way, the ship-check is: after removal, `officecli query "$FILE" 'p:contains("Template Notes")'` returns empty AND `query 'p:contains("{{")` (literal tokens the guide referenced) also returns empty. If the template notes paragraph survives, a downstream employee will read internal HR language. Treat this as a delivery gate for template builds.
 
 ### Advanced / specialty topics (skip if you are writing a report)
 
@@ -475,8 +473,8 @@ Reports, memos, letters, proposals, and HR templates don't need this section —
 **Equations and footnotes.** `--type equation` takes LaTeX — `\frac`, `\sum`, Greek letters, `\mathit` render; `\mathcal` emits invalid XML (use `\mathit` instead). Footnotes auto-number by paragraph index.
 
 ```bash
-officecli add doc.docx /body --type equation --prop formula="\\frac{a}{b} + \\sum_{i=1}^{n} x_i"
-officecli add doc.docx "/body/p[3]" --type footnote --prop text="See Appendix A for methodology."
+officecli add "$FILE" /body --type equation --prop formula="\\frac{a}{b} + \\sum_{i=1}^{n} x_i"
+officecli add "$FILE" "/body/p[3]" --type footnote --prop text="See Appendix A for methodology."
 ```
 
 `--type equation` always creates a standalone `/body/oMathPara[N]` block — never an inline run, even if you pass a paragraph path. For inline math inside running text, `raw-set` an `<m:oMath>` (not `<m:oMathPara>`) as a run child. Bibliography with hanging indent: `firstLineIndent=-720 indent=720` per entry (dotted `ind.hanging` is not canonical — see Known Issues).
@@ -507,20 +505,20 @@ Your first document is almost never correct. Treat QA as a bug hunt, not a confi
 
 ### Minimum cycle before "done"
 
-1. `officecli view doc.docx issues` — empty paras, missing alt text, formatting anomalies.
-2. `officecli view doc.docx outline` — heading hierarchy, TOC presence, section count. No skipped levels (H1 → H3).
-3. `officecli view doc.docx text --max-lines 400` — content pass: typos, stray `\$` / `\t` / `\n` literals, placeholder tokens.
+1. `officecli view "$FILE" issues` — empty paras, missing alt text, formatting anomalies.
+2. `officecli view "$FILE" outline` — heading hierarchy, TOC presence, section count. No skipped levels (H1 → H3).
+3. `officecli view "$FILE" text --max-lines 400` — content pass: typos, stray `\$` / `\t` / `\n` literals, placeholder tokens.
 4. Query for known classes of defect:
    ```bash
-   officecli query doc.docx 'p:contains("lorem")'
-   officecli query doc.docx 'p:contains("xxxx")'
-   officecli query doc.docx 'p:contains("TODO")'
-   officecli query doc.docx 'p:contains("{{")'
-   officecli query doc.docx 'p:empty'
-   officecli query doc.docx 'image:no-alt'
+   officecli query "$FILE" 'p:contains("lorem")'
+   officecli query "$FILE" 'p:contains("xxxx")'
+   officecli query "$FILE" 'p:contains("TODO")'
+   officecli query "$FILE" 'p:contains("{{")'
+   officecli query "$FILE" 'p:empty'
+   officecli query "$FILE" 'image:no-alt'
    ```
-5. `officecli validate doc.docx` — schema check. Close any resident first (see Known Issues).
-6. **Visual pass — walk every page via the HTML preview.** Run `officecli view doc.docx html` and Read the returned HTML path. Walk every page. "validate pass" is not delivery; "the preview looks like a real document" is delivery. For human review, run `officecli watch doc.docx` (user opens the live preview at their own discretion) or have them open the `.docx` directly in Word / WPS.
+5. `officecli validate "$FILE"` — schema check. Close any resident first (see Known Issues).
+6. **Visual pass — walk every page via the HTML preview.** Run `officecli view "$FILE" html` and Read the returned HTML path. Walk every page. "validate pass" is not delivery; "the preview looks like a real document" is delivery. For human review, run `officecli watch "$FILE"` (user opens the live preview at their own discretion) or have them open the `.docx` directly in Word / WPS.
 7. If anything failed, fix, then **rerun the full cycle**. One fix commonly creates another problem.
 
 ### Delivery Gate (run before handing off — any failure = REJECT, do NOT deliver)
@@ -552,7 +550,7 @@ Every gate must print its OK line before you declare the file delivered.
 
 TOC, PAGE, NUMPAGES, MERGEFIELD are all fields with **cached values** that may be stale or empty at write time. Confirm existence by structure, not by text.
 
-- [ ] Footer PAGE field: `get /footer[N] --depth 3` lists the runs that carry the `fldChar begin` / `instrText` / `fldChar separate` / cached value / `fldChar end` chain — expect ≥ 5 runs for a single PAGE, ≥ 11 for composite "Page X of Y". For the underlying `<w:fldChar>` XML, use `officecli raw doc.docx "/footer[1]" | grep -o fldChar | wc -l` (NOT `grep -c` — single-line XML returns 1, false-PASS risk), or run `officecli query doc.docx 'field[fieldType=page]'` for a semantic match. If you see a single run with text `"Page"`, the field is missing — re-add with `--prop field=page`.
+- [ ] Footer PAGE field: `get /footer[N] --depth 3` lists the runs that carry the `fldChar begin` / `instrText` / `fldChar separate` / cached value / `fldChar end` chain — expect ≥ 5 runs for a single PAGE, ≥ 11 for composite "Page X of Y". For the underlying `<w:fldChar>` XML, use `officecli raw "$FILE" "/footer[1]" | grep -o fldChar | wc -l` (NOT `grep -c` — single-line XML returns 1, false-PASS risk), or run `officecli query "$FILE" 'field[fieldType=page]'` for a semantic match. If you see a single run with text `"Page"`, the field is missing — re-add with `--prop field=page`.
 - [ ] TOC: `get /body/toc[1] --depth 2` must show field structure. In some viewers the TOC shows `1 1 1 1` for page numbers or the literal `Update field to see table of contents` until recalculated (see TOC delivery step).
 - [ ] MERGEFIELD: `query 'field[fieldType=mergefield]'` — one entry per template slot. No literal `{{name}}` text elsewhere.
 - [ ] SEQ / PAGEREF (if your document uses them via raw-set): confirm each `<w:fldChar>` chain exists by `raw`-inspecting the `document.xml`.

--- a/skills/officecli-pitch-deck/SKILL.md
+++ b/skills/officecli-pitch-deck/SKILL.md
@@ -128,9 +128,180 @@ Regulatory pipeline IS the business. Replace "product roadmap" with **clinical p
 
 **Cross-vertical rule.** You can mix elements across templates, but never drop a must-have from your primary vertical. A SaaS deck missing unit econ, a bio deck missing a pipeline chart, a marketplace deck missing a liquidity metric — each is an instant VC disqualification.
 
+## Slide Patterns (layout canon)
+
+Patterns are **layout geometry**; recipes below are **narrative intent**. A slide picks one pattern for its visual shape (6 canonical ones below) and one recipe for what it argues (cover / problem / traction / ...). Multiple recipes can share one pattern — Problem / Why-Now / Traction-callout all lean on the 3-stat row (C.2). Pick the pattern first, then fill it with recipe content.
+
+**Speaker notes rule.** Every content slide (non-cover, non-closing) MUST carry speaker notes via `officecli add "$FILE" /slide[N] --type notes --prop text='…'`. Missing notes = not shippable — inherits pptx v2 §Hard rules (H7). Run `officecli help pptx notes` to confirm prop names before building.
+
+**Pattern reuse discipline.** Never run the same pattern on two consecutive slides — even with different data, two identical geometries in a row read as a template loop. Alternate C.2 with C.4 or C.5b to break rhythm.
+
+**Vertical centering.** When a slide carries fewer elements than the pattern's maximum, nudge y-positions down 2–3cm to center the visual weight. Tables below assume full content.
+
+### C.1 Title / Cover (dark gradient)
+
+3–4 text shapes on a gradient fill. Slide 1 in every deck.
+
+```
++----------------------------------+
+|                                  |
+|          TITLE (centered)        |
+|          tagline                 |
+|                                  |
+|   round · amount · date          |
+|  ________________________        |  <- thin brand band
++----------------------------------+
+```
+
+| Element | X | Y | Width | Height | Font / size |
+|---|---|---|---|---|---|
+| Title | 2cm | 5cm | 29.87cm | 4cm | serif bold, ≥ 36pt (44 typical) |
+| Tagline | 2cm | 10cm | 29.87cm | 2cm | sans 18–22pt |
+| Meta (round · $ · date) | 2cm | 13cm | 29.87cm | 1.5cm | sans 12–16pt |
+
+**Use this when** the slide is the first one (Cover recipe 1) — 3-second identity grab. Background is a 180° linear gradient between two dark palette shades (e.g. Professional Navy `1E2761 → 0D1F35`). If the title wraps to 2 lines, **add height (4cm → 5cm), never drop font below 36pt** — sub-36pt on a pitch cover reads as timid regardless of content. Transition: fade.
+
+### C.2 3-Stat callout row
+
+Title + 3 big-number / label pairs across. The default for Problem / Why-Now / Traction-callout slides.
+
+```
++----------------------------------+
+|  Title                           |
+|                                  |
+|   73%      12hr      $4.2B       |
+|   label    label     label       |
+|   source   source    source      |
++----------------------------------+
+```
+
+| Element | X | Y | Width | Height | Font / size |
+|---|---|---|---|---|---|
+| Title | 1.5cm | 1cm | 30.87cm | 3cm | serif bold ≥ 36pt |
+| Stat 1 number | 2cm | 5cm | 9cm | 4cm | serif bold 60–64pt |
+| Stat 1 label | 2cm | 9.5cm | 9cm | 2cm | sans ≥ 16pt (H4 floor) |
+| Stat 2 number / label | 12.5cm | (same) | 9cm | (same) | (same) |
+| Stat 3 number / label | 23cm | (same) | 9cm | (same) | (same) |
+
+**Use this when** you have 2–3 anchoring numbers and the story is "three facts argue the point" — Problem, Why-Now, Market-callout, single-row Traction. Labels ≥ 16pt is the H4 floor (sub-label exception); a number without a label reads as bravado, so never drop labels to 12–14pt to fit more text.
+
+### C.3 4-Stat callout row
+
+Same geometry as C.2 but 4 columns. Numbers 60pt, width 7cm each.
+
+```
++-------------------------------------+
+|  Title                              |
+|                                     |
+|  73%   12hr   $9M   4.2x            |
+|  lbl   lbl    lbl   lbl             |
++-------------------------------------+
+```
+
+| Element | X positions | Y | Width | Height | Font / size |
+|---|---|---|---|---|---|
+| Title | 1.5cm | 1cm | 30.87cm | 3cm | serif bold 36pt |
+| Stat numbers | 1.5 / 9.5 / 17.5 / 25.5cm | 5cm | 7cm | 4cm | serif bold 60pt |
+| Stat labels | (same X) | 9.5cm | 7cm | 2cm | sans ≥ 16pt |
+
+**Use this when** exactly 4 parallel metrics tell the story and 3 feels under-counted. Prefer C.2 if in doubt — 4 always feels tighter than 3, and wrap risk is real.
+
+> **Wrap warning.** At 60pt in 7cm width, dollar patterns with both `$` and `.` fail: `$9.4M` is 5 glyphs but the wide `$` and `.` in a serif bold make it wrap to 2 lines and destroy the callout. Safe dollar shapes at 60pt/7cm: `$9M`, `$96B`, `$4K` (3–4 chars). Non-dollar shapes: `340%`, `4.2x`, `12.3` safe up to 5 chars. Values ≥ 6 chars (`197min`, `3 Days`) will wrap — either (a) drop font to 44–48pt, (b) abbreviate (`197m`, `$9M`), or (c) shift to C.2 (9cm per stat). Single tokens only, no internal spaces.
+
+### C.4 Chart + Context (chart left, stats right)
+
+Chart takes left 55%, 2–3 stacked callouts on the right. The default for Traction / Financials / Market-sizing-with-context.
+
+```
++-------------------------------------+
+|  Title                              |
+|                                     |
+|  +---------------+   +--------+     |
+|  |               |   | Stat 1 |     |
+|  |    chart      |   +--------+     |
+|  |               |   | Stat 2 |     |
+|  +---------------+   +--------+     |
++-------------------------------------+
+```
+
+| Element | X | Y | Width | Height |
+|---|---|---|---|---|
+| Title | 2cm | 1cm | 29.87cm | 3cm |
+| Chart | 2cm | 4cm | 17cm | 13cm |
+| Stats column | 21cm | 4cm+ | 11cm | 2.5cm number + 1.5cm label (~3.7cm per pair) |
+
+Sub-labels ≥ 16pt (H4 floor). For 5 stats stacked, drop number size to 44pt; 6+ stats means pick a different pattern. Post-batch for column/bar charts: `officecli set "$FILE" "/slide[N]/chart[1]" --prop gap=80` to tighten bar spacing.
+
+**Use this when** one primary chart drives the story and 2–3 numeric anchors reinforce it — Traction (ARR curve + current ARR + YoY + NRR), Financials (4-year column chart + assumption callouts), Market (bar chart + SOM / CAGR / methodology).
+
+### C.5 Icon-in-circle grid (3-row vertical)
+
+3 vertical rows, each = circle icon on the left + title + 1-line description.
+
+```
++---------------------------------------+
+|  Title                                |
+|                                       |
+|  (o)  Label one                       |
+|       description one                 |
+|                                       |
+|  (o)  Label two                       |
+|       description two                 |
+|                                       |
+|  (o)  Label three                     |
+|       description three               |
++---------------------------------------+
+```
+
+| Element | X | Y positions | Width | Height | Font / size |
+|---|---|---|---|---|---|
+| Icon circle | 2cm | 4.5 / 8.5 / 12.5cm | 2.5cm | 2.5cm | ellipse, accent fill |
+| Label | 5.5cm | (icon Y + 0) | 25cm | 1.2cm | sans bold 18pt |
+| Description | 5.5cm | (icon Y + 1.3cm) | 25cm | 1.8cm | sans ≥ 16pt (H4 floor), muted |
+
+**Use this when** you have 3 short vertical points that benefit from a visual anchor per row — Solution mechanism, Value pillars, Product loop. Choose C.5b (2×2 grid) when items are parallel and you have exactly 4; choose a horizontal 5-across variant when icons should read side-by-side (e.g. 5-step process).
+
+### C.5b 2×2 Feature grid (4 parallel items)
+
+4 rounded cards, 2 columns × 2 rows. Use when you have exactly 4 parallel items (product pillars, service types, feature quadrants).
+
+```
++-----------------------------+
+|  Title                      |
+|                             |
+|  +---------+  +---------+   |
+|  | (o) T1  |  | (o) T2  |   |
+|  | body    |  | body    |   |
+|  +---------+  +---------+   |
+|  +---------+  +---------+   |
+|  | (o) T3  |  | (o) T4  |   |
+|  | body    |  | body    |   |
+|  +---------+  +---------+   |
++-----------------------------+
+```
+
+| Element | X | Y | Width | Height | Font / size |
+|---|---|---|---|---|---|
+| Slide title | 2cm | 1cm | 29.87cm | 2.5cm | serif bold 32pt |
+| Card 1 bg (top-left) | 1.5cm | 4cm | 14.5cm | 7cm | roundRect |
+| Card 2 bg (top-right) | 17.5cm | 4cm | 14.5cm | 7cm | roundRect |
+| Card 3 bg (bottom-left) | 1.5cm | 12cm | 14.5cm | 7cm | roundRect |
+| Card 4 bg (bottom-right) | 17.5cm | 12cm | 14.5cm | 7cm | roundRect |
+| Icon ellipse (each card) | card_x + 0.5cm | card_y + 0.5cm | 2cm | 2cm | — |
+| Card title (each) | card_x + 3.2cm | card_y + 0.6cm | 10.5cm | 1.8cm | sans bold 16pt |
+| Card body (each) | card_x + 0.5cm | card_y + 3cm | 13cm | 3.5cm | sans ≥ 16pt (H4 floor) |
+
+**Use this when** you have exactly 4 parallel items and the eye should land on each equally — 4 product pillars, 4 service tiers, 4 stakeholder types. 3 items feel lonely in a 2×2; 5+ items break the grid — go to a 3×2 (see pptx v2 §(d) grid math) or C.5 row pattern.
+
+> **Z-order canon (critical).** Each card's `roundRect` background must be added immediately before that card's icon / title / body shapes in the batch JSON — pptx paints in insertion order, so a background added after its text paints over and hides the text. When building with `officecli batch`, follow the per-card sequence `bg → ellipse → title → body` strictly. Pattern and z-order details → see pptx v2 §Recipe (c) z-order canon; reuse grid math from pptx v2 §(d) for non-2×2 counts.
+
+**Dark-background variant.** Change card fill from `F0F4F8` (light) to a lighter-dark shade like `1A2540` and bump body text to `FFFFFF` / `E8E8E8`. Palette variables (e.g. `$MUTED`) do NOT expand inside single-quoted heredocs — write the literal hex (`64748B`) in the JSON.
+
+---
+
 ## Key-slide recipes (10 essentials)
 
-The 10 slides every pitch deck carries. Each recipe below gives: **visual outcome** (what the slide looks like from 3m away) + **runnable block** (≤ 18 lines) + **QA one-liner**. All recipes inherit pptx v2 palettes, grid math, type hierarchy, and `--prop tailEnd=triangle` on every connector. `$FILE` is your deck file.
+The 10 slides every pitch deck carries. Each recipe below gives: **visual outcome** (what the slide looks like from 3m away) + **runnable block** (≤ 18 lines) + **QA one-liner**. All recipes inherit pptx v2 palettes, grid math, type hierarchy, and `--prop tailEnd=triangle` on every connector. Recipes reference the Slide Patterns above: Cover reuses C.1; Problem / Why-Now reuse C.2; Traction / Financials reuse C.4; Feature / pillar slides reuse C.5b. `$FILE` is your deck file.
 
 **Long-title wrap rule.** A 36pt+ title that wraps to 2 lines: add `height` (e.g. 2cm → 3.5cm) — never drop the font below 36pt. Titles < 36pt on a pitch deck read as timid regardless of content.
 

--- a/skills/officecli-pptx/SKILL.md
+++ b/skills/officecli-pptx/SKILL.md
@@ -101,6 +101,15 @@ Before declaring done, the per-slide render (see QA) MUST satisfy:
 
 If any fails, STOP and fix before declaring done.
 
+### Hard rules — typography / contrast / notes / KPI fit
+
+These four fire on live-room failure modes that the Requirements table alone has not stopped in practice. Each is principle + exception + why.
+
+- **Body floors at 18pt** (absolute floor 16pt for tiny sublabels; 18pt is the working floor for all paragraph and card body text per the Requirements table). Exceptions are non-primary-read elements only: chart axis labels, legends, footer / page number, and KPI sublabels of ≤ 5 words (e.g. "Active users", "MoM growth"). Full descriptive sentences never qualify — shrink the sentence or split the slide, do not shrink the font. "The cards won't fit" is never a reason to drop below floor; it is a reason to drop cards.
+- **Dark backgrounds force near-white body.** When fill brightness < 30% (`1E2761`, `36454F`, `000000`, deep forest / berry / cherry), every run of body text, card body, chart series fill, and icon color must be `FFFFFF` or brightness > 80%. Mid-gray (`6B7B8D` ≈ 44%) reads fine on a laptop screen and disappears under projector glare. Check with `view html` after the dark-fill pass.
+- **Content slides carry speaker notes.** Every slide that is neither cover nor closing must have `--type notes --prop text="..."`. The speaker needs a script; the audience should not read the slide verbatim. Missing notes on a content slide is not shippable.
+- **KPI text fits the card — pre-compute, don't eyeball.** In a 7cm-wide card at 60pt Georgia bold, values with `$` and `.` (wide glyphs) wrap at 4 characters. `$9.4M` breaks the card; use `$9M` + "USD millions" sublabel, or move to the 3-card 9.78cm layout. Upper bound: `max_size_pt ≈ card_width_cm × denom`, where denom = 10 for 1–2 chars, 7 for 3–4 chars, 5 for 5+ chars.
+
 ### Hard rules worth repeating
 
 - **`layout=blank` is the default for custom designs.** Titles become plain `shape` elements, not placeholders. `view outline` / `view issues` reporting `(untitled)` / `Slide has no title` is **expected**, not a defect. Use `layout=title` + `placeholder[title]` only when screen-reader outline compatibility matters.
@@ -128,18 +137,43 @@ Standard widescreen is **33.87 × 19.05cm**. Treat it as a 12-column grid intern
 
 → See Requirements table above. Non-negotiable floors.
 
+### Font pairings
+
+Two fonts max — one for headings, one for body. Pair by document register, not by novelty. "Best For" is a prompt, not a decree; if the topic matches a row, use it as the default and move on.
+
+| Header | Body | Best For |
+|---|---|---|
+| Georgia | Calibri | Formal business, finance, executive reports |
+| Arial Black | Arial | Bold marketing, product launches |
+| Calibri | Calibri Light | Clean corporate, minimal design |
+| Cambria | Calibri | Traditional professional, legal, academic |
+| Trebuchet MS | Calibri | Friendly tech, startups, SaaS |
+| Impact | Arial | Bold headlines, event decks, keynotes |
+| Palatino | Garamond | Elegant editorial, luxury, nonprofit |
+| Consolas | Calibri | Developer tools, technical / engineering |
+
+Set both fonts explicitly on every shape (`--prop font=Georgia` on title shapes, `--prop font=Calibri` on body shapes) — theme-default inheritance drifts between masters. `officecli help pptx shape` shows the `font` prop.
+
 ### Color and contrast
 
-One dominant color does 60–70% of visual weight, two supporting tones, one accent used sparingly. Never use 4+ colors in body content.
+One dominant color does 60–70% of visual weight, two supporting tones, one accent used sparingly. Never use 4+ colors in body content. Columns are: **Primary** (dominant — the one color you see first), **Secondary** (the supporting tone), **Accent** (sparing, one-hit emphasis), **Text** (body on light fills), **Muted** (captions / axis labels / footer).
 
-| Theme | Dominant | Supporting | Accent | Dark body |
-|---|---|---|---|---|
-| Executive navy | `1E2761` | `CADCFC` | `FFFFFF` | `333333` |
-| Forest & moss | `2C5F2D` | `97BC62` | `F5F5F5` | `2D2D2D` |
-| Warm terracotta | `B85042` | `E7E8D1` | `A7BEAE` | `3D2B2B` |
-| Charcoal minimal | `36454F` | `F2F2F2` | `212121` | `333333` |
+| Theme | Primary | Secondary | Accent | Text | Muted |
+|---|---|---|---|---|---|
+| Coral Energy | `F96167` | `F9E795` | `2F3C7E` | `333333` | `8B7E6A` |
+| Midnight Executive | `1E2761` | `CADCFC` | `FFFFFF` | `333333` | `8899BB` |
+| Forest & Moss | `2C5F2D` | `97BC62` | `F5F5F5` | `2D2D2D` | `6B8E6B` |
+| Charcoal Minimal | `36454F` | `F2F2F2` | `212121` | `333333` | `7A8A94` |
+| Warm Terracotta | `B85042` | `E7E8D1` | `A7BEAE` | `3D2B2B` | `8C7B75` |
+| Berry & Cream | `6D2E46` | `A26769` | `ECE2D0` | `3D2233` | `8C6B7A` |
+| Ocean Gradient | `065A82` | `1C7293` | `21295C` | `2B3A4E` | `6B8FAA` |
+| Teal Trust | `028090` | `00A896` | `02C39A` | `2D3B3B` | `5E8C8C` |
+| Sage Calm | `84B59F` | `69A297` | `50808E` | `2D3D35` | `7A9488` |
+| Cherry Bold | `990011` | `FCF6F5` | `2F3C7E` | `333333` | `8B6B6B` |
 
-On dark backgrounds (fill brightness < 30%), text and chart series MUST be white or > 80%-bright. Mid-gray is invisible on projection.
+Pick by topic, not by default — finance reads Midnight Executive, a product launch reads Coral Energy, safety / LOTO reads Cherry Bold. If the closest named theme is not quite right, blend (e.g. Forest primary + gold `D4A843` accent). Use **Text** on light fills, **Muted** for captions / axis / footer, `FFFFFF` or Secondary for body on dark fills.
+
+On dark backgrounds (fill brightness < 30%), text and chart series MUST be white or > 80%-bright. Mid-gray is invisible on projection — see Hard rules above.
 
 ### Chart-choice decision table
 
@@ -169,8 +203,8 @@ Each animation is a cognitive interrupt. Limits:
 ## Common Workflow
 
 1. **Open/close mode.** Always `officecli open <file>` at start + `officecli close <file>` at end. Resident is the default, not an optimization. Use `batch` in ≤ 12-op chunks for repetitive shape grids.
-2. **Orient.** New deck: `officecli create deck.pptx`. Existing: `officecli view deck.pptx outline` first. Never edit blind.
-3. **Build in display order — HARD RULE.** `--index` on slide add is frequently ignored. Add slides in audience-view order: cover → agenda → section-1 divider → section-1 content → section-2 divider → … → closing. Out-of-order insertion requires `officecli move deck.pptx /slide[N] --index M` + re-verify with `get --depth 0`. **Before final delivery, confirm slide count + narrative arc match your build plan.** Gate 4 catches cases where the cover ends up as slide 11 of 14 instead of slide 1.
+2. **Orient.** New deck: `officecli create "$FILE"`. Existing: `officecli view "$FILE" outline` first. Never edit blind.
+3. **Build in display order — HARD RULE.** `--index` on slide add is frequently ignored. Add slides in audience-view order: cover → agenda → section-1 divider → section-1 content → section-2 divider → … → closing. Out-of-order insertion requires `officecli move "$FILE" /slide[N] --index M` + re-verify with `get --depth 0`. **Before final delivery, confirm slide count + narrative arc match your build plan.** Gate 4 catches cases where the cover ends up as slide 11 of 14 instead of slide 1.
 4. **Incremental per slide.** Create slide + background, then title, then supporting shapes / charts / connectors. Always `layout=blank` for custom designs. After each structural op, `get /slide[N] --depth 1` to confirm shape IDs.
 5. **Format to spec.** Explicit title ≥ 36pt, body ≥ 18pt, colors from one palette, connectors via `@id=`. Formatting is deliverable, not polish.
 6. **Close + verify in target viewer.** `officecli close` writes the ZIP. `view html` — Read the returned HTML path — is OK for structural QA; **always open in the target presentation viewer before shipping** — chart colors, animations, font substitution, zoom are runtime features that only the live viewer renders faithfully.
@@ -215,21 +249,21 @@ Verified: `validate` clean; titles ≥ 36pt, body 20pt, slide 2 has notes. Shape
 Start wide, then narrow. `outline` first, `view text` / `get` / `query` once you know where to look.
 
 ```bash
-officecli view deck.pptx outline          # slide count, titles, shape counts (undercounts tables/charts)
-officecli view deck.pptx annotated        # complete per-slide breakdown with fonts, sizes, tables, charts
-officecli view deck.pptx text --start 1 --end 5   # text dump (does NOT extract table cells — use get)
-officecli view deck.pptx issues           # empty slides, overflow hints
-officecli view deck.pptx stats            # counts + missing alt (remember false-positive zero — C-P picture alt note)
+officecli view "$FILE" outline          # slide count, titles, shape counts (undercounts tables/charts)
+officecli view "$FILE" annotated        # complete per-slide breakdown with fonts, sizes, tables, charts
+officecli view "$FILE" text --start 1 --end 5   # text dump (does NOT extract table cells — use get)
+officecli view "$FILE" issues           # empty slides, overflow hints
+officecli view "$FILE" stats            # counts + missing alt (remember false-positive zero — C-P picture alt note)
 ```
 
 **Inspect one element.** XPath-style paths, 1-based. ALWAYS quote.
 
 ```bash
-officecli get deck.pptx "/slide[1]" --depth 1              # shape list with IDs and names
-officecli get deck.pptx "/slide[1]/shape[@name=Title]"     # @name selector (LEAD — stable across reorderings)
-officecli get deck.pptx "/slide[1]/shape[@id=10007]"       # @id selector (also stable)
-officecli get deck.pptx "/slide[1]/chart[1]"               # chart data + config
-officecli get deck.pptx "/slide[1]/table[1]" --depth 3     # table rows / cells
+officecli get "$FILE" "/slide[1]" --depth 1              # shape list with IDs and names
+officecli get "$FILE" "/slide[1]/shape[@name=Title]"     # @name selector (LEAD — stable across reorderings)
+officecli get "$FILE" "/slide[1]/shape[@id=10007]"       # @id selector (also stable)
+officecli get "$FILE" "/slide[1]/chart[1]"               # chart data + config
+officecli get "$FILE" "/slide[1]/table[1]" --depth 3     # table rows / cells
 ```
 
 Add `--json` for machine output. Use `[last()]` for "the last": `/slide[last()]/shape[1]`.
@@ -237,11 +271,11 @@ Add `--json` for machine output. Use `[last()]` for "the last": `/slide[last()]/
 **Query across the deck.** CSS-like selectors; operators `=`, `!=`, `~=`, `>=`, `<=`, `[attr]`:
 
 ```bash
-officecli query deck.pptx 'shape:contains("Revenue")'
-officecli query deck.pptx 'picture:no-alt'                 # accessibility gap
-officecli query deck.pptx 'shape[fill=1E2761]'             # color match
-officecli query deck.pptx 'shape[width>=10cm]'             # numeric
-officecli query deck.pptx 'animation'                      # every animation in the deck
+officecli query "$FILE" 'shape:contains("Revenue")'
+officecli query "$FILE" 'picture:no-alt'                 # accessibility gap
+officecli query "$FILE" 'shape[fill=1E2761]'             # color match
+officecli query "$FILE" 'shape[width>=10cm]'             # numeric
+officecli query "$FILE" 'animation'                      # every animation in the deck
 ```
 
 **`query --json` output schema.** Results wrap in `.data.results[]`. To extract the first result's ID: `jq -r '.data.results[0].format.id'` — NOT `.[0].id`. Shape name is `.name`; fill is `.format.fill`; textColor is `.format.textColor`. Verify with `query ... --json | jq .data.results[0]` on an unknown shape.
@@ -249,9 +283,9 @@ officecli query deck.pptx 'animation'                      # every animation in 
 **Visual preview (LEAD).**
 
 ```bash
-officecli view deck.pptx html                # prints an HTML preview path; Read it for per-slide visual audit (best structural ground truth)
-officecli view deck.pptx svg --start 3 --end 3   # single slide SVG (charts + gradients do NOT render in SVG)
-officecli watch deck.pptx                     # live preview for the human user — they open it at their discretion
+officecli view "$FILE" html                # prints an HTML preview path; Read it for per-slide visual audit (best structural ground truth)
+officecli view "$FILE" svg --start 3 --end 3   # single slide SVG (charts + gradients do NOT render in SVG)
+officecli watch "$FILE"                     # live preview for the human user — they open it at their discretion
 ```
 
 `view html` is the best structural check. Not final ground truth for runtime-only features (animations, zoom) — see Renderer Honesty.
@@ -265,9 +299,9 @@ Verbs: `add` / `set` / `remove` / `move` / `swap` / `batch` / `raw-set`. Ninety 
 A slide is `/slide[N]`. Always pass `layout=blank` for custom designs. Background: solid, gradient, or image.
 
 ```bash
-officecli add deck.pptx / --type slide --prop layout=blank --prop background=1E2761                 # solid
-officecli add deck.pptx / --type slide --prop layout=blank --prop "background=1E2761-CADCFC-180"   # gradient (start-end-angle)
-officecli add deck.pptx / --type slide --prop layout=blank --prop "background.image=hero.jpg"      # image background (LEAD)
+officecli add "$FILE" / --type slide --prop layout=blank --prop background=1E2761                 # solid
+officecli add "$FILE" / --type slide --prop layout=blank --prop "background=1E2761-CADCFC-180"   # gradient (start-end-angle)
+officecli add "$FILE" / --type slide --prop layout=blank --prop "background.image=hero.jpg"      # image background (LEAD)
 ```
 
 → Full background prop list (image, tiling, alpha, scale): `officecli help pptx background`.
@@ -277,7 +311,7 @@ officecli add deck.pptx / --type slide --prop layout=blank --prop "background.im
 A `shape` holds text, fill, border, position, and optional animation / link.
 
 ```bash
-officecli add deck.pptx /slide[2] --type shape --prop name=Title --prop text="Key Insight" \
+officecli add "$FILE" /slide[2] --type shape --prop name=Title --prop text="Key Insight" \
   --prop x=2cm --prop y=2cm --prop width=20cm --prop height=3cm \
   --prop font=Georgia --prop size=36 --prop bold=true --prop color=1E2761 --prop fill=none
 ```
@@ -294,11 +328,11 @@ A shape has paragraphs (`paragraph[K]`) and runs. For one-line text, `--prop tex
 
 ```bash
 # add --type paragraph accepts only text + align; styling goes through a follow-up set or an add --type run:
-officecli add deck.pptx "/slide[2]/shape[@name=Card1]" --type paragraph --prop text="First bullet"
-officecli set deck.pptx "/slide[2]/shape[@name=Card1]/paragraph[1]" --prop bold=true --prop size=20 --prop color=FFFFFF
+officecli add "$FILE" "/slide[2]/shape[@name=Card1]" --type paragraph --prop text="First bullet"
+officecli set "$FILE" "/slide[2]/shape[@name=Card1]/paragraph[1]" --prop bold=true --prop size=20 --prop color=FFFFFF
 
 # Styled run in one step:
-officecli add deck.pptx "/slide[2]/shape[@name=Card1]/paragraph[1]" --type run \
+officecli add "$FILE" "/slide[2]/shape[@name=Card1]/paragraph[1]" --type run \
   --prop text=" (inline detail)" --prop size=14 --prop italic=true --prop color=8899BB
 ```
 
@@ -310,12 +344,12 @@ Chart types via `officecli help pptx chart` — column, bar, line, pie, doughnut
 
 ```bash
 # (a) compact inline — quick demo charts
-officecli add deck.pptx /slide[3] --type chart --prop chartType=column \
+officecli add "$FILE" /slide[3] --type chart --prop chartType=column \
   --prop "data=Revenue:42,45,48;Growth:2,7,7" --prop "categories=Q1,Q2,Q3" \
   --prop x=2cm --prop y=4cm --prop width=20cm --prop height=10cm --prop title="FY26"
 
 # (b) dotted per-series — multi-series with explicit brand colors (typical case)
-officecli add deck.pptx /slide[3] --type chart --prop chartType=column \
+officecli add "$FILE" /slide[3] --type chart --prop chartType=column \
   --prop series1.name=Revenue --prop series1.values="42,45,48" --prop series1.color=1E2761 \
   --prop series2.name=Growth  --prop series2.values="2,7,7"    --prop series2.color=CADCFC \
   --prop categories="Q1,Q2,Q3" \
@@ -328,12 +362,12 @@ Gotchas: (1) series cannot be added after creation — include all series at `ad
 
 ```bash
 # add --prop alt= is rejected (UNSUPPORTED, C-P-7). Two-step workflow:
-officecli add deck.pptx /slide[4] --type picture --prop src=hero.jpg \
+officecli add "$FILE" /slide[4] --type picture --prop src=hero.jpg \
   --prop x=1cm --prop y=1cm --prop width=32cm --prop height=18cm
-officecli set deck.pptx "/slide[4]/picture[1]" --prop alt="Product hero, gradient lit from right"
+officecli set "$FILE" "/slide[4]/picture[1]" --prop alt="Product hero, gradient lit from right"
 ```
 
-Confirm with `officecli query deck.pptx 'picture:no-alt'` — must be empty before delivery (but remember `view stats` is a false-positive zero because alt auto-fills to filename).
+Confirm with `officecli query "$FILE" 'picture:no-alt'` — must be empty before delivery (but remember `view stats` is a false-positive zero because alt auto-fills to filename).
 
 ### Connectors (LEAD — flowcharts / decision trees first-class)
 
@@ -366,9 +400,9 @@ officecli add "$FILE" /slide[5] --type connector \
 One preset per slide, ≤ 600ms. Set via shape-level prop (authoritative; deep-path readback is stale — C-P-3):
 
 ```bash
-officecli set deck.pptx "/slide[2]/shape[@name=HeroCard]" --prop animation=fade-entrance-400
-officecli get deck.pptx "/slide[2]/shape[@name=HeroCard]" --json | jq .animation
-officecli set deck.pptx "/slide[2]/shape[@name=HeroCard]" --prop animation=none    # remove (C-P-4)
+officecli set "$FILE" "/slide[2]/shape[@name=HeroCard]" --prop animation=fade-entrance-400
+officecli get "$FILE" "/slide[2]/shape[@name=HeroCard]" --json | jq .animation
+officecli set "$FILE" "/slide[2]/shape[@name=HeroCard]" --prop animation=none    # remove (C-P-4)
 ```
 
 **Get round-trip (1.0.58+).** `get animation[N]` now returns the `trigger` field as well — `onClick | afterPrevious | withPrevious` — so Add/Set and Get round-trip. Verify with `officecli get "$FILE" "/slide[N]/shape[@name=X]/animation[1]" --json | jq '.trigger,.duration'` if you need to confirm the read-back matches what you set.
@@ -378,14 +412,14 @@ officecli set deck.pptx "/slide[2]/shape[@name=HeroCard]" --prop animation=none 
 ### Hyperlinks, tooltips, slide-jump
 
 ```bash
-officecli set deck.pptx "/slide[7]/shape[@name=NavBtn]" --prop link=slide:2 --prop tooltip="Back to Agenda"
-officecli set deck.pptx "/slide[7]/shape[@name=DocsBtn]" --prop link=https://example.com
+officecli set "$FILE" "/slide[7]/shape[@name=NavBtn]" --prop link=slide:2 --prop tooltip="Back to Agenda"
+officecli set "$FILE" "/slide[7]/shape[@name=DocsBtn]" --prop link=https://example.com
 ```
 
 **CRITICAL ordering** (C-P-1): on a shape that already has run-level styling (`bold`/`color`/`font`/`size`), setting `link=` + `tooltip=` emits schema-invalid XML. Fix:
 
 1. Set `link=` + `tooltip=` BEFORE any run-level styling. OR
-2. Post-hoc cleanup: `officecli raw-set deck.pptx /slide[N] --xpath //a:rPr/a:hlinkClick --action remove`.
+2. Post-hoc cleanup: `officecli raw-set "$FILE" /slide[N] --xpath //a:rPr/a:hlinkClick --action remove`.
 
 ### Tables, placeholders, groups, zoom — one-liners
 
@@ -655,17 +689,17 @@ Color convention: red path = stop/escalate, blue path = standard-action, green t
 
 ### Minimum cycle before "done"
 
-1. `officecli view deck.pptx issues` + `view annotated` — empty slides, overflow hints, size violations (< 36pt title, < 18pt body). `"Slide has no title"` on `layout=blank` is expected, not a defect.
-2. `officecli view deck.pptx html` — Read the returned HTML path for a per-slide visual audit. Walk every slide for alignment, overflow, placeholder leaks, one clear focal point.
+1. `officecli view "$FILE" issues` + `view annotated` — empty slides, overflow hints, size violations (< 36pt title, < 18pt body). `"Slide has no title"` on `layout=blank` is expected, not a defect.
+2. `officecli view "$FILE" html` — Read the returned HTML path for a per-slide visual audit. Walk every slide for alignment, overflow, placeholder leaks, one clear focal point.
 3. Query for known defect classes:
    ```bash
-   officecli query deck.pptx 'shape:contains("lorem")'
-   officecli query deck.pptx 'shape:contains("{{")'
-   officecli query deck.pptx 'shape:contains("TODO")'
-   officecli query deck.pptx 'picture:no-alt'
+   officecli query "$FILE" 'shape:contains("lorem")'
+   officecli query "$FILE" 'shape:contains("{{")'
+   officecli query "$FILE" 'shape:contains("TODO")'
+   officecli query "$FILE" 'picture:no-alt'
    ```
-4. `officecli close deck.pptx && officecli validate deck.pptx` — schema check. NEVER run validate against a resident-open file (spurious errors).
-5. **Open the deck in the target presentation viewer before shipping.** `view html` (Read the returned HTML path) catches overflow and placeholders; the target viewer is ground truth for chart colors, fonts, zoom, and animations (these are runtime features). For human preview, run `officecli watch deck.pptx` — the user opens the live preview at their own discretion — or have them open the `.pptx` directly in PowerPoint / Keynote / WPS.
+4. `officecli close "$FILE" && officecli validate "$FILE"` — schema check. NEVER run validate against a resident-open file (spurious errors).
+5. **Open the deck in the target presentation viewer before shipping.** `view html` (Read the returned HTML path) catches overflow and placeholders; the target viewer is ground truth for chart colors, fonts, zoom, and animations (these are runtime features). For human preview, run `officecli watch "$FILE"` — the user opens the live preview at their own discretion — or have them open the `.pptx` directly in PowerPoint / Keynote / WPS.
 6. If anything failed, fix, then **rerun the full cycle**. One fix commonly creates another problem.
 
 ### Delivery Gate (any failure = REJECT, do NOT deliver)
@@ -740,7 +774,7 @@ When something looks broken, attribute it first: **[AGENT-ERROR]** (deck itself 
 
 | # | Symptom | Workaround |
 |---|---|---|
-| **C-P-1** | Hyperlink `link=`+`tooltip=` on a shape with pre-existing run-level styling (`bold/color/font/size`) emits schema-invalid `<a:rPr><a:hlinkClick>`. | Set `link=`+`tooltip=` **BEFORE** any run-level styling. Post-hoc cleanup: `officecli raw-set deck.pptx /slide[N] --xpath //a:rPr/a:hlinkClick --action remove`. Gate 3 in the Delivery Gate catches it. |
+| **C-P-1** | Hyperlink `link=`+`tooltip=` on a shape with pre-existing run-level styling (`bold/color/font/size`) emits schema-invalid `<a:rPr><a:hlinkClick>`. | Set `link=`+`tooltip=` **BEFORE** any run-level styling. Post-hoc cleanup: `officecli raw-set "$FILE" /slide[N] --xpath //a:rPr/a:hlinkClick --action remove`. Gate 3 in the Delivery Gate catches it. |
 | **C-P-2** | `validate` reports `ChartShapeProperties` schema warnings (1 per chart). Renders correctly everywhere. | Whitelist in Gate 1. Do not chase. |
 | **C-P-3** | `get /slide[N]/shape[@name=X]/animation[1]` returns stale `duration` after `set animation=...`. | Trust shape-level readback: `get "/slide[N]/shape[@name=X]" --json \| jq .animation`. |
 | **C-P-4** | `remove /slide[N]/shape[@id=X]/animation[1]` rejected (deep-path accepted by `add` but not `remove`). | Use `set --prop animation=none`, or overwrite with a new preset. |
@@ -783,7 +817,7 @@ If in doubt, `view text` after writing and compare character-for-character.
 `open`/`close` is the default (see Common Workflow step 1). For grids / timelines / skeletons, **batch** collapses many ops into one API call:
 
 ```bash
-cat <<'EOF' | officecli batch deck.pptx
+cat <<'EOF' | officecli batch "$FILE"
 [
   {"command":"add","parent":"/slide[1]","type":"shape","props":{"name":"Title","text":"FY26 Review","x":"2cm","y":"2cm","width":"30cm","height":"2cm","size":"36","bold":"true"}},
   {"command":"add","parent":"/slide[1]","type":"shape","props":{"name":"Body","text":"Revenue grew 18%","x":"2cm","y":"5cm","width":"30cm","height":"10cm","size":"20"}}

--- a/skills/officecli-pptx/SKILL.md
+++ b/skills/officecli-pptx/SKILL.md
@@ -200,6 +200,41 @@ Each animation is a cognitive interrupt. Limits:
 
 → Presets: `officecli help pptx animation`.
 
+### Layout patterns & data display
+
+Vary layout across slides — repeating the same pattern makes every slide feel identical. Pick one per slide from these building blocks:
+
+| Pattern | When to use | Key measurement |
+|---|---|---|
+| **Two-column** (text left, visual right) | Concept + evidence; feature + screenshot | Each col ≈ 14-15cm; gap 1cm |
+| **Icon rows** (icon in filled circle + bold header + description) | Feature lists, benefits, team roles | Icon circle 1.5-2cm; 3-4 rows max |
+| **2×2 or 2×3 grid** (card tiles) | Quadrant analysis, SWOT, option comparison | Gap ≥ 0.76cm; consistent card height |
+| **Half-bleed image** (full left or right half, content overlay on other side) | Hero moments, case study openers | Image 16-17cm wide; content column ≥ 14cm |
+| **Large stat callout** (60-72pt number + ≤5-word sublabel below) | Single KPI, milestone, market size | Use shape, NOT a chart; sublabel 14-16pt muted |
+
+**Data display quick rules:**
+- One big number reads faster than a chart — use a `shape` with 60-72pt bold for a single KPI.
+- Comparison columns (before/after, A vs B) beat a table for 2-3 options.
+- Timelines and process flows: numbered step shapes + connectors, not a bullet list.
+
+### Visual motif commitment
+
+Pick ONE distinctive element before slide 1 and carry it to every slide. Examples: rounded image frames, section numbers in filled circles, a thick single-side border band, diagonal accent strips. If you could swap the motif out for a completely different design and nothing would look wrong, you haven't committed — you've just applied a style to one slide.
+
+Write it in your build plan first: `## Motif: numbered circles in brand color`. Then enforce it on every slide.
+
+### What to avoid (common design mistakes)
+
+These are the patterns that make a deck look AI-generated or amateur:
+
+- **NEVER place a decorative line under slide titles.** Underline stripes below headings are the single most common AI-slide tell. Use whitespace or background color change instead.
+- **Don't repeat the same layout across consecutive slides.** Alternate between two-column, callout, grid, and half-bleed patterns. Same layout = same visual rhythm = audience tunes out.
+- **Don't center body text.** Left-align all paragraphs, lists, card descriptions. Center only slide titles and hero numbers.
+- **Don't default to blue** because it feels "professional." Pick the palette that fits the topic — finance reads navy, sustainability reads forest, energy reads coral.
+- **Don't use inconsistent spacing.** Choose either 0.76cm or 1.27cm as your inter-block gap and use it everywhere. Mixed gaps look unfinished.
+- **Don't create text-only slides.** If a slide has only a title and bullets, add a supporting shape, chart, icon, or image. A purely textual slide is a Word paragraph.
+- **Don't style one slide and leave the rest plain.** Commit fully or keep it simple throughout — partial styling reads as abandoned.
+
 ## Common Workflow
 
 1. **Open/close mode.** Always `officecli open <file>` at start + `officecli close <file>` at end. Resident is the default, not an optimization. Use `batch` in ≤ 12-op chunks for repetitive shape grids.

--- a/skills/officecli-word-form/SKILL.md
+++ b/skills/officecli-word-form/SKILL.md
@@ -462,7 +462,11 @@ This is the core pattern for medical intake, two-party contracts, sequential-app
 
 ## Recipe — Contract / SOW template with MERGEFIELD + signature
 
-Combines MERGEFIELD placeholders (for downstream mail-merge), an SDT dropdown with Path B items (for sales to pick), a signature block via `--after find:`, and a CONFIDENTIAL watermark. Row-map: SDT[1]=project_name, SDT[2]=contract_start, SDT[3]=payment_schedule, SDT[4]=signatory_name (inline).
+Row-map across the three sub-recipes: SDT[1]=project_name, SDT[2]=contract_start, SDT[3]=payment_schedule, SDT[4]=signatory_name (inline). Run (sow-a) → (sow-b) → (sow-c) in order on the same `$FILE`; each sub-recipe stays under 20 lines so a shell-escape slip never cascades past one block.
+
+### Recipe (sow-a) Boilerplate + cover + parties
+
+Creates the file, sets docDefaults, writes the title / intro, and drops the two MERGEFIELD placeholders (`CustomerName`, `ContractNo`) that downstream mail-merge will fill.
 
 ```bash
 FILE=sow.docx
@@ -471,40 +475,36 @@ officecli open "$FILE"
 officecli set "$FILE" / --prop title="Statement of Work" \
   --prop docDefaults.font="Calibri" --prop docDefaults.fontSize="12pt"
 
-# Title + boilerplate (becomes read-only under protection=forms)
 officecli add "$FILE" /body --type paragraph --prop text="Statement of Work" \
   --prop style=Heading1 --prop size=20 --prop bold=true --prop spaceAfter=12pt
 officecli add "$FILE" /body --type paragraph \
   --prop text="This Statement of Work ('SOW') is entered into between the parties identified below and governs the delivery of professional services." \
   --prop size=11 --prop spaceAfter=12pt
 
-# Customer block with MERGEFIELDs — downstream mail-merge fills these
 officecli add "$FILE" /body --type paragraph --prop text="Customer: "
 officecli add "$FILE" '/body/p[last()]' --type field \
   --prop fieldType=mergefield --prop name=CustomerName
 officecli add "$FILE" /body --type paragraph --prop text="Contract #: "
 officecli add "$FILE" '/body/p[last()]' --type field \
   --prop fieldType=mergefield --prop name=ContractNo
+```
 
-# Section headings (add as paragraphs with style=Heading2 size=14 bold=true spaceBefore=18pt spaceAfter=8pt)
-# "1. Project Details" then label + SDT pairs:
+### Recipe (sow-b) SDT fields + Path B raw-set specials
+
+Adds the three block-level SDTs (project / date / dropdown), the inline signature SDT anchored via `--after 'find:Client Signature:'`, then Path B raw-set to inject the date format and dropdown items (both are UNSUPPORTED via `add --prop`).
+
+```bash
 officecli add "$FILE" /body --type sdt --prop type=text \
   --prop alias="Project Name" --prop tag=project_name --prop text="Enter project name"
 officecli add "$FILE" /body --type sdt --prop type=date \
   --prop alias="Contract Start Date" --prop tag=contract_start
-
-# "2. Payment Terms"
 officecli add "$FILE" /body --type sdt --prop type=dropdown \
   --prop alias="Payment Schedule" --prop tag=payment_schedule
-
-# Signature — inline SDT via --after find:, outer single quotes (trap: inner " breaks match)
 officecli add "$FILE" /body --type paragraph --prop text="Client Signature:" \
   --prop bold=true --prop spaceBefore=18pt --prop spaceAfter=4pt
 officecli add "$FILE" /body --type sdt --prop type=text \
   --prop alias="Signatory Name" --prop tag=signatory_name --prop text="Authorized Signatory" \
   --after 'find:Client Signature:'
-
-# Path B injections
 officecli raw-set "$FILE" /document \
   --xpath "//w:sdt[w:sdtPr/w:tag/@w:val='contract_start']/w:sdtPr/w:date/w:dateFormat" \
   --action setattr --xml "w:val=MM/dd/yyyy"
@@ -512,12 +512,16 @@ officecli raw-set "$FILE" /document \
   --xpath "//w:sdt[w:sdtPr/w:tag/@w:val='payment_schedule']/w:sdtPr/w:dropDownList" \
   --action append \
   --xml '<w:listItem xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" w:displayText="Full Prepayment" w:value="Full Prepayment"/><w:listItem xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" w:displayText="Net 30 Upon Delivery" w:value="Net 30 Upon Delivery"/>'
+```
 
-# Watermark — parent is /, never /body
+### Recipe (sow-c) Watermark + locks + document protection
+
+Drops the CONFIDENTIAL watermark (parent is `/`, never `/body`), locks the three block-level SDTs, instructs how to lock the inline signatory_name SDT (path only known after `view forms`), then seals the document with `protection=forms` as the last command.
+
+```bash
 officecli add "$FILE" / --type watermark \
   --prop text="CONFIDENTIAL" --prop color=FF0000 --prop rotation=315
 
-# Locks — inline signatory_name SDT lives under a paragraph path; read from `view forms`
 officecli set "$FILE" '/body/sdt[1]' --prop lock=sdtlocked
 officecli set "$FILE" '/body/sdt[2]' --prop lock=sdtlocked
 officecli set "$FILE" '/body/sdt[3]' --prop lock=sdtlocked

--- a/skills/officecli-xlsx/SKILL.md
+++ b/skills/officecli-xlsx/SKILL.md
@@ -120,7 +120,7 @@ Scope: budgets, forecasts, 3-statement models, valuation, any `$`-heavy analytic
 Six steps. Every non-trivial build follows this shape.
 
 1. **Choose the mode.** Always use `officecli open <file>` at the start and `officecli close <file>` at the end. Resident mode is the default, not an optimization — it avoids re-parsing the file on every command. For many cells, use `batch`: **≤ 50 ops/block recommended; tested up to 80+ ops per block on pure value-set payloads with zero failures. Cross-sheet formula batches are the exception — run those non-resident, single heredoc (see Known Issues)**.
-2. **Create or load.** `officecli create foo.xlsx` (new) or `officecli view foo.xlsx outline` (existing — get the lay of the land first).
+2. **Create or load.** `officecli create "$FILE"` (new) or `officecli view "$FILE" outline` (existing — get the lay of the land first).
 3. **Build incrementally.** One command, read the output, continue. After any structural op (new sheet, chart, named range, pivot), run `get` on it to confirm shape before stacking more on top.
 4. **Format.** Column widths, number formats, freeze panes, tab colors, header fills. Formatting is not optional polish — per "Requirements for Outputs" it is part of the deliverable.
 5. **Close, then reckon with the cache.** `officecli close <file>` writes to disk. Newly-added formulas ship without cached values; when a human opens the file in a spreadsheet app, the app recalculates and populates them. **But your downstream `INDEX/MATCH`, `SUMPRODUCT`, or any formula that references an upstream formula will cache whatever the upstream cached at write-time — often `0` or a stale value — and that cached lie survives into non-recalculating readers.** After any multi-formula build involving array formulas (`SUMPRODUCT`, `SUMIFS` with dynamic criteria) or cross-sheet chains, **re-touch every downstream cell** (run `set` again with the same formula) so the engine recomputes its cache from the freshly-cached upstream. ⚠️ Re-touch on cross-sheet chains via resident is unreliable (see Batch / resident caveats) — prefer non-resident `set` for the re-touch pass. Then `officecli get` a few downstream cells and eyeball that their `cachedValue=` is plausible. **Array-formula fallback:** for `SUMPRODUCT(1/COUNTIF(range, range))` distinct-count patterns, the CLI engine treats the inner division as scalar and caches `1/N` (e.g. `0.001543`) rather than the true distinct count. Re-touching won't fix it. **Fallback: hardcode the correct value + an adjacent comment `"hardcoded distinct count; update if Data rows change"`, and tell the reader at delivery**. Better than shipping a cached lie. Do NOT run `validate` while a resident is open — it reports spurious drawing errors.
@@ -131,22 +131,22 @@ Six steps. Every non-trivial build follows this shape.
 Minimal viable xlsx: 3 months of revenue + a total formula + column widths + a currency format. Adapt, don't copy-paste — your file, your data.
 
 ```bash
-officecli create revenue.xlsx
-officecli open revenue.xlsx
-officecli set revenue.xlsx /Sheet1/A1 --prop value=Month --prop bold=true
-officecli set revenue.xlsx /Sheet1/B1 --prop value=Revenue --prop bold=true
-officecli set revenue.xlsx /Sheet1/A2 --prop value=Jan
-officecli set revenue.xlsx /Sheet1/A3 --prop value=Feb
-officecli set revenue.xlsx /Sheet1/A4 --prop value=Mar
-officecli set revenue.xlsx /Sheet1/B2 --prop value=42000 --prop numFmt='$#,##0'
-officecli set revenue.xlsx /Sheet1/B3 --prop value=45000 --prop numFmt='$#,##0'
-officecli set revenue.xlsx /Sheet1/B4 --prop value=48000 --prop numFmt='$#,##0'
-officecli set revenue.xlsx /Sheet1/A5 --prop value=Total --prop bold=true
-officecli set revenue.xlsx /Sheet1/B5 --prop formula="SUM(B2:B4)" --prop bold=true --prop numFmt='$#,##0'
-officecli set revenue.xlsx "/Sheet1/col[A]" --prop width=12
-officecli set revenue.xlsx "/Sheet1/col[B]" --prop width=15
-officecli close revenue.xlsx
-officecli validate revenue.xlsx
+officecli create "$FILE"
+officecli open "$FILE"
+officecli set "$FILE" /Sheet1/A1 --prop value=Month --prop bold=true
+officecli set "$FILE" /Sheet1/B1 --prop value=Revenue --prop bold=true
+officecli set "$FILE" /Sheet1/A2 --prop value=Jan
+officecli set "$FILE" /Sheet1/A3 --prop value=Feb
+officecli set "$FILE" /Sheet1/A4 --prop value=Mar
+officecli set "$FILE" /Sheet1/B2 --prop value=42000 --prop numFmt='$#,##0'
+officecli set "$FILE" /Sheet1/B3 --prop value=45000 --prop numFmt='$#,##0'
+officecli set "$FILE" /Sheet1/B4 --prop value=48000 --prop numFmt='$#,##0'
+officecli set "$FILE" /Sheet1/A5 --prop value=Total --prop bold=true
+officecli set "$FILE" /Sheet1/B5 --prop formula="SUM(B2:B4)" --prop bold=true --prop numFmt='$#,##0'
+officecli set "$FILE" "/Sheet1/col[A]" --prop width=12
+officecli set "$FILE" "/Sheet1/col[B]" --prop width=15
+officecli close "$FILE"
+officecli validate "$FILE"
 ```
 
 Verified: `validate` returns `no errors found`, `B5` resolves to `135000`. This is the shape of every build: open → set cells/formulas → format → close → validate.
@@ -156,9 +156,9 @@ Verified: `validate` returns `no errors found`, `B5` resolves to `135000`. This 
 **Native `import` command (preferred for CSV/TSV).** Fastest path; loads a CSV into a sheet in one call. `--header` sets AutoFilter + freeze pane on row 1. Widths and `numFmt` still need a follow-up pass (per D-12 in Dashboard skill).
 
 ```bash
-officecli import data.xlsx /Sheet1 --file data.csv --header
-officecli import data.xlsx /Sheet1 --file data.tsv --format tsv --header
-officecli import data.xlsx /Sheet1 --stdin --start-cell B2 < data.csv
+officecli import "$FILE" /Sheet1 --file data.csv --header
+officecli import "$FILE" /Sheet1 --file data.tsv --format tsv --header
+officecli import "$FILE" /Sheet1 --stdin --start-cell B2 < data.csv
 ```
 
 **Python + batch fallback** — use when you need custom type coercion, formula injection, or the CSV lives inside another data pipeline. Recipe for 600-6000+ cells:
@@ -180,7 +180,7 @@ for i in range(0, len(ops), 80):
 
 ```bash
 python gen_batch.py | while IFS= read -r chunk; do
-  printf '%s\n' "$chunk" | officecli batch data.xlsx
+  printf '%s\n' "$chunk" | officecli batch "$FILE"
 done
 ```
 
@@ -198,13 +198,13 @@ Use `view html` as your **first visual check after a batch of edits** — fix at
 **Orient.** Sheets, dimensions, formula counts.
 
 ```bash
-officecli view data.xlsx outline
+officecli view "$FILE" outline
 ```
 
 **Extract.** Plain text dump for content QA or LLM context; scope with `--start` / `--end` / `--cols` for big files.
 
 ```bash
-officecli view data.xlsx text --start 1 --end 50 --cols A,B,C
+officecli view "$FILE" text --start 1 --end 50 --cols A,B,C
 ```
 
 Other `view` modes worth knowing: `annotated` (cell values + types/formulas + warnings), `stats` (numeric summaries), `issues` (broken formulas, empty sheets, missing refs).
@@ -212,11 +212,11 @@ Other `view` modes worth knowing: `annotated` (cell values + types/formulas + wa
 **Inspect one element.** Use XPath-style paths. Always quote — shells glob `[N]`.
 
 ```bash
-officecli get data.xlsx "/Sheet1/A1"            # one cell
-officecli get data.xlsx "/Sheet1/A1:D10"        # range
-officecli get data.xlsx "/Sheet1/chart[1]"      # chart
-officecli get data.xlsx "/Sheet1/table[1]"      # ListObject
-officecli get data.xlsx "/namedrange[1]"        # workbook-level named range
+officecli get "$FILE" "/Sheet1/A1"            # one cell
+officecli get "$FILE" "/Sheet1/A1:D10"        # range
+officecli get "$FILE" "/Sheet1/chart[1]"      # chart
+officecli get "$FILE" "/Sheet1/table[1]"      # ListObject
+officecli get "$FILE" "/namedrange[1]"        # workbook-level named range
 ```
 
 Add `--depth N` to expand children; add `--json` for machine output. Full element list: `officecli help xlsx`.
@@ -224,10 +224,10 @@ Add `--depth N` to expand children; add `--json` for machine output. Full elemen
 **Query across the workbook.** CSS-like selectors. Use for systematic checks (formula coverage, error cells, empty headers) rather than hand-walking.
 
 ```bash
-officecli query data.xlsx 'cell:has(formula)'       # every formula cell
-officecli query data.xlsx 'cell:contains("#REF!")'  # broken references
-officecli query data.xlsx 'cell[type=Number]'       # typed filter
-officecli query data.xlsx 'Sheet1!B[value!=0]'      # sheet-scoped
+officecli query "$FILE" 'cell:has(formula)'       # every formula cell
+officecli query "$FILE" 'cell:contains("#REF!")'  # broken references
+officecli query "$FILE" 'cell[type=Number]'       # typed filter
+officecli query "$FILE" 'Sheet1!B[value!=0]'      # sheet-scoped
 ```
 
 Operators: `=`, `!=`, `~=` (contains), `>=`, `<=`, `[attr]` (exists).
@@ -249,16 +249,16 @@ Ninety percent of a build is cells, formulas, formatting, and one or two charts.
 Set a value and its format in one call. Never write `=` at the start of a formula — the CLI strips it.
 
 ```bash
-officecli set data.xlsx /Sheet1/B5 --prop formula="SUM(B2:B4)" --prop numFmt='$#,##0'
-officecli set data.xlsx /Sheet1/C5 --prop formula="B5/A5" --prop numFmt="0.0%"
+officecli set "$FILE" /Sheet1/B5 --prop formula="SUM(B2:B4)" --prop numFmt='$#,##0'
+officecli set "$FILE" /Sheet1/C5 --prop formula="B5/A5" --prop numFmt="0.0%"
 ```
 
 Structural properties (width, height, freeze, tabColor) live on row / col / sheet nodes:
 
 ```bash
-officecli set data.xlsx "/Sheet1/col[A]" --prop width=20
-officecli set data.xlsx "/Sheet1/row[1]" --prop height=22
-officecli set data.xlsx "/Sheet1" --prop freeze=A2 --prop tabColor=1F4E79
+officecli set "$FILE" "/Sheet1/col[A]" --prop width=20
+officecli set "$FILE" "/Sheet1/row[1]" --prop height=22
+officecli set "$FILE" "/Sheet1" --prop freeze=A2 --prop tabColor=1F4E79
 ```
 
 ### Named ranges
@@ -266,7 +266,7 @@ officecli set data.xlsx "/Sheet1" --prop freeze=A2 --prop tabColor=1F4E79
 Prefer named ranges over `$B$6` in formulas. They self-document (`GrowthRate` beats `$B$6`) and they let you move the assumption cell without breaking formulas. Because `ref` values contain both `!` and `$`, add them through a batch heredoc:
 
 ```bash
-cat <<'EOF' | officecli batch data.xlsx
+cat <<'EOF' | officecli batch "$FILE"
 [
   {"command":"add","parent":"/","type":"namedrange","props":{"name":"GrowthRate","ref":"Sheet1!$B$6"}}
 ]
@@ -318,7 +318,7 @@ Input cells in trackers and templates MUST carry data validation. It's cheap and
 **(a) Inline list** — allowed values are short and fixed in the rule itself.
 
 ```bash
-officecli add data.xlsx /Sheet1 --type validation \
+officecli add "$FILE" /Sheet1 --type validation \
   --prop sqref="C2:C100" --prop type=list \
   --prop formula1="Yes,No,Maybe" \
   --prop showError=true --prop errorTitle="Invalid" --prop error="Select from list"
@@ -327,7 +327,7 @@ officecli add data.xlsx /Sheet1 --type validation \
 **(b) Named range (preferred for cross-sheet lookups)** — allowed values live in another sheet and may grow. Define the named range first, then reference it. Use a batch heredoc because `ref` contains `!` and `$`:
 
 ```bash
-cat <<'EOF' | officecli batch data.xlsx
+cat <<'EOF' | officecli batch "$FILE"
 [
   {"command":"add","parent":"/","type":"namedrange","props":{"name":"StatusList","ref":"Lookups!$A$2:$A$4"}},
   {"command":"add","parent":"/Sheet1","type":"validation","props":{"sqref":"B2:B100","type":"list","formula1":"=StatusList"}}
@@ -338,14 +338,14 @@ EOF
 **(c) Direct cross-sheet range** — no named range, raw `Lookups!$A$2:$A$4` inside `formula1`. Also needs a batch heredoc to keep `!` and `$` intact:
 
 ```bash
-cat <<'EOF' | officecli batch data.xlsx
+cat <<'EOF' | officecli batch "$FILE"
 [
   {"command":"add","parent":"/Sheet1","type":"validation","props":{"sqref":"C2:C100","type":"list","formula1":"Lookups!$A$2:$A$4"}}
 ]
 EOF
 ```
 
-If you write the cross-sheet variant as `--prop formula1=...` on the shell, the `!` gets shell-mangled into `\!` and the dropdown will silently fall back to no list. Verify with `officecli get data.xlsx /Sheet1/validation[N]` — `formula1=` must show a plain `!`, no backslash.
+If you write the cross-sheet variant as `--prop formula1=...` on the shell, the `!` gets shell-mangled into `\!` and the dropdown will silently fall back to no list. Verify with `officecli get "$FILE" /Sheet1/validation[N]` — `formula1=` must show a plain `!`, no backslash.
 
 Other common `type` values: `decimal`, `whole`, `date`, `textLength`, `custom`. See `officecli help xlsx validation` for operators and the full prop list.
 
@@ -360,9 +360,9 @@ Other common `type` values: `decimal`, `whole`, `date`, `textLength`, `custom`. 
 Editing a chart axis in place is cheaper than rebuilding the chart. Address axes by **role** (`value` = Y, `category` = X), not by index — the XML order isn't stable.
 
 ```bash
-officecli get data.xlsx "/Sheet1/chart[1]/axis[@role=value]"
-officecli set data.xlsx "/Sheet1/chart[1]/axis[@role=value]" --prop min=0 --prop max=100000
-officecli set data.xlsx "/Sheet1/chart[1]/axis[@role=category]" --prop title="Month"
+officecli get "$FILE" "/Sheet1/chart[1]/axis[@role=value]"
+officecli set "$FILE" "/Sheet1/chart[1]/axis[@role=value]" --prop min=0 --prop max=100000
+officecli set "$FILE" "/Sheet1/chart[1]/axis[@role=category]" --prop title="Month"
 ```
 
 Safe props: `title`, `min`, `max`, `majorGridlines`, `visible`. Do NOT use `labelRotation` — it emits invalid XML today (see Known Issues).
@@ -375,15 +375,15 @@ Your first workbook is almost never correct. Treat QA as a bug hunt, not a confi
 
 ### Minimum cycle before "done"
 
-1. `officecli view data.xlsx issues` — empty sheets, broken formulas, missing refs.
-2. `officecli view data.xlsx annotated` (sample ranges) — values + types + warnings.
+1. `officecli view "$FILE" issues` — empty sheets, broken formulas, missing refs.
+2. `officecli view "$FILE" annotated` (sample ranges) — values + types + warnings.
 3. For every Excel error type, query it:
    ```bash
-   officecli query data.xlsx 'cell:contains("#REF!")'
-   officecli query data.xlsx 'cell:contains("#DIV/0!")'
-   officecli query data.xlsx 'cell:contains("#VALUE!")'
-   officecli query data.xlsx 'cell:contains("#NAME?")'
-   officecli query data.xlsx 'cell:contains("#N/A")'
+   officecli query "$FILE" 'cell:contains("#REF!")'
+   officecli query "$FILE" 'cell:contains("#DIV/0!")'
+   officecli query "$FILE" 'cell:contains("#VALUE!")'
+   officecli query "$FILE" 'cell:contains("#NAME?")'
+   officecli query "$FILE" 'cell:contains("#N/A")'
    ```
 4. `officecli validate "$FILE"` — close any resident first (see Known Issues).
 5. **Visual pass — walk every sheet via the HTML preview.** Run `officecli view "$FILE" html` and Read the returned HTML path. Each sheet renders with charts inline. Scan for `###`, truncated titles, placeholder tokens (`$fy$24`, `{var}`, `<TODO>`), sliced charts, white-slice pie charts, empty chart anchors — **STOP and fix before declaring done**. "validate pass" is not delivery; "the preview looks like a real workbook" is delivery. For human preview, run `officecli watch "$FILE"` (user opens the live preview at their own discretion) or have them open the `.xlsx` directly in Excel / WPS / Numbers.
@@ -403,7 +403,7 @@ Your first workbook is almost never correct. Treat QA as a bug hunt, not a confi
 - [ ] **Spot-check one cell per numeric column.** `%` columns showing integer `0.0%` throughout means the denominator is wrong or the numerator is cached stale — investigate one cell, fix the pattern.
 - [ ] Ranges include every row: off-by-one on `SUM(B2:B12)` when data goes to `B13` is the most common bug.
 - [ ] Cross-sheet formulas (`Sheet1!A1`) contain no `\!`. If `officecli get` shows `Sheet1\!A1`, the `!` was shell-corrupted — delete and re-enter via batch/heredoc.
-- [ ] Named ranges (`officecli get data.xlsx "/namedrange[1]"`) point at what their names claim.
+- [ ] Named ranges (`officecli get "$FILE" "/namedrange[1]"`) point at what their names claim.
 - [ ] Every `/` denominator is guarded — `IFERROR(x/y, 0)` or `IF(y=0, 0, x/y)`.
 - [ ] Chart data vs source cells: for every chart with inline data, spot-check data points against `officecli get` of the source cells.
 - [ ] Chart title / series name / legend contain **no** unreplaced tokens (`$...$`, `{var}`, `<TODO>`). Grep the chart via `officecli get /Sheet1/chart[N]`.
@@ -413,9 +413,9 @@ Your first workbook is almost never correct. Treat QA as a bug hunt, not a confi
 When editing a template, check for leftover placeholders — they look like content and slip past `validate`:
 
 ```bash
-officecli query data.xlsx 'cell:contains("{{")'
-officecli query data.xlsx 'cell:contains("xxxx")'
-officecli query data.xlsx 'cell:contains("TBD")'
+officecli query "$FILE" 'cell:contains("{{")'
+officecli query "$FILE" 'cell:contains("xxxx")'
+officecli query "$FILE" 'cell:contains("TBD")'
 ```
 
 ### Fresh eyes
@@ -435,7 +435,7 @@ Shells (bash history expansion, zsh splitting) and CLI arg parsing mangle `!` in
 **Fix.** Use a batch heredoc with single-quoted delimiter (`<<'EOF'`), which disables all shell expansion:
 
 ```bash
-cat <<'EOF' | officecli batch data.xlsx
+cat <<'EOF' | officecli batch "$FILE"
 [{"command":"set","path":"/Summary/B2","props":{"formula":"Revenue!B13"}}]
 EOF
 ```
@@ -444,7 +444,7 @@ EOF
 
 ### CLI bug backlog (short)
 
-Avoid these until fixed; they produce invalid XML or silent breakage. Full details in `reports/` on the repo.
+Avoid these until fixed; they produce invalid XML or silent breakage.
 
 - **`chartType=pareto`** — emits empty `cx:axisId val=""`; `validate` fails after `close`. Substitute `column` or `boxWhisker`.
 - **`labelRotation` on axis-by-role** — inserts bad `a:endParaRPr`. Use `title`/`min`/`max`/`majorGridlines`/`visible` only.

--- a/skills/officecli-xlsx/SKILL.md
+++ b/skills/officecli-xlsx/SKILL.md
@@ -96,14 +96,17 @@ Trigger: sheet holds a chart, or > 8 columns, or the user's ask mentions print /
 
 Scope: budgets, forecasts, 3-statement models, valuation, any `$`-heavy analytical workbook. A customer-support tracker or onboarding template does not need this section.
 
-**Color coding — industry standard.** Four core colors used as a language, not decoration. A reviewer should tell what a cell IS by color: blue = hardcoded input, black = formula, green = cross-sheet link, yellow fill = assumption needing review. (See a dedicated financial-model skill for red external links, multi-scenario conventions, or audit colors.)
+**Color coding — industry standard.** Five core colors used as a language, not decoration. A reviewer should tell what a cell IS by color alone — before reading the formula.
 
 | Color | Role | Example |
 |---|---|---|
 | Blue text `0000FF` | Hardcoded inputs, scenario variables | `font.color=0000FF` |
 | Black text `000000` | ALL formulas and calculations | default |
 | Green text `008000` | Cross-sheet links inside this workbook | `font.color=008000` |
+| Red text `FF0000` | Links to external files / workbooks | `font.color=FF0000` |
 | Yellow fill `FFFF00` | Key assumptions needing review | `fill=FFFF00` |
+
+A reviewer should tell what a cell IS just by its color — before reading the formula. This is a communication contract, not a cosmetic preference.
 
 **Number formatting — standards, not preferences.**
 
@@ -112,8 +115,17 @@ Scope: budgets, forecasts, 3-statement models, valuation, any `$`-heavy analytic
 - **Zeros display as `-`**, not `0`. Use `$#,##0;($#,##0);"-"`.
 - **Percentages** default to one decimal: `0.0%`.
 - **Negatives use parentheses**: `(1,234)` not `-1,234`.
+- **Valuation multiples** use `0.0x` format (EV/EBITDA, P/E, etc.).
 
-**Assumptions live in cells, not inside formulas.** `=B5*(1+$B$6)` is correct; `=B5*1.05` is a bug. Document each blue input with an adjacent "Source: ..." cell or comment.
+**Assumptions live in cells, not inside formulas.** `=B5*(1+$B$6)` is correct; `=B5*1.05` is a bug. Document each blue hardcoded input with an adjacent source note in the next cell or a cell comment:
+
+```
+Source: Company 10-K, FY2024, Page 45, Revenue Note
+Source: Bloomberg, 2026-05-02, AAPL US Equity
+Source: Management guidance, Q2 2026 earnings call
+```
+
+Any hardcoded number without a source is an undocumented assumption — a reviewer cannot audit it.
 
 ## Common Workflow
 


### PR DESCRIPTION
## Why

After the v2 philosophy-first rewrite (PRs #84 / #85 / #93), the PPT-family skills lost visible design guidance. Testers started shipping decks with body text <16pt, mid-gray on dark backgrounds, no speaker notes, improvised slide layouts, and common AI-slide tells (decorative lines under titles, centered body text, repeated layouts). Separately, a scan for hardcoded filenames and long heredocs turned up 170+ shell-escape-prone patterns across the Office skills.

This PR restores the design depth and sweeps the hardcode footprint in one atomic changeset across 6 skills.

## What changed

### officecli-pptx (831 → 900)

**Design Principles expanded**

- **Hard rules** (H4 / H6 / H7 / KPI sublabel char-fit) — body ≥16pt, dark-bg text brightness ≥80%, speaker notes mandatory on content slides, KPI values sized so they don't wrap.
- **Palette catalogue** — 4 → **10 named themes** × 5 roles (Primary / Secondary / Accent / Text / Muted). Picked by topic, not by default.
- **Font pairings** — new 8-row table (Header × Body × Best-For) replacing the 0-row placeholder.
- **Layout patterns & data display** — 5 reusable skeletons (two-column / icon rows / 2×2 grid / half-bleed / big-stat callout) with key measurements, plus quick rules on when to use a shape vs a chart.
- **Visual motif commitment** — pick ONE motif before slide 1 and carry it to every slide.
- **What to avoid** — 7 common AI-slide tells explicitly banned: decorative lines under titles, repeated layouts, centered body text, default blue, inconsistent spacing, text-only slides, partial styling.

**P1 sweep:** 50 of 52 hardcoded `deck.pptx` → `"$FILE"`; two `FILE="deck.pptx"` declarations retained as variable seeds.

### officecli-pitch-deck (655 → 826)

- **Slide Patterns canon** — six canonical layouts (C.1 Title / C.2 3-Stat / C.3 4-Stat with `$9.4M`-wrap warning / C.4 Chart+Context / C.5 Icon-in-Circle / C.5b 2×2 Grid) with X/Y/W/H tables.
- **Speaker-notes inheritance** from pptx H7.

### morph-ppt (502 → 554)

- **`reference/pptx-design.md` (146 → 254)** — regains Color Principles + Fonts & Typography sections. New **Ghost Discipline & Actor Lifecycle** section explains the per-slide re-ghost rule.
- **`reference/morph-helpers.sh` + `.py` fix** — the CLI JSON schema moved to lowercase (`format`/`children`/`path`/`type`/`text`) but helpers still probed capitalized keys and silently swallowed the KeyError via `except: sys.exit(0)`, so `morph_verify_slide` printed "OK" on every broken deck. All 17 sh / 13 py capitalized uses lowercased; silent exits now surface errors to stderr with exit 2. Live-verified: helpers correctly detect unghosted actors and duplicate text across adjacent slides.
- **`reference/decision-rules.md`** — frontmatter aligned to v2 convention with a How-to-use preamble.
- **Speaker-notes rule** added to inherit pptx H7.

### officecli-xlsx (493)

- **Color coding** — 4 → **5 colors** (red external-link row added) so hardcoded external-file references are visually distinct from in-workbook cross-sheet links.
- **Number formatting** — valuation-multiples row added (`0.0x` for EV/EBITDA, P/E).
- **Hardcode source annotation** — expanded with three canonical examples (10-K / Bloomberg / management guidance) so undocumented assumptions stay flagged for review.
- **P1 sweep:** L447 dead link to `reports/` removed; 58 hardcoded filenames → `"$FILE"`. `data.csv` retained where it names an import source rather than the workbook.

### officecli-docx (680 → 678)

- L62 two-convention rule (literal `doc.docx` vs `$FILE`) unified — every command uses `"$FILE"`, set once at the top of the script. 63 occurrences updated. The two-convention was a recurring source of confusion where Testers wrote literal `doc.docx` into output directories.

### officecli-word-form (666 → 670)

- Monolithic 62-line SOW contract recipe split into three sub-recipes (sow-a boilerplate + cover + parties / sow-b SDT fields + raw-set specials / sow-c watermark + locks + protection) each ≤ 20 lines. The heredoc length cap prevents hidden shell-escape bugs.

## Not in scope

- `officecli-{academic-paper,financial-model,data-dashboard}` — design content already adequate in R3 polish; no changes needed.
- `officecli-animated-pptx` + `morph-ppt-3d` — did not enter v2 flow; remain on their existing trajectory.

## Test plan

- [ ] `morph_verify_slide` against a deck with unghosted `!!actor-*` returns failure with non-empty stderr (was silently "OK" before).
- [ ] pptx SKILL.md renders 10-row palette table + 8-row font-pairing table + 5-row layout-pattern table + 7-bullet avoid list.
- [ ] pitch-deck SKILL.md renders six distinct slide-pattern skeletons (C.1–C.5b) each with X/Y/W/H tables.
- [ ] xlsx SKILL.md §Color coding shows 5 rows (blue/black/green/red/yellow fill).
- [ ] word-form SOW recipe produces three separate fenced blocks each ≤ 20 lines.
- [ ] No hardcoded `doc.docx` / `data.xlsx` / `deck.pptx` in command examples (only in `FILE="…"` variable declarations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)