### PR TITLE
Word/docx batch of correctness fixes (59 commits)

### DIFF
--- a/schemas/help/_shared/chart.json
+++ b/schemas/help/_shared/chart.json
@@ -226,10 +226,10 @@
     },
     "chartFill": {
       "type": "color",
-      "add": false,
-      "set": false,
+      "add": true,
+      "set": true,
       "get": true,
-      "description": "chart-level fill color readback.",
+      "description": "chart-level fill color (accepts #RRGGBB, named colors, or scheme names).",
       "readback": "#RRGGBB or color descriptor",
       "enforcement": "report"
     },
@@ -1280,34 +1280,34 @@
     },
     "title.bold": {
       "type": "bool",
-      "add": false,
-      "set": false,
+      "add": true,
+      "set": true,
       "get": true,
-      "description": "title bold flag (readback only)",
+      "description": "title bold flag.",
       "readback": "true | false"
     },
     "title.color": {
       "type": "color",
-      "add": false,
-      "set": false,
+      "add": true,
+      "set": true,
       "get": true,
-      "description": "title font color (readback only, #RRGGBB)",
+      "description": "title font color (#RRGGBB, named, or scheme color).",
       "readback": "#RRGGBB"
     },
     "title.font": {
       "type": "string",
-      "add": false,
-      "set": false,
+      "add": true,
+      "set": true,
       "get": true,
-      "description": "title font name (readback only)",
+      "description": "title font name.",
       "readback": "font name"
     },
     "title.size": {
       "type": "font-size",
-      "add": false,
-      "set": false,
+      "add": true,
+      "set": true,
       "get": true,
-      "description": "title font size (readback only, e.g. 14pt)",
+      "description": "title font size (e.g. 14 or 14pt).",
       "readback": "Npt"
     },
     "totalColor": {

--- a/schemas/help/docx/document.json
+++ b/schemas/help/docx/document.json
@@ -428,8 +428,17 @@
       "description": "different headers for even/odd pages.",
       "add": false,
       "set": true,
-      "get": false,
-      "readback": "n/a (set-only)",
+      "get": true,
+      "readback": "true when settings/evenAndOddHeaders is present",
+      "enforcement": "report"
+    },
+    "autoHyphenation": {
+      "type": "bool",
+      "description": "enable automatic hyphenation (settings/autoHyphenation).",
+      "add": false,
+      "set": true,
+      "get": true,
+      "readback": "true when settings/autoHyphenation is present",
       "enforcement": "report"
     },
     "defaultTabStop": {

--- a/schemas/help/docx/hyperlink.json
+++ b/schemas/help/docx/hyperlink.json
@@ -61,6 +61,18 @@
       "readback": "concatenated run text",
       "enforcement": "report"
     },
+    "rStyle": {
+      "type": "string",
+      "description": "Run style id applied to the hyperlink's run (typically 'Hyperlink' to inherit theme color/underline).",
+      "add": true,
+      "set": false,
+      "get": true,
+      "examples": [
+        "--prop rStyle=Hyperlink"
+      ],
+      "readback": "style id",
+      "enforcement": "report"
+    },
     "color": {
       "type": "color",
       "description": "override link color (default: theme Hyperlink or 0563C1). Set after Add not supported — formatting lives on inner runs (Set the run, not the hyperlink wrapper).",

--- a/schemas/help/docx/paragraph.json
+++ b/schemas/help/docx/paragraph.json
@@ -924,11 +924,20 @@
     },
     "outlineLvl": {
       "type": "number",
-      "description": "outline level (0-9). Emitted only when present.",
-      "add": false,
-      "set": false,
+      "description": "outline level (0-9). Used by Word's TOC and document map.",
+      "add": true,
+      "set": true,
       "get": true,
       "readback": "integer",
+      "enforcement": "report"
+    },
+    "rStyle": {
+      "type": "string",
+      "description": "Paragraph mark run style id (e.g. FootnoteReference, IntenseEmphasis). Inherited by runs without their own rStyle.",
+      "add": true,
+      "set": true,
+      "get": true,
+      "readback": "style id",
       "enforcement": "report"
     },
     "tabs": {

--- a/schemas/help/docx/picture.json
+++ b/schemas/help/docx/picture.json
@@ -39,7 +39,7 @@
       "add": true,
       "set": true,
       "get": true,
-      "description": "text wrapping mode for floating picture (none, square, tight, topAndBottom, behind, through).",
+      "description": "text wrapping mode for floating picture (none, square, tight, topandbottom, through). For 'behind text', use wrap=none + behindText=true.",
       "examples": [
         "--prop wrap=square"
       ],

--- a/schemas/help/docx/picture.json
+++ b/schemas/help/docx/picture.json
@@ -22,10 +22,34 @@
     "_shared/picture.docx-xlsx"
   ],
   "properties": {
+    "anchor": {
+      "type": "bool",
+      "add": true,
+      "set": false,
+      "get": true,
+      "description": "true to create a floating (anchored) picture instead of inline. Required to enable wrap/hPosition/vPosition/hRelative/vRelative/behindText.",
+      "examples": [
+        "--prop anchor=true --prop wrap=square"
+      ],
+      "readback": "true on floating pictures",
+      "enforcement": "report"
+    },
+    "wrap": {
+      "type": "string",
+      "add": true,
+      "set": true,
+      "get": true,
+      "description": "text wrapping mode for floating picture (none, square, tight, topAndBottom, behind, through).",
+      "examples": [
+        "--prop wrap=square"
+      ],
+      "readback": "wrap token",
+      "enforcement": "report"
+    },
     "behindText": {
       "type": "bool",
-      "add": false,
-      "set": false,
+      "add": true,
+      "set": true,
       "get": true,
       "description": "true when the picture floats behind text (anchor @behindDoc=1).",
       "readback": "true on behind-text floats",
@@ -33,20 +57,44 @@
     },
     "hPosition": {
       "type": "length",
-      "add": false,
-      "set": false,
+      "add": true,
+      "set": true,
       "get": true,
       "description": "absolute horizontal anchor position in cm (positionH/posOffset).",
+      "examples": [
+        "--prop hPosition=3cm"
+      ],
       "readback": "length in cm (e.g. `5.0cm`)",
+      "enforcement": "report"
+    },
+    "vPosition": {
+      "type": "length",
+      "add": true,
+      "set": true,
+      "get": true,
+      "description": "absolute vertical anchor position in cm (positionV/posOffset).",
+      "examples": [
+        "--prop vPosition=4cm"
+      ],
+      "readback": "length in cm (e.g. `4.0cm`)",
       "enforcement": "report"
     },
     "hRelative": {
       "type": "string",
-      "add": false,
-      "set": false,
+      "add": true,
+      "set": true,
       "get": true,
       "description": "horizontal anchor reference frame (e.g. page, margin, column, character).",
       "readback": "OOXML positionH @relativeFrom token",
+      "enforcement": "report"
+    },
+    "vRelative": {
+      "type": "string",
+      "add": true,
+      "set": true,
+      "get": true,
+      "description": "vertical anchor reference frame (e.g. page, margin, paragraph, line).",
+      "readback": "OOXML positionV @relativeFrom token",
       "enforcement": "report"
     },
     "width": {

--- a/src/officecli/BatchTypes.cs
+++ b/src/officecli/BatchTypes.cs
@@ -99,6 +99,8 @@ internal class BatchItemConverter : JsonConverter<BatchItem>
         if (value.Type != null) writer.WriteString("type", value.Type);
         if (value.From != null) writer.WriteString("from", value.From);
         if (value.Index.HasValue) writer.WriteNumber("index", value.Index.Value);
+        if (value.After != null) writer.WriteString("after", value.After);
+        if (value.Before != null) writer.WriteString("before", value.Before);
         if (value.To != null) writer.WriteString("to", value.To);
         if (value.Props != null) { writer.WritePropertyName("props"); PropsConverter.Write(writer, value.Props, options); }
         if (value.Selector != null) writer.WriteString("selector", value.Selector);

--- a/src/officecli/CommandBuilder.Batch.cs
+++ b/src/officecli/CommandBuilder.Batch.cs
@@ -98,6 +98,16 @@ static partial class CommandBuilder
             }
             if (items.Count == 0)
             {
+                // BUG-R6-07: empty command array previously short-circuited
+                // before the file-existence check, so
+                //   officecli batch /missing.docx --commands '[]' --json
+                // returned a clean zero-result success instead of the
+                // expected file_not_found. Validate the target file
+                // exists first so empty-array semantics match the
+                // non-empty path's diagnostics.
+                if (!file.Exists)
+                    throw new CliException($"File not found: {file.FullName}")
+                        { Code = "file_not_found" };
                 PrintBatchResults(new List<BatchResult>(), json, 0);
                 return 0;
             }

--- a/src/officecli/CommandBuilder.Batch.cs
+++ b/src/officecli/CommandBuilder.Batch.cs
@@ -187,7 +187,23 @@ static partial class CommandBuilder
                     if (stopOnError) break;
                 }
             }
-            PrintBatchResults(batchResults, json, items.Count);
+            // BUG-R6-02: in --json mode the non-resident path emitted the raw
+            // {"results":...,"summary":...} body while the resident path
+            // wrapped it in {"success":..., "data":{...}} (resident server
+            // calls OutputFormatter.WrapEnvelope on any JSON-shaped stdout).
+            // Capture PrintBatchResults output and apply the same envelope
+            // here so callers see the same shape regardless of resident state.
+            if (json)
+            {
+                using var sw = new System.IO.StringWriter();
+                PrintBatchResults(batchResults, json, items.Count, sw);
+                var inner = sw.ToString().TrimEnd('\n', '\r');
+                Console.WriteLine(OfficeCli.Core.OutputFormatter.WrapEnvelope(inner));
+            }
+            else
+            {
+                PrintBatchResults(batchResults, json, items.Count);
+            }
             if (batchResults.Any(r => r.Success))
                 NotifyWatch(handler, file.FullName, null);
             return batchResults.Any(r => !r.Success) ? 1 : 0;

--- a/src/officecli/CommandBuilder.Batch.cs
+++ b/src/officecli/CommandBuilder.Batch.cs
@@ -45,6 +45,28 @@ static partial class CommandBuilder
             var forceFlag = result.GetValue(batchForceOpt);
 
             string jsonText;
+            // BUG-R7-09 (F-6): previously --commands/--input/stdin were
+            // silently prioritized in that order — passing two of them at
+            // once dropped the lower-priority source with no warning, so
+            // scripts could fail subtly when an agent piped data into a
+            // command that already had --commands set. Reject the
+            // combination loudly. (Detect stdin via Console.IsInputRedirected
+            // to avoid spurious failures from interactive terminals.)
+            bool stdinHasInput = Console.IsInputRedirected;
+            int sourceCount = (inlineCommands != null ? 1 : 0)
+                            + (inputFile != null ? 1 : 0)
+                            + ((inlineCommands == null && inputFile == null && stdinHasInput) ? 1 : 0);
+            if (inlineCommands != null && inputFile != null)
+                throw new ArgumentException(
+                    "batch: --commands and --input are mutually exclusive. Pick one source.");
+            if ((inlineCommands != null || inputFile != null) && stdinHasInput
+                && Environment.GetEnvironmentVariable("OFFICECLI_BATCH_ALLOW_STDIN_REDIRECT") == null)
+            {
+                Console.Error.WriteLine(
+                    "Warning: batch is reading from --commands/--input but stdin is also redirected; "
+                    + "stdin will be ignored. Pass only one source to silence this warning, or set "
+                    + "OFFICECLI_BATCH_ALLOW_STDIN_REDIRECT=1.");
+            }
             if (inlineCommands != null)
             {
                 jsonText = inlineCommands;
@@ -65,6 +87,19 @@ static partial class CommandBuilder
 
             // Pre-validate: check for unknown JSON fields before deserializing
             using var jsonDoc = System.Text.Json.JsonDocument.Parse(jsonText);
+            // BUG-R7-10: when the batch input is a JSON object/string/etc.
+            // (not an array), Deserialize<List<BatchItem>> threw a generic
+            // JsonException whose message exposed the C# generic type name
+            // (`System.Collections.Generic.List`1[OfficeCli.BatchItem]`).
+            // Convert it to a human-friendly error first so AI agents and
+            // humans see a stable, model-agnostic diagnostic.
+            if (jsonDoc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Array
+                && jsonDoc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Null)
+            {
+                throw new ArgumentException(
+                    $"Batch input must be a JSON array. Got: {jsonDoc.RootElement.ValueKind.ToString().ToLowerInvariant()}. "
+                    + "Wrap a single item like [{\"command\":\"get\",\"path\":\"/\"}].");
+            }
             if (jsonDoc.RootElement.ValueKind == System.Text.Json.JsonValueKind.Array)
             {
                 int ri = 0;
@@ -108,7 +143,22 @@ static partial class CommandBuilder
                 if (!file.Exists)
                     throw new CliException($"File not found: {file.FullName}")
                         { Code = "file_not_found" };
-                PrintBatchResults(new List<BatchResult>(), json, 0);
+                // BUG-R7-09: in --json mode an empty/null batch input
+                // previously skipped the {"success":...,"data":{...}}
+                // envelope used by the populated-array path, so AI agents
+                // saw a missing `success` key. Apply the same envelope
+                // wrap here for shape parity.
+                if (json)
+                {
+                    using var sw = new System.IO.StringWriter();
+                    PrintBatchResults(new List<BatchResult>(), json, 0, sw);
+                    var inner = sw.ToString().TrimEnd('\n', '\r');
+                    Console.WriteLine(OfficeCli.Core.OutputFormatter.WrapEnvelope(inner));
+                }
+                else
+                {
+                    PrintBatchResults(new List<BatchResult>(), json, 0);
+                }
                 return 0;
             }
 

--- a/src/officecli/CommandBuilder.Batch.cs
+++ b/src/officecli/CommandBuilder.Batch.cs
@@ -53,9 +53,6 @@ static partial class CommandBuilder
             // combination loudly. (Detect stdin via Console.IsInputRedirected
             // to avoid spurious failures from interactive terminals.)
             bool stdinHasInput = Console.IsInputRedirected;
-            int sourceCount = (inlineCommands != null ? 1 : 0)
-                            + (inputFile != null ? 1 : 0)
-                            + ((inlineCommands == null && inputFile == null && stdinHasInput) ? 1 : 0);
             if (inlineCommands != null && inputFile != null)
                 throw new ArgumentException(
                     "batch: --commands and --input are mutually exclusive. Pick one source.");
@@ -114,7 +111,7 @@ static partial class CommandBuilder
                                 unknown.Add(prop.Name);
                         }
                         if (unknown.Count > 0)
-                            throw new ArgumentException($"batch item[{ri}]: unknown field(s) {string.Join(", ", unknown.Select(f => $"\"{f}\""))}. Valid fields: command, parent, path, type, from, index, to, props, selector, text, mode, depth, part, xpath, action, xml");
+                            throw new ArgumentException($"batch item[{ri}]: unknown field(s) {string.Join(", ", unknown.Select(f => $"\"{f}\""))}. Valid fields: {string.Join(", ", BatchItem.KnownFields)}");
                     }
                     ri++;
                 }

--- a/src/officecli/CommandBuilder.Batch.cs
+++ b/src/officecli/CommandBuilder.Batch.cs
@@ -14,12 +14,22 @@ static partial class CommandBuilder
         var batchFileArg = new Argument<FileInfo>("file") { Description = "Office document path" };
         var batchInputOpt = new Option<FileInfo?>("--input") { Description = "JSON file containing batch commands. If omitted, reads from stdin" };
         var batchCommandsOpt = new Option<string?>("--commands") { Description = "Inline JSON array of batch commands (alternative to --input or stdin)" };
-        var batchForceOpt = new Option<bool>("--force") { Description = "Continue execution even if a command fails (default: stop on first error)" };
+        // BUG-R4-BT2: default flipped to continue-on-error. A 700-command
+        // dump replay losing 80% of the document on the first failing item
+        // (e.g. one unsupported prop) is a far worse default than reporting
+        // the failure and letting the rest of the batch through. Errors are
+        // still surfaced individually (BatchResult.Error) and the overall
+        // exit code is 1 if any item failed, so callers can still tell
+        // "everything succeeded". `--stop-on-error` opts back into the
+        // strict abort-on-first-failure flow for callers who depend on it.
+        var batchForceOpt = new Option<bool>("--force") { Description = "Deprecated alias for the default continue-on-error mode (kept for compatibility)" };
+        var batchStopOpt = new Option<bool>("--stop-on-error") { Description = "Abort the batch as soon as any command fails (default: continue and report per-item errors)" };
         var batchCommand = new Command("batch", "Execute multiple commands from a JSON array (one open/save cycle)");
         batchCommand.Add(batchFileArg);
         batchCommand.Add(batchInputOpt);
         batchCommand.Add(batchCommandsOpt);
         batchCommand.Add(batchForceOpt);
+        batchCommand.Add(batchStopOpt);
         batchCommand.Add(jsonOption);
 
         batchCommand.SetAction(result => { var json = result.GetValue(jsonOption); return SafeRun(() =>
@@ -27,7 +37,12 @@ static partial class CommandBuilder
             var file = result.GetValue(batchFileArg)!;
             var inputFile = result.GetValue(batchInputOpt);
             var inlineCommands = result.GetValue(batchCommandsOpt);
-            var stopOnError = !result.GetValue(batchForceOpt);
+            // Default: continue on error. --stop-on-error flips it to strict.
+            // --force still acts as the docx-protection bypass (matches set
+            // --force semantics) but no longer doubles as the continue-on-
+            // error switch.
+            var stopOnError = result.GetValue(batchStopOpt);
+            var forceFlag = result.GetValue(batchForceOpt);
 
             string jsonText;
             if (inlineCommands != null)
@@ -99,7 +114,7 @@ static partial class CommandBuilder
             // CONSISTENCY(docx-protection): if you change the protection
             // semantics, also update CommandBuilder.Set.cs at the matching
             // CheckDocxProtection call site.
-            var force = !stopOnError;
+            var force = forceFlag;
             if (!force && file.Extension.Equals(".docx", StringComparison.OrdinalIgnoreCase))
             {
                 foreach (var batchItem in items)
@@ -133,7 +148,8 @@ static partial class CommandBuilder
                     Args =
                     {
                         ["batchJson"] = jsonText,
-                        ["force"] = force.ToString()
+                        ["force"] = force.ToString(),
+                        ["stopOnError"] = stopOnError.ToString()
                     }
                 };
                 // CONSISTENCY(resident-two-step): long connectTimeoutMs so the

--- a/src/officecli/CommandBuilder.Dump.cs
+++ b/src/officecli/CommandBuilder.Dump.cs
@@ -59,10 +59,28 @@ static partial class CommandBuilder
                 outPath = null;
             if (outPath != null)
             {
+                // The on-disk file is the canonical batch wire form (bare
+                // JSON array) so it can feed `batch --input <file>`
+                // unchanged — wrapping it in an envelope would break
+                // batch consumption.
                 File.WriteAllText(outPath, output);
                 if (json)
-                    Console.WriteLine(OutputFormatter.WrapEnvelope(
-                        "\"" + outPath.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""));
+                {
+                    // BUG-R6-01: previously stdout returned
+                    //   {"success": true, "data": "/tmp/out.json"}
+                    // which was indistinguishable in shape from the
+                    // no-out form (data is array). Make the file mode's
+                    // envelope unambiguous by surfacing structured
+                    // metadata under `data` instead of a bare path
+                    // string. Callers can detect "data has outputFile" to
+                    // disambiguate.
+                    var meta = new System.Text.Json.Nodes.JsonObject
+                    {
+                        ["outputFile"] = outPath,
+                        ["itemCount"] = items.Count
+                    };
+                    Console.WriteLine(OutputFormatter.WrapEnvelope(meta.ToJsonString()));
+                }
                 else
                     Console.WriteLine(outPath);
             }

--- a/src/officecli/CommandBuilder.Dump.cs
+++ b/src/officecli/CommandBuilder.Dump.cs
@@ -52,6 +52,12 @@ static partial class CommandBuilder
             // dropped the dead options block.
             var output = JsonSerializer.Serialize(items, BatchJsonContext.Default.ListBatchItem);
             var json = result.GetValue(jsonOption);
+            // BUG-R4-FUZZ-3: Unix convention — `--out -` means stdout, not a
+            // file literally named "-". Without this, running `dump --out -`
+            // silently created a `-` file in the cwd (and could pollute the
+            // project tree if invoked from inside it).
+            if (outPath == "-")
+                outPath = null;
             if (outPath != null)
             {
                 File.WriteAllText(outPath, output);

--- a/src/officecli/CommandBuilder.Dump.cs
+++ b/src/officecli/CommandBuilder.Dump.cs
@@ -26,7 +26,7 @@ static partial class CommandBuilder
         dumpCommand.Add(outOpt);
         dumpCommand.Add(jsonOption);
 
-        dumpCommand.SetAction(result => SafeRun(() =>
+        dumpCommand.SetAction(result => { var json = result.GetValue(jsonOption); return SafeRun(() =>
         {
             var file = result.GetValue(dumpFileArg)!;
             var format = (result.GetValue(formatOpt) ?? "batch").ToLowerInvariant();
@@ -51,7 +51,6 @@ static partial class CommandBuilder
             // never threaded into Serialize — kept the compact behavior, just
             // dropped the dead options block.
             var output = JsonSerializer.Serialize(items, BatchJsonContext.Default.ListBatchItem);
-            var json = result.GetValue(jsonOption);
             // BUG-R4-FUZZ-3: Unix convention — `--out -` means stdout, not a
             // file literally named "-". Without this, running `dump --out -`
             // silently created a `-` file in the cwd (and could pollute the
@@ -75,7 +74,7 @@ static partial class CommandBuilder
                     Console.WriteLine(output);
             }
             return 0;
-        }));
+        }, json); });
 
         return dumpCommand;
     }

--- a/src/officecli/Core/BatchEmitter.cs
+++ b/src/officecli/Core/BatchEmitter.cs
@@ -419,17 +419,6 @@ public static class BatchEmitter
         });
     }
 
-    // Mirror of AddStyle's builtInIds set — these styles ship in every
-    // blank template, so EmitStyles must use `set` instead of `add` to
-    // avoid "already exists" errors on round-trip into a fresh document.
-    private static readonly HashSet<string> BuiltInStyleIds = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "Normal", "Heading1", "Heading2", "Heading3", "Heading4", "Heading5",
-        "Heading6", "Heading7", "Heading8", "Heading9", "Title", "Subtitle",
-        "Quote", "IntenseQuote", "ListParagraph", "NoSpacing", "TOCHeading",
-        "DefaultParagraphFont", "TableNormal", "NoList",
-    };
-
     private static void EmitStyles(WordHandler word, List<BatchItem> items)
     {
         // Use query() rather than walking Get("/styles").Children — the
@@ -455,43 +444,20 @@ public static class BatchEmitter
                 if (props.TryGetValue("name", out var n)) props["id"] = n;
                 else continue;
             }
-            // BUG-R6-03: built-in styles (Normal / Heading1-9 / Title /
-            // Subtitle / Quote / IntenseQuote / ListParagraph / NoSpacing /
-            // TOCHeading) are present in every blank template, so emitting
-            // `add` for them on a fresh batch target fails with
-            // "Style 'X' already exists". Emit `set` on /styles/<id> for
-            // those — it's already an upsert-on-existing path — so a real
-            // document's customised Normal/Heading values land on the
-            // template's built-ins instead of being rejected.
-            var styleIdGuess = props.TryGetValue("id", out var sidGuess) ? sidGuess
-                : props.TryGetValue("styleId", out sidGuess) ? sidGuess : null;
-            bool isBuiltInStyle = styleIdGuess != null && BuiltInStyleIds.Contains(styleIdGuess);
-            if (isBuiltInStyle)
+            // BUG-R6-03: built-in style ids (Normal / Heading1-9 / Title /
+            // …) collide with the blank template's reservations on a
+            // fresh batch target. AddStyle is now idempotent for those
+            // specific ids (upsert: drop existing + re-add). For non-
+            // built-in ids the strict "already exists" check still
+            // applies. Emit `add` uniformly so the wire format stays a
+            // simple `add`-only stream regardless of style provenance.
+            items.Add(new BatchItem
             {
-                // /styles/<id> set rejects keys it doesn't model; strip the
-                // identity-only bag (id/styleId/name/type) since those
-                // would no-op anyway.
-                var setProps = new Dictionary<string, string>(props, StringComparer.OrdinalIgnoreCase);
-                setProps.Remove("id");
-                setProps.Remove("styleId");
-                setProps.Remove("type");
-                items.Add(new BatchItem
-                {
-                    Command = "set",
-                    Path = $"/styles/{styleIdGuess}",
-                    Props = setProps
-                });
-            }
-            else
-            {
-                items.Add(new BatchItem
-                {
-                    Command = "add",
-                    Parent = "/styles",
-                    Type = "style",
-                    Props = props
-                });
-            }
+                Command = "add",
+                Parent = "/styles",
+                Type = "style",
+                Props = props
+            });
             // BUG-R4-T1: FilterEmittableProps drops the `tabs` scalar (it's a
             // List<Dict>, not stringable). EmitParagraph compensates by
             // emitting per-stop `add tab` rows; EmitStyles must do the same

--- a/src/officecli/Core/BatchEmitter.cs
+++ b/src/officecli/Core/BatchEmitter.cs
@@ -127,70 +127,82 @@ public static class BatchEmitter
     {
         var root = word.Get("/");
         if (root.Children == null) return;
+        // BUG-R4-T2: header/footer parts carry no `type` key on Get; the
+        // section's `headerRef.default|first|even` (and `footerRef.*`)
+        // entries are the only place the part's role is recorded. Build a
+        // reverse lookup so EmitHeaderFooterPart can emit the right
+        // `type` prop (default/first/even) instead of always emitting
+        // "default" — which on a doc with both default + first headers
+        // throws "Header of type 'default' already exists" on replay.
+        var headerPathToType = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var footerPathToType = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, val) in root.Format)
+        {
+            if (val == null) continue;
+            var s = val.ToString();
+            if (string.IsNullOrEmpty(s)) continue;
+            if (key.StartsWith("headerRef.", StringComparison.OrdinalIgnoreCase))
+            {
+                var t = key["headerRef.".Length..];
+                if (!headerPathToType.ContainsKey(s)) headerPathToType[s] = t;
+            }
+            else if (key.StartsWith("footerRef.", StringComparison.OrdinalIgnoreCase))
+            {
+                var t = key["footerRef.".Length..];
+                if (!footerPathToType.ContainsKey(s)) footerPathToType[s] = t;
+            }
+        }
+
         int hIdx = 0, fIdx = 0;
         foreach (var child in root.Children)
         {
             if (child.Type == "header")
             {
                 hIdx++;
-                EmitHeaderFooterPart(word, child.Path, "header", hIdx, items);
+                var t = headerPathToType.TryGetValue(child.Path, out var ht) ? ht : "default";
+                EmitHeaderFooterPart(word, child.Path, "header", hIdx, items, t);
             }
             else if (child.Type == "footer")
             {
                 fIdx++;
-                EmitHeaderFooterPart(word, child.Path, "footer", fIdx, items);
+                var t = footerPathToType.TryGetValue(child.Path, out var ft) ? ft : "default";
+                EmitHeaderFooterPart(word, child.Path, "footer", fIdx, items, t);
             }
         }
     }
 
     private static void EmitHeaderFooterPart(WordHandler word, string sourcePath, string kind,
-                                             int targetIndex, List<BatchItem> items)
+                                             int targetIndex, List<BatchItem> items,
+                                             string subTypeOverride = "default")
     {
         var partNode = word.Get(sourcePath);
         var paras = (partNode.Children ?? new List<DocumentNode>())
             .Where(c => c.Type == "paragraph" || c.Type == "p")
             .ToList();
-        var subType = partNode.Format.TryGetValue("type", out var t) ? t?.ToString() ?? "default" : "default";
+        // partNode.Format does not expose `type`; the caller resolves the
+        // role (default/first/even) from the section's headerRef.* / footerRef.*
+        // map and passes it via subTypeOverride.
+        var subType = subTypeOverride;
 
-        // Seed the part with the first paragraph's text (AddHeader/AddFooter
-        // create a single auto paragraph and accept text/align/style on it).
-        // Multi-run first paragraphs collapse into a flat text string here —
-        // run-level formatting on the seed paragraph is a v0.5 lossy item.
-        var seedProps = new Dictionary<string, string> { ["type"] = subType };
-        if (paras.Count > 0)
-        {
-            // Get on /header[1] returns paragraph stubs without their run
-            // children — re-Get the first paragraph to surface its runs.
-            var firstPara = word.Get(paras[0].Path);
-            var firstRuns = (firstPara.Children ?? new List<DocumentNode>())
-                .Where(c => c.Type == "run" || c.Type == "r")
-                .ToList();
-            if (firstRuns.Count == 1 && !string.IsNullOrEmpty(firstRuns[0].Text))
-            {
-                seedProps["text"] = firstRuns[0].Text!;
-                var runProps = FilterEmittableProps(firstRuns[0].Format);
-                foreach (var (k, v) in runProps)
-                    if (!seedProps.ContainsKey(k)) seedProps[k] = v;
-            }
-            else if (firstRuns.Count >= 1)
-            {
-                // Multi-run: collapse plain text only, drop per-run formatting.
-                seedProps["text"] = string.Join("", firstRuns.Select(r => r.Text ?? ""));
-            }
-        }
+        // Create the part with just its role (default/first/even). AddHeader/
+        // AddFooter seed an empty auto paragraph; EmitParagraph(autoPresent:
+        // true) on paras[0] then routes through CollapseFieldChains so a
+        // PAGE-field header (the canonical case) round-trips as a typed
+        // `add field` row instead of being baked into static "1" text on the
+        // seed paragraph (BUG-R4-T3). Run-level formatting on multi-run
+        // first paragraphs is preserved by the per-run emit path below.
         items.Add(new BatchItem
         {
             Command = "add",
             Parent = "/",
             Type = kind,
-            Props = seedProps
+            Props = new Dictionary<string, string> { ["type"] = subType }
         });
 
-        // Additional paragraphs (>= 2nd) appended to the part directly.
         var partTargetPath = $"/{kind}[{targetIndex}]";
-        for (int p = 1; p < paras.Count; p++)
+        for (int p = 0; p < paras.Count; p++)
         {
-            EmitParagraph(word, paras[p].Path, partTargetPath, p + 1, items, autoPresent: false);
+            EmitParagraph(word, paras[p].Path, partTargetPath, p + 1, items, autoPresent: p == 0);
         }
     }
 
@@ -409,6 +421,17 @@ public static class BatchEmitter
                 Type = "style",
                 Props = props
             });
+            // BUG-R4-T1: FilterEmittableProps drops the `tabs` scalar (it's a
+            // List<Dict>, not stringable). EmitParagraph compensates by
+            // emitting per-stop `add tab` rows; EmitStyles must do the same
+            // or paragraph-level custom tab stops on a style (Heading TOC
+            // leader tabs, etc.) silently disappear on round-trip.
+            var styleId = props.TryGetValue("id", out var sid) ? sid
+                : props.TryGetValue("styleId", out sid) ? sid : null;
+            if (styleId != null && full.Format.TryGetValue("tabs", out var styleTabs))
+            {
+                EmitTabStops($"/styles/{styleId}", styleTabs, items);
+            }
         }
     }
 
@@ -463,8 +486,24 @@ public static class BatchEmitter
             {
                 case "paragraph":
                 case "p":
-                    pIndex++;
-                    EmitParagraph(word, child.Path, "/body", pIndex, items, autoPresent: false, ctx);
+                    // BUG-R4-FUZZ-1: display-mode equations surface in
+                    // bodyNode.Children as type="paragraph" but the path
+                    // resolver addresses them as /body/oMathPara[N], NOT as
+                    // /body/p[N]. Incrementing pIndex for them would offset
+                    // every subsequent inline-child path (hyperlink/footnote/
+                    // run) by +1 per preceding equation, breaking round-trip.
+                    // Detect the wrapper via path and route to EmitParagraph
+                    // without bumping pIndex — EmitParagraph's equation branch
+                    // re-emits the equation as `add /body --type equation`.
+                    if (child.Path.Contains("/oMathPara[", StringComparison.OrdinalIgnoreCase))
+                    {
+                        EmitParagraph(word, child.Path, "/body", pIndex + 1, items, autoPresent: false, ctx);
+                    }
+                    else
+                    {
+                        pIndex++;
+                        EmitParagraph(word, child.Path, "/body", pIndex, items, autoPresent: false, ctx);
+                    }
                     break;
                 case "table":
                     tblIndex++;
@@ -638,9 +677,20 @@ public static class BatchEmitter
         // re-emitted as `add hyperlink` below.
         bool singleRunIsHyperlink = runs.Count == 1 &&
             (runs[0].Format.ContainsKey("url") || runs[0].Format.ContainsKey("anchor"));
+        // BUG-R4-FUZZ-2: when a paragraph's sole run is a footnote/endnote
+        // reference (rStyle=FootnoteReference / EndnoteReference), collapsing
+        // the run into the paragraph prop bag emits `add p props={rStyle=...}`
+        // and drops the typed `add footnote/endnote` row entirely (Add does
+        // not consume rStyle on a paragraph; the note text is lost). Force
+        // the multi-run path so the dedicated note-emit branch below fires.
+        bool singleRunIsNoteRef = runs.Count == 1 &&
+            runs[0].Format.TryGetValue("rStyle", out var srStyle)
+            && (string.Equals(srStyle?.ToString(), "FootnoteReference", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(srStyle?.ToString(), "EndnoteReference", StringComparison.OrdinalIgnoreCase));
         bool collapseSingleRun = runs.Count <= 1 &&
             !(runs.Count == 1 && runs[0].Type == "picture") &&
             !singleRunIsHyperlink &&
+            !singleRunIsNoteRef &&
             breaks.Count == 0;
         // Pull paragraph-level tab stops out for per-stop `add tab` emit
         // (FilterEmittableProps already drops the `tabs` scalar).

--- a/src/officecli/Core/BatchEmitter.cs
+++ b/src/officecli/Core/BatchEmitter.cs
@@ -386,9 +386,15 @@ public static class BatchEmitter
         var styles = word.Query("style");
         foreach (var stub in styles)
         {
+            // CONSISTENCY(slash-in-style-id): style ids/names containing '/'
+            // produce paths like /styles/Style/With/Slash that the path
+            // parser splits on. Get fails. Fall back to the Query stub —
+            // we lose pPr/rPr details but at least the style stub
+            // (id/name/type/basedOn) round-trips, instead of dropping the
+            // style entirely (BUG BT-3).
             DocumentNode full;
             try { full = word.Get(stub.Path); }
-            catch { continue; }
+            catch { full = stub; }
             var props = FilterEmittableProps(full.Format);
             // Ensure id is present (Add requires it for /styles target).
             if (!props.ContainsKey("id") && !props.ContainsKey("styleId"))
@@ -1300,6 +1306,12 @@ public static class BatchEmitter
         // for them, cause double-application. Drop the aliases so the
         // dump bag stays minimal.
         "styleId", "styleName",
+        // CONSISTENCY(line-rule-inferred): style/paragraph Get emits `lineRule`
+        // alongside `lineSpacing`, but lineSpacing already encodes the rule
+        // (e.g. "1.5x" => Auto, "18pt" => Exact via SpacingConverter). Set has
+        // no `lineRule` case, so emitting it produces "UNSUPPORTED" warnings
+        // (104+ on a typical real-world doc). Drop it from dump.
+        "lineRule",
     };
 
     // Serialize the tabs list (List<Dictionary<string,object?>>) to the
@@ -1326,11 +1338,68 @@ public static class BatchEmitter
     private static Dictionary<string, string> FilterEmittableProps(Dictionary<string, object?> raw)
     {
         var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        // CONSISTENCY(border-fold): Get emits `pbdr.bottom: single`,
+        // `pbdr.bottom.sz: 6`, `pbdr.bottom.color: #FF0000`, `pbdr.bottom.space: 1`
+        // as separate keys (mirrors `border.*` on Excel). Set accepts a single
+        // colon-encoded value `pbdr.bottom=single:6:#FF0000:1`. Without folding,
+        // the 2-segment key applies an empty-style border and the 3-segment
+        // subkeys hit unsupported (BUG BT-6: Title/Intense Quote lose bottom
+        // border on round-trip). Fold the 4 keys into one before validation.
+        var pbdrFold = new Dictionary<string, (string? style, string? sz, string? color, string? space)>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, val) in raw)
+        {
+            if (val == null) continue;
+            if (!key.StartsWith("pbdr.", StringComparison.OrdinalIgnoreCase)) continue;
+            var parts = key.Split('.');
+            if (parts.Length < 2) continue;
+            var side = $"{parts[0]}.{parts[1]}"; // pbdr.bottom
+            pbdrFold.TryGetValue(side, out var cur);
+            var sval = val.ToString() ?? "";
+            if (parts.Length == 2) cur.style = sval;
+            else if (parts.Length == 3)
+            {
+                switch (parts[2].ToLowerInvariant())
+                {
+                    case "sz": cur.sz = sval; break;
+                    case "color": cur.color = sval; break;
+                    case "space": cur.space = sval; break;
+                }
+            }
+            pbdrFold[side] = cur;
+        }
+
         foreach (var (key, val) in raw)
         {
             if (SkipKeys.Contains(key)) continue;
             if (key.StartsWith("effective.", StringComparison.OrdinalIgnoreCase)) continue;
             if (key.EndsWith(".cs.source", StringComparison.OrdinalIgnoreCase)) continue;
+
+            // pbdr fold: skip subkeys, rewrite the bare side key into colon form.
+            if (key.StartsWith("pbdr.", StringComparison.OrdinalIgnoreCase))
+            {
+                var parts = key.Split('.');
+                if (parts.Length >= 3) continue; // subkey already folded
+                var side = $"{parts[0]}.{parts[1]}";
+                if (pbdrFold.TryGetValue(side, out var folded) && folded.style != null)
+                {
+                    // ParseBorderValue format: STYLE[;SIZE[;COLOR[;SPACE]]] — empties
+                    // for missing intermediates so positional parts stay aligned.
+                    var sz = folded.sz ?? "";
+                    var col = folded.color ?? "";
+                    var sp = folded.space ?? "";
+                    var v = folded.style!;
+                    if (folded.sz != null || folded.color != null || folded.space != null)
+                        v += ";" + sz;
+                    if (folded.color != null || folded.space != null)
+                        v += ";" + col;
+                    if (folded.space != null)
+                        v += ";" + sp;
+                    result[key] = v;
+                }
+                continue;
+            }
 
             // BORDER subattr asymmetry: Get exposes `border.top: single` AND
             // `border.top.sz: 4` / `border.top.color: 808080` as separate keys,

--- a/src/officecli/Core/BatchEmitter.cs
+++ b/src/officecli/Core/BatchEmitter.cs
@@ -399,6 +399,17 @@ public static class BatchEmitter
             props.Remove("docDefaults.font");
             props["docDefaults.font.latin"] = bareFont;
         }
+        // BUG-R6-05: BlankDocCreator stamps `Times New Roman` into
+        // docDefaults RunFonts. Source docs that omit the slot (use theme
+        // fonts) round-trip with the blank's TNR baked in. Force an
+        // explicit empty `docDefaults.font.latin=` so the Set path clears
+        // the blank's TNR back to absent. Same for docGrid.type which the
+        // blank sets to `default`.
+        if (!props.ContainsKey("docDefaults.font.latin")
+            && !props.ContainsKey("docDefaults.font"))
+        {
+            props["docDefaults.font.latin"] = "";
+        }
         if (props.Count == 0) return;
         items.Add(new BatchItem
         {

--- a/src/officecli/Core/BatchEmitter.cs
+++ b/src/officecli/Core/BatchEmitter.cs
@@ -248,10 +248,11 @@ public static class BatchEmitter
             // The comment id is allocated by AddComment on the target side;
             // do not propagate the source id (would conflict on replay).
             props.Remove("id");
-            // Date is auto-stamped by the SDK on add — emitting it would
-            // overwrite the user's local "now" with the source moment, which
-            // is rarely the desired round-trip behaviour.
-            props.Remove("date");
+            // BUG-R7-04 (T-4): previously dropped `date` so dump→replay always
+            // re-stamped the comment with the SDK's "now". That breaks
+            // archival / audit-trail use cases where the source timestamp is
+            // load-bearing. Preserve it; AddComment accepts an explicit
+            // ISO-8601 date and the SDK will use it instead of stamping.
 
             items.Add(new BatchItem
             {
@@ -736,12 +737,24 @@ public static class BatchEmitter
             runs[0].Format.TryGetValue("rStyle", out var srStyle)
             && (string.Equals(srStyle?.ToString(), "FootnoteReference", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(srStyle?.ToString(), "EndnoteReference", StringComparison.OrdinalIgnoreCase));
+        // BUG-R7-05: a synthetic field run (from CollapseFieldChains) carries
+        // `instruction=PAGE` + `text="1"` — collapsing those onto the
+        // paragraph emits `set /footer[1]/p[1] instruction=PAGE text=1` which
+        // ApplyParagraphLevelProperty doesn't translate into an actual field
+        // chain (paragraph just becomes static text "1"). Force the multi-run
+        // path so the field run is re-emitted as `add field` and the chain
+        // is rebuilt on replay. Header parts hit this same code path; the
+        // bug surfaces in footers because header documents in earlier rounds
+        // happened to have multiple runs that already forced the multi-run
+        // branch.
+        bool singleRunIsField = runs.Count == 1 && runs[0].Type == "field";
         bool collapseSingleRun = runs.Count <= 1 &&
             !(runs.Count == 1 && runs[0].Type == "picture") &&
             !(runs.Count == 1 && runs[0].Type == "ptab") &&
             !singleRunIsHyperlink &&
             !singleRunIsNoteRef &&
             !singleRunHasW14 &&
+            !singleRunIsField &&
             breaks.Count == 0;
         // Pull paragraph-level tab stops out for per-stop `add tab` emit
         // (FilterEmittableProps already drops the `tabs` scalar).
@@ -1569,6 +1582,37 @@ public static class BatchEmitter
             pbdrFold[side] = cur;
         }
 
+        // BUG-R7-04: same fold for table `border.*` keys. Get emits
+        // `border.top: single`, `border.top.sz: 12`, `border.top.color: #000000`
+        // separately; Set accepts only the colon-encoded form
+        // `border.top=single;12;#000000;1`. Without folding, dump strips the
+        // 3-segment subkeys (see the explicit "drop them here" comment below)
+        // and round-trip silently downgrades real borders to default thin
+        // single. Fold sz/color/space into the 2-segment key.
+        var borderFold = new Dictionary<string, (string? style, string? sz, string? color, string? space)>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, val) in raw)
+        {
+            if (val == null) continue;
+            if (!key.StartsWith("border.", StringComparison.OrdinalIgnoreCase)) continue;
+            var parts = key.Split('.');
+            if (parts.Length < 2) continue;
+            var side = $"{parts[0]}.{parts[1]}"; // border.top
+            borderFold.TryGetValue(side, out var cur);
+            var sval = val.ToString() ?? "";
+            if (parts.Length == 2) cur.style = sval;
+            else if (parts.Length == 3)
+            {
+                switch (parts[2].ToLowerInvariant())
+                {
+                    case "sz": cur.sz = sval; break;
+                    case "color": cur.color = sval; break;
+                    case "space": cur.space = sval; break;
+                }
+            }
+            borderFold[side] = cur;
+        }
+
         foreach (var (key, val) in raw)
         {
             if (SkipKeys.Contains(key)) continue;
@@ -1600,17 +1644,29 @@ public static class BatchEmitter
                 continue;
             }
 
-            // BORDER subattr asymmetry: Get exposes `border.top: single` AND
-            // `border.top.sz: 4` / `border.top.color: 808080` as separate keys,
-            // but Set's case table stops at the 2-segment level — the 3-segment
-            // sub-attribute keys would be misrouted through ApplyTableBorders'
-            // dotted fallback and crash on `Invalid border style: '4'`. Drop
-            // them here as a known lossy projection until Set grows the
-            // matching cases (border width / color readback survive only via
-            // the main `border.*` style key for now).
-            if (key.StartsWith("border.", StringComparison.OrdinalIgnoreCase) &&
-                key.Count(ch => ch == '.') >= 2)
+            // BUG-R7-04: fold border.* like pbdr.*. Skip the 3-segment subkeys
+            // (folded into the 2-segment side key below) and rewrite the bare
+            // side key into the colon-encoded form Set's ParseBorderValue
+            // expects.
+            if (key.StartsWith("border.", StringComparison.OrdinalIgnoreCase))
             {
+                var bparts = key.Split('.');
+                if (bparts.Length >= 3) continue; // subkey already folded
+                var bside = $"{bparts[0]}.{bparts[1]}";
+                if (borderFold.TryGetValue(bside, out var folded) && folded.style != null)
+                {
+                    var sz = folded.sz ?? "";
+                    var col = folded.color ?? "";
+                    var sp = folded.space ?? "";
+                    var v = folded.style!;
+                    if (folded.sz != null || folded.color != null || folded.space != null)
+                        v += ";" + sz;
+                    if (folded.color != null || folded.space != null)
+                        v += ";" + col;
+                    if (folded.space != null)
+                        v += ";" + sp;
+                    result[key] = v;
+                }
                 continue;
             }
 

--- a/src/officecli/Core/BatchEmitter.cs
+++ b/src/officecli/Core/BatchEmitter.cs
@@ -1518,12 +1518,11 @@ public static class BatchEmitter
         // for them, cause double-application. Drop the aliases so the
         // dump bag stays minimal.
         "styleId", "styleName",
-        // CONSISTENCY(line-rule-inferred): style/paragraph Get emits `lineRule`
-        // alongside `lineSpacing`, but lineSpacing already encodes the rule
-        // (e.g. "1.5x" => Auto, "18pt" => Exact via SpacingConverter). Set has
-        // no `lineRule` case, so emitting it produces "UNSUPPORTED" warnings
-        // (104+ on a typical real-world doc). Drop it from dump.
-        "lineRule",
+        // BUG-019: lineSpacing alone cannot distinguish AtLeast from Exact —
+        // SpacingConverter.FormatWordLineSpacing serializes both as "Npt".
+        // Set/AddParagraph now accept `lineRule` explicitly so it must flow
+        // through dump for AtLeast spacing to round-trip without silent
+        // downgrade to Exact (which clips tall glyphs).
     };
 
     // Serialize the tabs list (List<Dictionary<string,object?>>) to the

--- a/src/officecli/Core/BatchEmitter.cs
+++ b/src/officecli/Core/BatchEmitter.cs
@@ -1525,27 +1525,6 @@ public static class BatchEmitter
         // downgrade to Exact (which clips tall glyphs).
     };
 
-    // Serialize the tabs list (List<Dictionary<string,object?>>) to the
-    // semicolon-separated form Add/Set's tab parser accepts:
-    //   "pos=2160 val=left leader=dot;pos=4320 val=center"
-    // ApplyTabsString in WordHandler.Helpers parses both space- and
-    // comma-delimited fields per stop. Without this projection, the raw
-    // .NET List<Dict> rendered as "System.Collections.Generic.List`1[…]"
-    // and tab stops were silently lost on round-trip (BUG-R2-01).
-    private static string SerializeTabsList(IEnumerable<Dictionary<string, object?>> tabs)
-    {
-        var stops = new List<string>();
-        foreach (var t in tabs)
-        {
-            var parts = new List<string>();
-            if (t.TryGetValue("pos", out var p) && p != null) parts.Add($"pos={p}");
-            if (t.TryGetValue("val", out var v) && v != null) parts.Add($"val={v}");
-            if (t.TryGetValue("leader", out var l) && l != null) parts.Add($"leader={l}");
-            if (parts.Count > 0) stops.Add(string.Join(" ", parts));
-        }
-        return string.Join(";", stops);
-    }
-
     private static Dictionary<string, string> FilterEmittableProps(Dictionary<string, object?> raw)
     {
         var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/src/officecli/Core/BatchEmitter.cs
+++ b/src/officecli/Core/BatchEmitter.cs
@@ -408,6 +408,17 @@ public static class BatchEmitter
         });
     }
 
+    // Mirror of AddStyle's builtInIds set — these styles ship in every
+    // blank template, so EmitStyles must use `set` instead of `add` to
+    // avoid "already exists" errors on round-trip into a fresh document.
+    private static readonly HashSet<string> BuiltInStyleIds = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Normal", "Heading1", "Heading2", "Heading3", "Heading4", "Heading5",
+        "Heading6", "Heading7", "Heading8", "Heading9", "Title", "Subtitle",
+        "Quote", "IntenseQuote", "ListParagraph", "NoSpacing", "TOCHeading",
+        "DefaultParagraphFont", "TableNormal", "NoList",
+    };
+
     private static void EmitStyles(WordHandler word, List<BatchItem> items)
     {
         // Use query() rather than walking Get("/styles").Children — the
@@ -433,13 +444,43 @@ public static class BatchEmitter
                 if (props.TryGetValue("name", out var n)) props["id"] = n;
                 else continue;
             }
-            items.Add(new BatchItem
+            // BUG-R6-03: built-in styles (Normal / Heading1-9 / Title /
+            // Subtitle / Quote / IntenseQuote / ListParagraph / NoSpacing /
+            // TOCHeading) are present in every blank template, so emitting
+            // `add` for them on a fresh batch target fails with
+            // "Style 'X' already exists". Emit `set` on /styles/<id> for
+            // those — it's already an upsert-on-existing path — so a real
+            // document's customised Normal/Heading values land on the
+            // template's built-ins instead of being rejected.
+            var styleIdGuess = props.TryGetValue("id", out var sidGuess) ? sidGuess
+                : props.TryGetValue("styleId", out sidGuess) ? sidGuess : null;
+            bool isBuiltInStyle = styleIdGuess != null && BuiltInStyleIds.Contains(styleIdGuess);
+            if (isBuiltInStyle)
             {
-                Command = "add",
-                Parent = "/styles",
-                Type = "style",
-                Props = props
-            });
+                // /styles/<id> set rejects keys it doesn't model; strip the
+                // identity-only bag (id/styleId/name/type) since those
+                // would no-op anyway.
+                var setProps = new Dictionary<string, string>(props, StringComparer.OrdinalIgnoreCase);
+                setProps.Remove("id");
+                setProps.Remove("styleId");
+                setProps.Remove("type");
+                items.Add(new BatchItem
+                {
+                    Command = "set",
+                    Path = $"/styles/{styleIdGuess}",
+                    Props = setProps
+                });
+            }
+            else
+            {
+                items.Add(new BatchItem
+                {
+                    Command = "add",
+                    Parent = "/styles",
+                    Type = "style",
+                    Props = props
+                });
+            }
             // BUG-R4-T1: FilterEmittableProps drops the `tabs` scalar (it's a
             // List<Dict>, not stringable). EmitParagraph compensates by
             // emitting per-stop `add tab` rows; EmitStyles must do the same

--- a/src/officecli/Core/BatchEmitter.cs
+++ b/src/officecli/Core/BatchEmitter.cs
@@ -675,7 +675,7 @@ public static class BatchEmitter
         // their evaluated string and stop auto-updating (BUG-R2-05 / R2-1).
         var fieldEntries = CollapseFieldChains(pNode.Children ?? new List<DocumentNode>());
         var runs = fieldEntries
-            .Where(c => c.Type == "run" || c.Type == "r" || c.Type == "picture" || c.Type == "field")
+            .Where(c => c.Type == "run" || c.Type == "r" || c.Type == "picture" || c.Type == "field" || c.Type == "ptab")
             .ToList();
         var breaks = (pNode.Children ?? new List<DocumentNode>())
             .Where(c => c.Type == "break")
@@ -702,14 +702,28 @@ public static class BatchEmitter
         // and drops the typed `add footnote/endnote` row entirely (Add does
         // not consume rStyle on a paragraph; the note text is lost). Force
         // the multi-run path so the dedicated note-emit branch below fires.
+        // BUG-R6-6: w14 text effects (textOutline / textFill / w14shadow /
+        // w14glow / w14reflection) live on a run but AddParagraph's
+        // ApplyRunFormatting fallback has no case for them — collapsing
+        // the single run would route the keys to the paragraph prop bag
+        // and they'd surface as UNSUPPORTED on replay (effect lost).
+        // Force the multi-run path so the effects ride along on `add r`.
+        bool singleRunHasW14 = runs.Count == 1 &&
+            (runs[0].Format.ContainsKey("w14shadow")
+             || runs[0].Format.ContainsKey("textOutline")
+             || runs[0].Format.ContainsKey("textFill")
+             || runs[0].Format.ContainsKey("w14glow")
+             || runs[0].Format.ContainsKey("w14reflection"));
         bool singleRunIsNoteRef = runs.Count == 1 &&
             runs[0].Format.TryGetValue("rStyle", out var srStyle)
             && (string.Equals(srStyle?.ToString(), "FootnoteReference", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(srStyle?.ToString(), "EndnoteReference", StringComparison.OrdinalIgnoreCase));
         bool collapseSingleRun = runs.Count <= 1 &&
             !(runs.Count == 1 && runs[0].Type == "picture") &&
+            !(runs.Count == 1 && runs[0].Type == "ptab") &&
             !singleRunIsHyperlink &&
             !singleRunIsNoteRef &&
+            !singleRunHasW14 &&
             breaks.Count == 0;
         // Pull paragraph-level tab stops out for per-stop `add tab` emit
         // (FilterEmittableProps already drops the `tabs` scalar).
@@ -806,6 +820,29 @@ public static class BatchEmitter
 
         foreach (var run in runs)
         {
+            // Positional tab — Navigation surfaces ptab as its own run type
+            // with align/relativeTo/leader on Format. Without an explicit
+            // emit branch the runs filter would drop it (BUG-R6-4) and the
+            // round-trip would silently lose right-align/header-style tabs.
+            if (run.Type == "ptab")
+            {
+                var ptabProps = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                if (run.Format.TryGetValue("align", out var pAlign) && pAlign != null)
+                    ptabProps["alignment"] = pAlign.ToString() ?? "";
+                if (run.Format.TryGetValue("relativeTo", out var pRel) && pRel != null)
+                    ptabProps["relativeTo"] = pRel.ToString() ?? "";
+                if (run.Format.TryGetValue("leader", out var pLead) && pLead != null)
+                    ptabProps["leader"] = pLead.ToString() ?? "";
+                items.Add(new BatchItem
+                {
+                    Command = "add",
+                    Parent = paraTargetPath,
+                    Type = "ptab",
+                    Props = ptabProps.Count > 0 ? ptabProps : null
+                });
+                continue;
+            }
+
             // Synthetic field entry from CollapseFieldChains. Format carries
             // `instruction` (the raw fldSimple/instrText string) and Text holds
             // the cached display value. AddField parses the instruction code
@@ -1017,9 +1054,11 @@ public static class BatchEmitter
         // truncate the table shape and break later `set tc[N]` rows.
         var rowEffectiveWidths = new List<int>(rows.Count);
         var rowCellNodes = new List<List<DocumentNode>>(rows.Count);
+        var rowNodes = new List<DocumentNode>(rows.Count);
         foreach (var rowChild in rows)
         {
             var rowNode = word.Get(rowChild.Path);
+            rowNodes.Add(rowNode);
             var cells = (rowNode.Children ?? new List<DocumentNode>())
                 .Where(c => c.Type == "cell")
                 .ToList();
@@ -1070,6 +1109,21 @@ public static class BatchEmitter
             : $"/body/tbl[{targetIndex}]";
         for (int r = 0; r < rows.Count; r++)
         {
+            // Emit row-level properties (header / height / height.rule) as a
+            // `set` on the row path — `add table` only seeds rows, it doesn't
+            // surface per-row props (BUG-R6-2). Without this, `dump→batch`
+            // silently strips repeating-header rows and explicit row heights.
+            var rowNode = rowNodes[r];
+            var rowProps = ExtractRowOnlyProps(rowNode.Format);
+            if (rowProps.Count > 0)
+            {
+                items.Add(new BatchItem
+                {
+                    Command = "set",
+                    Path = $"{tablePath}/tr[{r + 1}]",
+                    Props = rowProps
+                });
+            }
             var cells = rowCellNodes[r];
             for (int c = 0; c < cells.Count; c++)
             {
@@ -1220,8 +1274,6 @@ public static class BatchEmitter
         {
             case "PAGE":
             case "NUMPAGES":
-            case "DATE":
-            case "TIME":
             case "AUTHOR":
             case "TITLE":
             case "SUBJECT":
@@ -1229,6 +1281,24 @@ public static class BatchEmitter
             case "SECTION":
             case "SECTIONPAGES":
                 break;
+            case "DATE":
+            case "TIME":
+            case "CREATEDATE":
+            case "SAVEDATE":
+            case "PRINTDATE":
+            {
+                // Preserve the `\@ "MMMM d, yyyy"` format switch so dump
+                // round-trips Word's locale-formatted date fields. Without
+                // this, BuildFieldAddProps dropped `rest` and replay
+                // produced a bare DATE field rendered in the default
+                // locale (BUG-R6-3). AddField consumes the value via
+                // --prop format=…
+                var fmtMatch = System.Text.RegularExpressions.Regex.Match(
+                    rest ?? "", "\\\\@\\s+\"([^\"]+)\"");
+                if (fmtMatch.Success)
+                    props["format"] = fmtMatch.Groups[1].Value;
+                break;
+            }
             case "REF":
             case "PAGEREF":
             case "NOTEREF":
@@ -1332,6 +1402,40 @@ public static class BatchEmitter
             if (CellOnlyKeys.Contains(key) ||
                 key.StartsWith("border.", StringComparison.OrdinalIgnoreCase) ||
                 key.StartsWith("padding.", StringComparison.OrdinalIgnoreCase))
+            {
+                filtered[key] = val;
+            }
+        }
+        return FilterEmittableProps(filtered);
+    }
+
+    // Row-level keys surfaced by Navigation.ReadRowProps. Used by EmitTable
+    // so dump→batch round-trips header rows / heights / cantSplit. Cell
+    // children are emitted separately via ExtractCellOnlyProps.
+    private static readonly HashSet<string> RowOnlyKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "header", "height", "cantSplit",
+    };
+
+    private static Dictionary<string, string> ExtractRowOnlyProps(Dictionary<string, object?> raw)
+    {
+        var filtered = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        bool heightExact = false;
+        if (raw.TryGetValue("height.rule", out var ruleObj) &&
+            string.Equals(ruleObj?.ToString(), "exact", StringComparison.OrdinalIgnoreCase))
+        {
+            heightExact = true;
+        }
+        foreach (var (key, val) in raw)
+        {
+            if (!RowOnlyKeys.Contains(key)) continue;
+            // height + height.rule=exact → SetElementTableRow expects key
+            // `height.exact`. Translate so dump output applies cleanly.
+            if (heightExact && string.Equals(key, "height", StringComparison.OrdinalIgnoreCase))
+            {
+                filtered["height.exact"] = val;
+            }
+            else
             {
                 filtered[key] = val;
             }

--- a/src/officecli/Core/BatchEmitter.cs
+++ b/src/officecli/Core/BatchEmitter.cs
@@ -136,22 +136,41 @@ public static class BatchEmitter
         // throws "Header of type 'default' already exists" on replay.
         var headerPathToType = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var footerPathToType = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var (key, val) in root.Format)
+        // BUG-R5-2 / R5-F2: headerRef.<type> / footerRef.<type> live on
+        // **section** nodes (see WordHandler.Query.cs:902), not on root.
+        // The earlier R4 fix scanned root.Format and silently found nothing,
+        // so every emitted header/footer was typed "default" — round-trip
+        // failed when a doc had both default + first headers. Walk all
+        // section children to build the path→type map.
+        void HarvestRefs(DocumentNode node)
         {
-            if (val == null) continue;
-            var s = val.ToString();
-            if (string.IsNullOrEmpty(s)) continue;
-            if (key.StartsWith("headerRef.", StringComparison.OrdinalIgnoreCase))
+            foreach (var (key, val) in node.Format)
             {
-                var t = key["headerRef.".Length..];
-                if (!headerPathToType.ContainsKey(s)) headerPathToType[s] = t;
-            }
-            else if (key.StartsWith("footerRef.", StringComparison.OrdinalIgnoreCase))
-            {
-                var t = key["footerRef.".Length..];
-                if (!footerPathToType.ContainsKey(s)) footerPathToType[s] = t;
+                if (val == null) continue;
+                var s = val.ToString();
+                if (string.IsNullOrEmpty(s)) continue;
+                if (key.StartsWith("headerRef.", StringComparison.OrdinalIgnoreCase))
+                {
+                    var t = key["headerRef.".Length..];
+                    if (!headerPathToType.ContainsKey(s)) headerPathToType[s] = t;
+                }
+                else if (key.StartsWith("footerRef.", StringComparison.OrdinalIgnoreCase))
+                {
+                    var t = key["footerRef.".Length..];
+                    if (!footerPathToType.ContainsKey(s)) footerPathToType[s] = t;
+                }
             }
         }
+        HarvestRefs(root);
+        try
+        {
+            var sections = word.Query("section");
+            if (sections != null)
+            {
+                foreach (var sec in sections) HarvestRefs(sec);
+            }
+        }
+        catch { /* missing section info — fall through with default typing */ }
 
         int hIdx = 0, fIdx = 0;
         foreach (var child in root.Children)

--- a/src/officecli/Core/BatchEmitter.cs
+++ b/src/officecli/Core/BatchEmitter.cs
@@ -232,6 +232,40 @@ public static class BatchEmitter
         }
     }
 
+    // Emit a body-level SDT (Content Control) as a typed `add /body --type sdt`
+    // row. Get exposes type, alias, tag, items (dropdown/combobox), editable,
+    // and the visible text — all of which AddSdt round-trips. Without this,
+    // SDTs were silently dropped from dump output (BUG-R2-06 / R2-3).
+    private static void EmitSdt(WordHandler word, string sourcePath, List<BatchItem> items)
+    {
+        DocumentNode sdt;
+        try { sdt = word.Get(sourcePath); }
+        catch { return; }
+
+        var props = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        // Whitelist Get-canonical keys that AddSdt consumes. `editable` is a
+        // Get readback (negation of `lock`), the source-side `id` is allocated
+        // at creation, so neither is forwarded.
+        foreach (var key in new[] { "type", "alias", "tag", "items", "format" })
+        {
+            if (sdt.Format.TryGetValue(key, out var v) && v != null)
+            {
+                var s = v.ToString() ?? "";
+                if (s.Length > 0) props[key] = s;
+            }
+        }
+        if (!string.IsNullOrEmpty(sdt.Text))
+            props["text"] = sdt.Text!;
+
+        items.Add(new BatchItem
+        {
+            Command = "add",
+            Parent = "/body",
+            Type = "sdt",
+            Props = props
+        });
+    }
+
     private static string? ExtractParaId(string anchorPath)
     {
         var m = System.Text.RegularExpressions.Regex.Match(anchorPath, @"@paraId=([0-9A-Fa-f]+)");
@@ -250,6 +284,16 @@ public static class BatchEmitter
         "pageStart", "pageNumFmt",
         "titlePage", "direction", "rtlGutter",
         "lineNumbers", "lineNumberCountBy",
+        // Multi-column section layout. Get exposes these as canonical keys
+        // (columns, columnSpace, columns.equalWidth) and Set's case table
+        // accepts all three (WordHandler.Set.SectionLayout.cs). Without them
+        // here, multi-column documents silently revert to single column on
+        // round-trip.
+        "columns", "columnSpace",
+        // Document-level final-section break type (oddPage / evenPage /
+        // continuous). Set / accepts section.type but the canonical Get
+        // surfaces it bare; emit so the trailing sectPr's type survives.
+        "section.type",
         // Document protection
         "protection", "protectionEnforced",
         // Document grid (CJK-aware line layout)
@@ -268,6 +312,9 @@ public static class BatchEmitter
     {
         "docDefaults.",
         "docGrid.",
+        // columns.equalWidth / columns.separator etc. roundtrip via the
+        // canonical dotted form Get already emits.
+        "columns.",
     };
 
     private static void EmitSection(WordHandler word, List<BatchItem> items)
@@ -424,8 +471,11 @@ public static class BatchEmitter
                     // that default and skip emitting section properties.
                     // Section emit is a follow-up.
                     break;
+                case "sdt":
+                    EmitSdt(word, child.Path, items);
+                    break;
                 default:
-                    // Unknown body-level child types (sdt, etc.) — skip for v0.5.
+                    // Unknown body-level child types — skip for v0.5.
                     break;
             }
         }
@@ -553,8 +603,15 @@ public static class BatchEmitter
             props.Remove("listStyle");
             props.Remove("start");
         }
-        var runs = (pNode.Children ?? new List<DocumentNode>())
-            .Where(c => c.Type == "run" || c.Type == "r" || c.Type == "picture")
+        // Collapse non-TOC field chains (fldChar(begin) + instrText(" PAGE ")
+        // + fldChar(separate) + display run(s) + fldChar(end)) into a single
+        // synthetic "field" entry. Without this collapse, the subsequent
+        // `runs` filter sees only the cached display run and emits the field
+        // value as static text — PAGE/REF/SEQ/HYPERLINK/NUMPAGES degrade to
+        // their evaluated string and stop auto-updating (BUG-R2-05 / R2-1).
+        var fieldEntries = CollapseFieldChains(pNode.Children ?? new List<DocumentNode>());
+        var runs = fieldEntries
+            .Where(c => c.Type == "run" || c.Type == "r" || c.Type == "picture" || c.Type == "field")
             .ToList();
         var breaks = (pNode.Children ?? new List<DocumentNode>())
             .Where(c => c.Type == "break")
@@ -579,6 +636,10 @@ public static class BatchEmitter
             !(runs.Count == 1 && runs[0].Type == "picture") &&
             !singleRunIsHyperlink &&
             breaks.Count == 0;
+        // Pull paragraph-level tab stops out for per-stop `add tab` emit
+        // (FilterEmittableProps already drops the `tabs` scalar).
+        pNode.Format.TryGetValue("tabs", out var pTabs);
+
         if (collapseSingleRun)
         {
             if (runs.Count == 1)
@@ -617,6 +678,7 @@ public static class BatchEmitter
                     Props = props.Count > 0 ? props : null
                 });
             }
+            EmitTabStops($"{parentPath}/p[{targetIndex}]", pTabs, items);
             return;
         }
 
@@ -646,6 +708,7 @@ public static class BatchEmitter
         }
 
         var paraTargetPath = $"{parentPath}/p[{targetIndex}]";
+        EmitTabStops(paraTargetPath, pTabs, items);
 
         // Emit any break runs (page/column/textWrapping/line) the paragraph
         // carries. Without this, a break-only paragraph (the OOXML idiom
@@ -668,6 +731,41 @@ public static class BatchEmitter
 
         foreach (var run in runs)
         {
+            // Synthetic field entry from CollapseFieldChains. Format carries
+            // `instruction` (the raw fldSimple/instrText string) and Text holds
+            // the cached display value. AddField parses the instruction code
+            // and rebuilds the fldChar chain on replay.
+            if (run.Type == "field")
+            {
+                var instr = run.Format.TryGetValue("instruction", out var iv)
+                    ? iv?.ToString() ?? "" : "";
+                var fieldProps = BuildFieldAddProps(instr, run.Text ?? "");
+                if (fieldProps != null)
+                {
+                    items.Add(new BatchItem
+                    {
+                        Command = "add",
+                        Parent = paraTargetPath,
+                        Type = "field",
+                        Props = fieldProps
+                    });
+                }
+                else if (!string.IsNullOrEmpty(run.Text))
+                {
+                    // Unparseable instruction — fall back to plain text so the
+                    // paragraph still renders the cached value rather than going
+                    // empty.
+                    items.Add(new BatchItem
+                    {
+                        Command = "add",
+                        Parent = paraTargetPath,
+                        Type = "r",
+                        Props = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["text"] = run.Text! }
+                    });
+                }
+                continue;
+            }
+
             // Drawing-bearing runs surface as type=="picture" regardless of
             // whether the Drawing wraps an image (Blip) or a chart
             // (c:chart). Try the image path first; if there's no embedded
@@ -954,6 +1052,167 @@ public static class BatchEmitter
         }
     }
 
+    // Collapse OOXML complex field chains (fldChar(begin) + instrText + …
+    // + fldChar(end)) into a single synthetic "field" DocumentNode with
+    // Format["instruction"] (raw code) and Text (cached display value).
+    // Non-field children pass through untouched in original order. The TOC
+    // chain is handled by the dedicated EmitParagraph branch above and never
+    // reaches this collapsing step (early-return in that branch).
+    private static List<DocumentNode> CollapseFieldChains(List<DocumentNode> children)
+    {
+        var result = new List<DocumentNode>();
+        for (int i = 0; i < children.Count; i++)
+        {
+            var c = children[i];
+            bool isBegin = c.Type == "fieldChar"
+                && c.Format.TryGetValue("fieldCharType", out var fct)
+                && string.Equals(fct?.ToString(), "begin", StringComparison.OrdinalIgnoreCase);
+            if (!isBegin)
+            {
+                result.Add(c);
+                continue;
+            }
+
+            // Walk forward to find instruction text and end marker.
+            string instruction = "";
+            string display = "";
+            int end = -1;
+            for (int j = i + 1; j < children.Count; j++)
+            {
+                var k = children[j];
+                if (k.Type == "instrText")
+                {
+                    if (k.Format.TryGetValue("instruction", out var iv) && iv != null)
+                        instruction += iv.ToString();
+                    else if (!string.IsNullOrEmpty(k.Text))
+                        instruction += k.Text;
+                }
+                else if (k.Type == "fieldChar"
+                    && k.Format.TryGetValue("fieldCharType", out var ft)
+                    && string.Equals(ft?.ToString(), "end", StringComparison.OrdinalIgnoreCase))
+                {
+                    end = j;
+                    break;
+                }
+                else if (k.Type == "run" || k.Type == "r")
+                {
+                    // Cached display segments after fldChar(separate). Concatenate
+                    // their text — formatting on the display run is dropped (the
+                    // field renders fresh on replay).
+                    if (!string.IsNullOrEmpty(k.Text)) display += k.Text;
+                }
+            }
+            if (end < 0)
+            {
+                // Malformed (no end marker) — fall back to passing through.
+                result.Add(c);
+                continue;
+            }
+            var synth = new DocumentNode
+            {
+                Path = c.Path,
+                Type = "field",
+                Text = display,
+                Format = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["instruction"] = instruction.Trim()
+                }
+            };
+            result.Add(synth);
+            i = end;
+        }
+        return result;
+    }
+
+    // Build the prop bag AddField consumes from a parsed field instruction.
+    // Returns null when the instruction is empty or its first token is not a
+    // known field code; the caller falls back to a plain-text run for the
+    // cached display value so the paragraph still renders.
+    private static Dictionary<string, string>? BuildFieldAddProps(string instruction, string display)
+    {
+        if (string.IsNullOrWhiteSpace(instruction)) return null;
+        var trimmed = instruction.Trim();
+        // First whitespace-separated token is the field code.
+        var firstSpace = trimmed.IndexOfAny(new[] { ' ', '\t' });
+        var code = (firstSpace < 0 ? trimmed : trimmed[..firstSpace]).ToUpperInvariant();
+        var rest = firstSpace < 0 ? "" : trimmed[(firstSpace + 1)..].Trim();
+
+        var props = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["fieldType"] = code
+        };
+        switch (code)
+        {
+            case "PAGE":
+            case "NUMPAGES":
+            case "DATE":
+            case "TIME":
+            case "AUTHOR":
+            case "TITLE":
+            case "SUBJECT":
+            case "FILENAME":
+            case "SECTION":
+            case "SECTIONPAGES":
+                break;
+            case "REF":
+            case "PAGEREF":
+            case "NOTEREF":
+            {
+                // First arg is the bookmark name (may be quoted).
+                var name = ExtractFirstArg(rest);
+                if (string.IsNullOrEmpty(name)) return null;
+                props["bookmarkName"] = name;
+                break;
+            }
+            case "SEQ":
+            {
+                var ident = ExtractFirstArg(rest);
+                if (string.IsNullOrEmpty(ident)) return null;
+                props["identifier"] = ident;
+                break;
+            }
+            case "MERGEFIELD":
+            {
+                var name = ExtractFirstArg(rest);
+                if (string.IsNullOrEmpty(name)) return null;
+                props["fieldName"] = name;
+                break;
+            }
+            case "HYPERLINK":
+            {
+                // Either `\l "anchor"` or a URL as the first arg.
+                var anchorMatch = System.Text.RegularExpressions.Regex.Match(rest, "\\\\l\\s+\"([^\"]+)\"");
+                if (anchorMatch.Success) props["anchor"] = anchorMatch.Groups[1].Value;
+                else
+                {
+                    var url = ExtractFirstArg(rest);
+                    if (string.IsNullOrEmpty(url)) return null;
+                    props["url"] = url;
+                }
+                break;
+            }
+            default:
+                // Unknown field code — let the generic field add try.
+                break;
+        }
+        if (!string.IsNullOrEmpty(display))
+            props["text"] = display;
+        return props;
+    }
+
+    private static string ExtractFirstArg(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return "";
+        var t = s.TrimStart();
+        if (t.StartsWith('"'))
+        {
+            var end = t.IndexOf('"', 1);
+            return end > 0 ? t[1..end] : "";
+        }
+        var spc = t.IndexOfAny(new[] { ' ', '\t' });
+        return spc < 0 ? t : t[..spc];
+    }
+
     // Parse a TOC field instruction (` TOC \o "1-3" \h \u \z `) into the
     // prop bag AddToc accepts. AddToc emits the canonical instruction so
     // round-tripping the parsed props back through it lands at the same
@@ -1043,6 +1302,27 @@ public static class BatchEmitter
         "styleId", "styleName",
     };
 
+    // Serialize the tabs list (List<Dictionary<string,object?>>) to the
+    // semicolon-separated form Add/Set's tab parser accepts:
+    //   "pos=2160 val=left leader=dot;pos=4320 val=center"
+    // ApplyTabsString in WordHandler.Helpers parses both space- and
+    // comma-delimited fields per stop. Without this projection, the raw
+    // .NET List<Dict> rendered as "System.Collections.Generic.List`1[…]"
+    // and tab stops were silently lost on round-trip (BUG-R2-01).
+    private static string SerializeTabsList(IEnumerable<Dictionary<string, object?>> tabs)
+    {
+        var stops = new List<string>();
+        foreach (var t in tabs)
+        {
+            var parts = new List<string>();
+            if (t.TryGetValue("pos", out var p) && p != null) parts.Add($"pos={p}");
+            if (t.TryGetValue("val", out var v) && v != null) parts.Add($"val={v}");
+            if (t.TryGetValue("leader", out var l) && l != null) parts.Add($"leader={l}");
+            if (parts.Count > 0) stops.Add(string.Join(" ", parts));
+        }
+        return string.Join(";", stops);
+    }
+
     private static Dictionary<string, string> FilterEmittableProps(Dictionary<string, object?> raw)
     {
         var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -1066,8 +1346,16 @@ public static class BatchEmitter
                 continue;
             }
 
+            // tabs is a List<Dict>, not a flat scalar. Both Add and Set ingest
+            // tab stops via the dedicated `add ... --type tab` command (one
+            // row per stop), not as a paragraph/style scalar prop. Skipping
+            // here avoids serializing the .NET list type name into the prop
+            // string (BUG-R2-01); paragraph emitters layer per-stop add rows
+            // separately.
+            if (string.Equals(key, "tabs", StringComparison.OrdinalIgnoreCase)) continue;
+
             if (val == null) continue;
-            var s = val switch
+            string s = val switch
             {
                 bool b => b ? "true" : "false",
                 _ => val.ToString() ?? ""
@@ -1075,5 +1363,27 @@ public static class BatchEmitter
             if (s.Length > 0) result[key] = s;
         }
         return result;
+    }
+
+    // Layer per-stop `add tab` rows under a parent path that already has the
+    // host paragraph/style created. tabs is the flat List<Dict> Get exposes.
+    private static void EmitTabStops(string parentPath, object? tabsVal, List<BatchItem> items)
+    {
+        if (tabsVal is not IEnumerable<Dictionary<string, object?>> list) return;
+        foreach (var t in list)
+        {
+            var props = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (t.TryGetValue("pos", out var p) && p != null) props["pos"] = p.ToString() ?? "";
+            if (t.TryGetValue("val", out var v) && v != null) props["val"] = v.ToString() ?? "";
+            if (t.TryGetValue("leader", out var l) && l != null) props["leader"] = l.ToString() ?? "";
+            if (props.Count == 0 || !props.ContainsKey("pos")) continue;
+            items.Add(new BatchItem
+            {
+                Command = "add",
+                Parent = parentPath,
+                Type = "tab",
+                Props = props
+            });
+        }
     }
 }

--- a/src/officecli/Core/BatchEmitter.cs
+++ b/src/officecli/Core/BatchEmitter.cs
@@ -1304,6 +1304,14 @@ public static class BatchEmitter
         // \z suppresses page numbers; absence means pageNumbers=true
         props["pageNumbers"] = System.Text.RegularExpressions.Regex.IsMatch(instruction, "\\\\z\\b")
             ? "false" : "true";
+        // BUG-R5-03: \t = custom-style→level mapping ("Style;level,..."),
+        // \b = bookmark scope. Capture the quoted argument so AddToc can
+        // round-trip them; otherwise custom TOC switches were silently
+        // dropped on dump.
+        var ct = System.Text.RegularExpressions.Regex.Match(instruction, "\\\\t\\s+\"([^\"]+)\"");
+        if (ct.Success) props["customStyles"] = ct.Groups[1].Value;
+        var cb = System.Text.RegularExpressions.Regex.Match(instruction, "\\\\b\\s+\"([^\"]+)\"");
+        if (cb.Success) props["bookmark"] = cb.Groups[1].Value;
         return props;
     }
 

--- a/src/officecli/Core/Formula/FormulaParser.cs
+++ b/src/officecli/Core/Formula/FormulaParser.cs
@@ -156,10 +156,10 @@ internal static class FormulaParser
         switch (name)
         {
             case "oMathPara":
-                return string.Concat(element.ChildElements.Select(ToLatexByName));
+                return JoinChildren(element);
 
             case "oMath":
-                return string.Concat(element.ChildElements.Select(ToLatexByName));
+                return JoinChildren(element);
 
             case "r":
             {
@@ -517,6 +517,37 @@ internal static class FormulaParser
             default:
                 return string.Concat(element.ChildElements.Select(ToReadableText));
         }
+    }
+
+    /// <summary>
+    /// Concat oMath/oMathPara children with whitespace deduping at sibling
+    /// boundaries. SymbolToCommandMap entries (e.g. "\pm ", "\sqrt ") encode
+    /// a trailing space so the LaTeX command can't fuse with the next token
+    /// (e.g. "\pma"). Adjacent text runs in the OMML re-introduce that same
+    /// separating space, producing one extra space per round-trip
+    /// (BUG-R3-1: \pm becomes \pm  becomes \pm   becomes \pm    after each
+    /// dump→batch). Collapse `WS{trailing}WS{leading}` to a single WS so the
+    /// LaTeX text stays stable across round-trips.
+    /// </summary>
+    private static string JoinChildren(OpenXmlElement element)
+    {
+        var sb = new System.Text.StringBuilder();
+        foreach (var child in element.ChildElements)
+        {
+            var part = ToLatexByName(child);
+            if (sb.Length > 0 && part.Length > 0
+                && char.IsWhiteSpace(sb[^1]) && char.IsWhiteSpace(part[0]))
+            {
+                int p = 0;
+                while (p < part.Length && char.IsWhiteSpace(part[p])) p++;
+                sb.Append(part, p, part.Length - p);
+            }
+            else
+            {
+                sb.Append(part);
+            }
+        }
+        return sb.ToString();
     }
 
     // ==================== Tokenizer ====================
@@ -1661,7 +1692,11 @@ internal static class FormulaParser
     private static string ArgToLatex(OpenXmlElement? arg)
     {
         if (arg == null) return "";
-        return string.Concat(arg.ChildElements.Select(ToLatex));
+        // CONSISTENCY(formula-space-dedup): see JoinChildren — same boundary
+        // dedupe must apply inside arg containers (Numerator/Denominator/e/
+        // sub/sup) or the per-round-trip space accumulation reappears one
+        // level down (BUG-R3-1).
+        return JoinChildren(arg);
     }
 
     private static string ArgToReadable(OpenXmlElement? arg)

--- a/src/officecli/Core/OutputFormatter.cs
+++ b/src/officecli/Core/OutputFormatter.cs
@@ -154,6 +154,12 @@ internal static class OutputFormatter
         var envelope = new JsonObject
         {
             ["success"] = true,
+            // BUG-R6-04: `add --json` previously emitted only `message`,
+            // diverging from get/set/dump which surface a `data` field.
+            // Keep `message` for backwards compatibility but also expose
+            // it under `data` so a single parser (`.data`) works across
+            // every command's --json output.
+            ["data"] = message,
             ["message"] = message
         };
 

--- a/src/officecli/Core/ParseHelpers.cs
+++ b/src/officecli/Core/ParseHelpers.cs
@@ -297,6 +297,9 @@ internal static class ParseHelpers
         "hyperlink", "followedHyperlink",
         // Extra variants seen in OOXML: text1/text2/background1/background2 alias dark/light.
         "text1", "text2", "background1", "background2",
+        // BUG-R6-06: alternate Word theme color aliases (windowText / windowBackground)
+        // are valid OOXML w:themeColor values that map to dark1/light1.
+        "windowText", "windowBackground",
         "none", "auto",
     };
 
@@ -329,6 +332,8 @@ internal static class ParseHelpers
             "text2" => "dark2",
             "background1" => "light1",
             "background2" => "light2",
+            "windowtext" => "dark1",
+            "windowbackground" => "light1",
             _ => v,
         };
     }

--- a/src/officecli/Core/RawXmlHelper.cs
+++ b/src/officecli/Core/RawXmlHelper.cs
@@ -227,13 +227,71 @@ internal static class RawXmlHelper
     public static List<ValidationError> ValidateDocument(OpenXmlPackage package)
     {
         var validator = new OpenXmlValidator(DocumentFormat.OpenXml.FileFormatVersions.Microsoft365);
-        return validator.Validate(package)
-            .Select(e => new ValidationError(
-                e.ErrorType.ToString(),
-                e.Description,
-                e.Path?.XPath,
-                e.Part?.Uri.ToString()))
-            .ToList();
+        // BUG-R6-08: documents containing w:numPicBullet can trip an NRE
+        // inside SDK validation when one of its child accessors hits a
+        // null. Materialise per-error with try/catch so a single problem
+        // entry doesn't bring the whole `validate` command down. Surface
+        // the exception as a synthetic ValidationError instead of
+        // bubbling out as a process-level crash.
+        var errors = new List<ValidationError>();
+        IEnumerable<DocumentFormat.OpenXml.Validation.ValidationErrorInfo> raw;
+        try
+        {
+            raw = validator.Validate(package);
+        }
+        catch (Exception ex)
+        {
+            errors.Add(new ValidationError(
+                "ValidatorException",
+                $"Validator threw before producing results: {ex.GetType().Name}: {ex.Message}",
+                null, null));
+            return errors;
+        }
+        // The IEnumerable is lazy — iterate with try/catch so one bad
+        // error entry does not abort the rest.
+        using var enumerator = raw.GetEnumerator();
+        while (true)
+        {
+            DocumentFormat.OpenXml.Validation.ValidationErrorInfo? e = null;
+            try
+            {
+                if (!enumerator.MoveNext()) break;
+                e = enumerator.Current;
+            }
+            catch (NullReferenceException nre)
+            {
+                errors.Add(new ValidationError(
+                    "ValidatorNullReference",
+                    $"SDK validator hit a null while inspecting next error: {nre.Message}",
+                    null, null));
+                continue;
+            }
+            catch (Exception ex)
+            {
+                errors.Add(new ValidationError(
+                    "ValidatorException",
+                    $"SDK validator threw while inspecting next error: {ex.GetType().Name}: {ex.Message}",
+                    null, null));
+                continue;
+            }
+            if (e == null) continue;
+            try
+            {
+                errors.Add(new ValidationError(
+                    e.ErrorType.ToString(),
+                    e.Description,
+                    e.Path?.XPath,
+                    e.Part?.Uri.ToString()));
+            }
+            catch (Exception ex)
+            {
+                errors.Add(new ValidationError(
+                    "ValidatorException",
+                    $"Failed to materialise validation error: {ex.GetType().Name}: {ex.Message}",
+                    null, null));
+            }
+        }
+        return errors;
     }
 
     private static void TryAddNamespace(XmlNamespaceManager nsManager, string prefix, string uri)

--- a/src/officecli/Core/StyleUnsupportedHints.cs
+++ b/src/officecli/Core/StyleUnsupportedHints.cs
@@ -23,10 +23,8 @@ internal static class StyleUnsupportedHints
         ["leftChars"]      = "char-based indent is not supported on styles",
         ["rightChars"]     = "char-based indent is not supported on styles",
         ["hangingChars"]   = "char-based indent is not supported on styles",
-        ["firstLineIndent"] = "indent attrs on styles are not supported; set indent at paragraph level instead",
-        ["leftIndent"]      = "indent attrs on styles are not supported; set indent at paragraph level instead",
-        ["rightIndent"]     = "indent attrs on styles are not supported; set indent at paragraph level instead",
-        ["hangingIndent"]   = "indent attrs on styles are not supported; set indent at paragraph level instead",
+        // firstLineIndent / leftIndent / rightIndent / hangingIndent are now
+        // wired in WordHandler.Set.Dispatch.cs SetStylePath (Round 3 BT-5).
 
         ["spaceBeforeLines"] = "line-based spacing is not supported; use 'spaceBefore=<twips|pt|cm>' instead",
         ["spaceAfterLines"]  = "line-based spacing is not supported; use 'spaceAfter=<twips|pt|cm>' instead",

--- a/src/officecli/Handlers/ExcelHandler.cs
+++ b/src/officecli/Handlers/ExcelHandler.cs
@@ -262,7 +262,8 @@ public partial class ExcelHandler : IDocumentHandler
 
         var affected = RawXmlHelper.Execute(rootElement, xpath, action, xml);
         rootElement.Save();
-        Console.WriteLine($"raw-set: {affected} element(s) affected");
+        // BUG-R5-01: silent — CLI wrappers print their own structured message.
+        _ = affected;
     }
 
     public List<ValidationError> Validate() => RawXmlHelper.ValidateDocument(_doc);

--- a/src/officecli/Handlers/PowerPointHandler.cs
+++ b/src/officecli/Handlers/PowerPointHandler.cs
@@ -117,7 +117,8 @@ public partial class PowerPointHandler : IDocumentHandler
         // duplicate cNvPr ids that PowerPoint silently rejects. Rebuild the
         // shape-id index from the live tree after every raw-set.
         InitShapeIdCounter();
-        Console.WriteLine($"raw-set: {affected} element(s) affected");
+        // BUG-R5-01: silent — CLI wrappers print their own structured message.
+        _ = affected;
     }
 
     public (string RelId, string PartPath) AddPart(string parentPartPath, string partType, Dictionary<string, string>? properties = null)

--- a/src/officecli/Handlers/Pptx/PowerPointHandler.Add.Media.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.Add.Media.cs
@@ -115,7 +115,19 @@ public partial class PowerPointHandler
 
                 var imgShapeId = GenerateUniqueShapeId(imgShapeTree);
                 var imgName = properties.GetValueOrDefault("name", $"Picture {imgShapeTree.Elements<Picture>().Count() + 1}");
-                var altText = properties.GetValueOrDefault("alt", Path.GetFileName(imgPath));
+                // BUG-R5-02: data URIs / raw base64 blobs make Path.GetFileName
+                // return a meaningless tail (e.g. "png;base64,iVBOR..."). Use a
+                // placeholder unless the caller supplied an explicit alt=.
+                string DefaultPictureAlt()
+                {
+                    if (string.IsNullOrEmpty(imgPath)) return imgName;
+                    if (imgPath.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) return imgName;
+                    if (imgPath.Length > 256 && imgPath.IndexOf('/') < 0 && imgPath.IndexOf('\\') < 0) return imgName;
+                    try { return Path.GetFileName(imgPath); } catch { return imgName; }
+                }
+                var altText = properties.TryGetValue("alt", out var altOverride) && !string.IsNullOrEmpty(altOverride)
+                    ? altOverride
+                    : DefaultPictureAlt();
 
                 // Build Picture element following Open-XML-SDK conventions
                 var picture = new Picture();

--- a/src/officecli/Handlers/Word/WordHandler.Add.Media.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Media.cs
@@ -60,9 +60,14 @@ public partial class WordHandler
         // dump emitted name=… on round-trip but Add silently dropped it,
         // so the chart's shape name reverted to its title every replay.
         // Honor caller intent first; fall back to title, then synthesize.
-        var chartName = properties.GetValueOrDefault("name")
-                     ?? chartTitle
-                     ?? $"Chart {docPropId}";
+        // CONSISTENCY(empty-string-fallback): mirror AddPicture's
+        // !IsNullOrEmpty guard — `??` only short-circuits on null, so a
+        // literal name="" would otherwise pin the chart's shape name to
+        // empty instead of falling through to title.
+        var chartName = (properties.TryGetValue("name", out var chartNameOverride)
+                         && !string.IsNullOrEmpty(chartNameOverride))
+            ? chartNameOverride
+            : (chartTitle ?? $"Chart {docPropId}");
 
         // Extended chart types (cx:chart) — funnel, treemap, sunburst, boxWhisker, histogram
         if (Core.ChartExBuilder.IsExtendedChartType(chartType))

--- a/src/officecli/Handlers/Word/WordHandler.Add.Media.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Media.cs
@@ -310,7 +310,17 @@ public partial class WordHandler
 
         var imgDocPropId = NextDocPropId();
         Run imgRun;
-        if (properties.TryGetValue("anchor", out var anchorVal) && IsTruthy(anchorVal))
+        // BUG-R4-BT3: a non-"none" `wrap` value implies floating placement —
+        // wrap only has meaning on a <wp:anchor>. Previously, callers passing
+        // `wrap=square|tight|topBottom|behind|inFront` without an explicit
+        // `anchor=true` got an inline picture and the wrap was silently
+        // dropped (also affected dump round-trip of floating pictures).
+        bool wrapImpliesAnchor = properties.TryGetValue("wrap", out var implicitWrap)
+            && !string.IsNullOrEmpty(implicitWrap)
+            && !string.Equals(implicitWrap, "none", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(implicitWrap, "inline", StringComparison.OrdinalIgnoreCase);
+        if ((properties.TryGetValue("anchor", out var anchorVal) && IsTruthy(anchorVal))
+            || wrapImpliesAnchor)
         {
             var wrapType = properties.GetValueOrDefault("wrap", "none");
             long hPos = properties.TryGetValue("hposition", out var hPosStr) ? ParseEmu(hPosStr) : 0;

--- a/src/officecli/Handlers/Word/WordHandler.Add.Media.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Media.cs
@@ -306,7 +306,27 @@ public partial class WordHandler
             }
         }
 
-        var altText = properties.GetValueOrDefault("alt", Path.GetFileName(imgPath));
+        // BUG-R5-02: data URIs (data:image/png;base64,iVBOR...) contain
+        // multiple slashes inside the base64 payload, so Path.GetFileName
+        // returns a meaningless tail like "png;base64,iVBOR..." which then
+        // becomes both the picture name AND the alt text. Detect data: /
+        // base64-blob inputs and fall back to a neutral placeholder unless
+        // the caller supplied an explicit alt= or name=.
+        string DefaultPictureName()
+        {
+            if (string.IsNullOrEmpty(imgPath)) return "image";
+            if (imgPath.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) return "image";
+            // Heuristic for raw base64 (no scheme): no path separator and length
+            // is implausibly long for a real filename.
+            if (imgPath.Length > 256 && imgPath.IndexOf('/') < 0 && imgPath.IndexOf('\\') < 0) return "image";
+            try { return Path.GetFileName(imgPath); }
+            catch { return "image"; }
+        }
+        var altText = properties.TryGetValue("alt", out var altOverride) && !string.IsNullOrEmpty(altOverride)
+            ? altOverride
+            : (properties.TryGetValue("name", out var nameOverride) && !string.IsNullOrEmpty(nameOverride)
+                ? nameOverride
+                : DefaultPictureName());
 
         var imgDocPropId = NextDocPropId();
         Run imgRun;

--- a/src/officecli/Handlers/Word/WordHandler.Add.Media.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Media.cs
@@ -56,7 +56,13 @@ public partial class WordHandler
         long chartCy = properties.TryGetValue("height", out var chStr) ? ParseEmu(chStr) : 3600000;
 
         var docPropId = NextDocPropId();
-        var chartName = chartTitle ?? $"Chart {docPropId}";
+        // BUG-R7-02 (T-2): explicit `name` prop was previously ignored —
+        // dump emitted name=… on round-trip but Add silently dropped it,
+        // so the chart's shape name reverted to its title every replay.
+        // Honor caller intent first; fall back to title, then synthesize.
+        var chartName = properties.GetValueOrDefault("name")
+                     ?? chartTitle
+                     ?? $"Chart {docPropId}";
 
         // Extended chart types (cx:chart) — funnel, treemap, sunburst, boxWhisker, histogram
         if (Core.ChartExBuilder.IsExtendedChartType(chartType))

--- a/src/officecli/Handlers/Word/WordHandler.Add.Misc.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Misc.cs
@@ -550,6 +550,18 @@ public partial class WordHandler
             "styleref" => $" STYLEREF \"{styleRefName}\" ",
             "docproperty" => $" DOCPROPERTY \"{docPropertyName}\" ",
             "if" => BuildIfFieldInstruction(properties),
+            // CONSISTENCY(field-add-symmetry): BatchEmitter.BuildFieldAddProps
+            // emits HYPERLINK fields as fieldType=HYPERLINK + url/anchor (+ text),
+            // never as a raw `instr`. Without a hyperlink case the default arm
+            // throws `Unknown field type 'hyperlink'` and (under the new
+            // continue-on-error default) the link is silently dropped on
+            // dump→batch round-trips of complex-field HYPERLINK chains.
+            "hyperlink" => properties.TryGetValue("anchor", out var hAnchor) && !string.IsNullOrEmpty(hAnchor)
+                ? $" HYPERLINK \\l \"{hAnchor}\" "
+                : (properties.TryGetValue("url", out var hUrl) && !string.IsNullOrEmpty(hUrl)
+                    ? $" HYPERLINK \"{hUrl}\" "
+                    : throw new ArgumentException(
+                        "HYPERLINK field requires either 'url' or 'anchor' property.")),
             // CONSISTENCY(canonical-keys): field.json declares `instr` as
             // the canonical raw-instruction key with `instruction` and
             // `code` as aliases. Help docs and AI prompts use `instr=`
@@ -752,6 +764,7 @@ public partial class WordHandler
         ["createdate"] = new[] { "format" },
         ["savedate"] = new[] { "format" },
         ["printdate"] = new[] { "format" },
+        ["hyperlink"] = new[] { "url", "anchor" },
     };
 
     // Universal props every fieldType accepts: routing keys, run rPr,

--- a/src/officecli/Handlers/Word/WordHandler.Add.Misc.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Misc.cs
@@ -956,11 +956,8 @@ public partial class WordHandler
                     var ddl = new SdtContentDropDownList();
                     if (ciProps.TryGetValue("items", out var items))
                     {
-                        foreach (var item in items.Split(','))
-                        {
-                            var trimmed = item.Trim();
-                            ddl.AppendChild(new ListItem { DisplayText = trimmed, Value = trimmed });
-                        }
+                        foreach (var li in ParseSdtItems(items))
+                            ddl.AppendChild(li);
                     }
                     sdtProps.AppendChild(ddl);
                     break;
@@ -970,11 +967,8 @@ public partial class WordHandler
                     var cb = new SdtContentComboBox();
                     if (ciProps.TryGetValue("items", out var items))
                     {
-                        foreach (var item in items.Split(','))
-                        {
-                            var trimmed = item.Trim();
-                            cb.AppendChild(new ListItem { DisplayText = trimmed, Value = trimmed });
-                        }
+                        foreach (var li in ParseSdtItems(items))
+                            cb.AppendChild(li);
                     }
                     sdtProps.AppendChild(cb);
                     break;
@@ -1076,11 +1070,8 @@ public partial class WordHandler
                     var ddl = new SdtContentDropDownList();
                     if (ciProps.TryGetValue("items", out var items))
                     {
-                        foreach (var item in items.Split(','))
-                        {
-                            var trimmed = item.Trim();
-                            ddl.AppendChild(new ListItem { DisplayText = trimmed, Value = trimmed });
-                        }
+                        foreach (var li in ParseSdtItems(items))
+                            ddl.AppendChild(li);
                     }
                     sdtProps.AppendChild(ddl);
                     break;
@@ -1090,11 +1081,8 @@ public partial class WordHandler
                     var cb = new SdtContentComboBox();
                     if (ciProps.TryGetValue("items", out var items))
                     {
-                        foreach (var item in items.Split(','))
-                        {
-                            var trimmed = item.Trim();
-                            cb.AppendChild(new ListItem { DisplayText = trimmed, Value = trimmed });
-                        }
+                        foreach (var li in ParseSdtItems(items))
+                            cb.AppendChild(li);
                     }
                     sdtProps.AppendChild(cb);
                     break;
@@ -1256,5 +1244,36 @@ public partial class WordHandler
         var createdIdx = siblings.IndexOf(created) + 1;
         var resultPath = $"{parentPath}/{created.LocalName}[{createdIdx}]";
         return resultPath;
+    }
+
+    /// <summary>
+    /// Parse the SDT --prop items= argument into ListItem children.
+    /// BUG-R5-07: previously the comma-split tokens were used as both
+    /// displayText and value, which is fine for "Draft,Review,Final" but
+    /// erases the distinct value attribute that real Word documents use
+    /// ("Draft|DRAFT,Review|REVIEW,Final|FINAL"). dump emits this
+    /// pipe-separated form when DisplayText differs from Value; accept it
+    /// here so add round-trips correctly. A bare token (no `|`) keeps the
+    /// old behavior — display == value.
+    /// </summary>
+    private static IEnumerable<ListItem> ParseSdtItems(string items)
+    {
+        foreach (var raw in items.Split(','))
+        {
+            var trimmed = raw.Trim();
+            if (string.IsNullOrEmpty(trimmed)) continue;
+            string display, value;
+            var pipeIdx = trimmed.IndexOf('|');
+            if (pipeIdx > 0)
+            {
+                display = trimmed[..pipeIdx].Trim();
+                value = trimmed[(pipeIdx + 1)..].Trim();
+            }
+            else
+            {
+                display = value = trimmed;
+            }
+            yield return new ListItem { DisplayText = display, Value = value };
+        }
     }
 }

--- a/src/officecli/Handlers/Word/WordHandler.Add.Misc.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Misc.cs
@@ -403,6 +403,17 @@ public partial class WordHandler
             hlRProps.Bold = new Bold();
         if (properties.TryGetValue("italic", out var hlItalic) && IsTruthy(hlItalic))
             hlRProps.Italic = new Italic();
+        // CONSISTENCY(add-set-symmetry): hyperlink runs commonly bind to the
+        // built-in `Hyperlink` character style (rStyle=Hyperlink) so they
+        // pick up the document's hyperlink theme color/underline. Run Add
+        // and paragraph dump emit echo rStyle back; AddHyperlink must
+        // accept it on the wrapped run or batch replay strips it with an
+        // UNSUPPORTED warning. BUG-R4-BT5.
+        if (properties.TryGetValue("rStyle", out var hlRStyle) || properties.TryGetValue("rstyle", out hlRStyle))
+        {
+            if (!string.IsNullOrEmpty(hlRStyle))
+                hlRProps.RunStyle = new RunStyle { Val = hlRStyle };
+        }
         // CONSISTENCY(rtl-cascade): inherit pPr/bidi from the enclosing
         // paragraph onto the hyperlink's run rPr. Mirrors the cascade in
         // SetElementParagraph / Add.Text run insertion (R16-bt-3). Without

--- a/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
@@ -1333,6 +1333,50 @@ public partial class WordHandler
             level.AppendChild(pPr);
         }
 
+        // BUG-R5-T2: AddLvl previously dropped font/size/color/bold/italic/
+        // underline silently — they're documented for SetAbstractNumPath
+        // level-scope but Add never consumed them. Mirror the Set branch
+        // (NumberingSymbolRunProperties is the lvl-level rPr container).
+        NumberingSymbolRunProperties? rPr = null;
+        NumberingSymbolRunProperties EnsureRPr() => rPr ??= new NumberingSymbolRunProperties();
+        if (properties.TryGetValue("font", out var lvlFontRaw) && !string.IsNullOrEmpty(lvlFontRaw))
+        {
+            var rp = EnsureRPr();
+            var rf = rp.GetFirstChild<RunFonts>() ?? rp.AppendChild(new RunFonts());
+            rf.Ascii = lvlFontRaw;
+            rf.HighAnsi = lvlFontRaw;
+            rf.EastAsia = lvlFontRaw;
+        }
+        if (properties.TryGetValue("size", out var lvlSizeRaw) && !string.IsNullOrEmpty(lvlSizeRaw))
+        {
+            var rp = EnsureRPr();
+            var halfPt = (int)Math.Round(ParseFontSize(lvlSizeRaw) * 2, MidpointRounding.AwayFromZero);
+            rp.AppendChild(new FontSize { Val = halfPt.ToString() });
+        }
+        if (properties.TryGetValue("color", out var lvlColorRaw) && !string.IsNullOrEmpty(lvlColorRaw))
+        {
+            var rp = EnsureRPr();
+            rp.AppendChild(new Color { Val = SanitizeHex(lvlColorRaw) });
+        }
+        if (properties.TryGetValue("bold", out var lvlBoldRaw) && IsTruthy(lvlBoldRaw))
+        {
+            EnsureRPr().AppendChild(new Bold());
+        }
+        if (properties.TryGetValue("italic", out var lvlItalRaw) && IsTruthy(lvlItalRaw))
+        {
+            EnsureRPr().AppendChild(new Italic());
+        }
+        if (properties.TryGetValue("underline", out var lvlUnderRaw) && !string.IsNullOrEmpty(lvlUnderRaw))
+        {
+            var u = new Underline();
+            if (IsTruthy(lvlUnderRaw)) u.Val = UnderlineValues.Single;
+            else if (string.Equals(lvlUnderRaw, "double", StringComparison.OrdinalIgnoreCase)) u.Val = UnderlineValues.Double;
+            else if (string.Equals(lvlUnderRaw, "none", StringComparison.OrdinalIgnoreCase) || string.Equals(lvlUnderRaw, "false", StringComparison.OrdinalIgnoreCase)) u.Val = UnderlineValues.None;
+            else u.Val = UnderlineValues.Single;
+            EnsureRPr().AppendChild(u);
+        }
+        if (rPr != null) level.AppendChild(rPr);
+
         // CRITICAL: AppendChild — NOT AddChild. Schema-aware AddChild treats
         // <w:lvl> as a single-instance child slot (the SDK's metadata says
         // "lvl[0..8]" but its schema model still flags them all as the same

--- a/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
@@ -482,14 +482,43 @@ public partial class WordHandler
         // to keep the call idempotent-ish for scripts that only pass --prop name.
         bool IdTaken(string candidate) => stylesPart.Styles.Elements<Style>()
             .Any(s => string.Equals(s.StyleId?.Value, candidate, StringComparison.Ordinal));
+        // BUG-R6-03: dump→batch on a fresh blank docx fails 42×
+        // ("Style Normal already exists") because real documents always
+        // carry built-in style definitions (Normal, Heading1-9, Title,
+        // ListParagraph, …) and the blank template ships with the same
+        // ids reserved. For built-in ids the safe semantics is upsert:
+        // remove the existing definition and let the rest of AddStyle
+        // re-create it with the caller's full property bag. Mirrors
+        // BlankDocCreator's hands-off treatment of built-ins (it only
+        // registers the bare style scaffolding).
+        var builtInIdsForUpsert = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Normal", "Heading1", "Heading2", "Heading3", "Heading4", "Heading5",
+            "Heading6", "Heading7", "Heading8", "Heading9", "Title", "Subtitle",
+            "Quote", "IntenseQuote", "ListParagraph", "NoSpacing", "TOCHeading",
+            "DefaultParagraphFont", "TableNormal", "NoList",
+        };
         if (IdTaken(styleId))
         {
-            if (explicitId)
+            if (builtInIdsForUpsert.Contains(styleId))
+            {
+                // Idempotent re-add: drop the existing definition. We
+                // preserve the explicitId path's strictness for non-
+                // built-in ids so users authoring custom styles still
+                // see a clear "duplicate id" error.
+                var existing = stylesPart.Styles.Elements<Style>()
+                    .FirstOrDefault(s => string.Equals(s.StyleId?.Value, styleId, StringComparison.Ordinal));
+                existing?.Remove();
+            }
+            else if (explicitId)
                 throw new ArgumentException(
                     $"Style '{styleId}' already exists. Pick a unique --prop id or --prop name.");
-            var baseId = styleId;
-            int suffix = 2;
-            while (IdTaken(styleId)) styleId = $"{baseId}{suffix++}";
+            else
+            {
+                var baseId = styleId;
+                int suffix = 2;
+                while (IdTaken(styleId)) styleId = $"{baseId}{suffix++}";
+            }
         }
 
         // OOXML requires w:name to be unique across styles.xml, same as w:styleId.

--- a/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
@@ -602,6 +602,14 @@ public partial class WordHandler
                 : new DocumentFormat.OpenXml.EnumValue<LineSpacingRuleValues>(LineSpacingRuleValues.Exact);
             hasPPr = true;
         }
+        // BUG-019: explicit lineRule override (auto/exact/atLeast) — needed
+        // because lineSpacing alone serializes AtLeast and Exact identically.
+        if (properties.TryGetValue("lineRule", out var sLineRule) || properties.TryGetValue("linerule", out sLineRule))
+        {
+            var sp = stylePPr.SpacingBetweenLines ?? (stylePPr.SpacingBetweenLines = new SpacingBetweenLines());
+            sp.LineRule = ParseLineRule(sLineRule);
+            hasPPr = true;
+        }
         // Reading direction: <w:bidi/> on style pPr (mirrors AddParagraph).
         // Without this, `add /styles --prop direction=rtl` either fell through
         // to the dotted-key probe (which writes <w:rtl/> on rPr but skips

--- a/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
@@ -464,10 +464,19 @@ public partial class WordHandler
                    ?? properties.GetValueOrDefault("styleName")
                    ?? properties.GetValueOrDefault("stylename")
                    ?? "CustomStyle";
+        // BUG-R7-08: when the caller passes only `id` (no name), AddStyle used
+        // to default the name to the id. That mutated the round-trip output
+        // for any docx whose original style had an `id` but no `<w:name>`
+        // (or empty name) — the next dump showed `name=<id>`. Preserve the
+        // "no explicit name" intent by emitting an empty <w:name w:val=""/>
+        // (still schema-valid; matches the original).
+        var explicitName = properties.ContainsKey("name")
+            || properties.ContainsKey("styleName")
+            || properties.ContainsKey("stylename");
         var styleName = properties.GetValueOrDefault("name")
                      ?? properties.GetValueOrDefault("styleName")
                      ?? properties.GetValueOrDefault("stylename")
-                     ?? styleId;
+                     ?? (explicitName ? styleId : "");
         var styleType = properties.GetValueOrDefault("type", "paragraph").ToLowerInvariant() switch
         {
             "character" or "char" => StyleValues.Character,
@@ -527,7 +536,10 @@ public partial class WordHandler
         // that users could not tell apart (BUG-R17-02).
         bool NameTaken(string candidate) => stylesPart.Styles.Elements<Style>()
             .Any(s => string.Equals(s.StyleName?.Val?.Value, candidate, StringComparison.Ordinal));
-        if (NameTaken(styleName))
+        // BUG-R7-08: empty styleName (id-only style, see styleName fallback
+        // above) is allowed to repeat — multiple unnamed styles round-trip
+        // from real docx files where the author left out the display name.
+        if (!string.IsNullOrEmpty(styleName) && NameTaken(styleName))
             throw new ArgumentException(
                 $"Style with name '{styleName}' already exists. Pick a unique --prop name.");
 

--- a/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
@@ -791,6 +791,48 @@ public partial class WordHandler
                     key, value);
                 continue;
             }
+            // CONSISTENCY(style-indent): list-family styles round-trip with
+            // leftIndent / hangingIndent / firstLineIndent / rightIndent on the
+            // style definition (BUG BT-5). Mirror SetStylePath's wiring so
+            // dump→batch survives without losing list indents.
+            switch (key.ToLowerInvariant())
+            {
+                case "leftindent":
+                {
+                    var pPrLi = newStyle.StyleParagraphProperties ?? EnsureStyleParagraphProperties(newStyle);
+                    var indLi = pPrLi.Indentation ?? (pPrLi.Indentation = new Indentation());
+                    indLi.Left = SpacingConverter.ParseWordSpacing(value).ToString();
+                    continue;
+                }
+                case "rightindent":
+                {
+                    var pPrRi = newStyle.StyleParagraphProperties ?? EnsureStyleParagraphProperties(newStyle);
+                    var indRi = pPrRi.Indentation ?? (pPrRi.Indentation = new Indentation());
+                    indRi.Right = SpacingConverter.ParseWordSpacing(value).ToString();
+                    continue;
+                }
+                case "firstlineindent":
+                {
+                    var pPrFli = newStyle.StyleParagraphProperties ?? EnsureStyleParagraphProperties(newStyle);
+                    var indFli = pPrFli.Indentation ?? (pPrFli.Indentation = new Indentation());
+                    indFli.FirstLine = SpacingConverter.ParseWordSpacing(value).ToString();
+                    continue;
+                }
+                case "hangingindent":
+                {
+                    var pPrHi = newStyle.StyleParagraphProperties ?? EnsureStyleParagraphProperties(newStyle);
+                    var indHi = pPrHi.Indentation ?? (pPrHi.Indentation = new Indentation());
+                    indHi.Hanging = SpacingConverter.ParseWordSpacing(value).ToString();
+                    continue;
+                }
+                case "pbdr.top" or "pbdr.bottom" or "pbdr.left" or "pbdr.right" or "pbdr.between" or "pbdr.bar" or "pbdr.all" or "pbdr":
+                {
+                    var pPrB = newStyle.StyleParagraphProperties ?? EnsureStyleParagraphProperties(newStyle);
+                    ApplyStyleParagraphBorders(pPrB, key, value);
+                    continue;
+                }
+            }
+
             // Anything still unconsumed is a genuine silent drop — composites
             // (font.eastAsia, ind.firstLine, tabs, numId, ...) that the
             // curated AddStyle does not yet model. Record so the CLI layer

--- a/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
@@ -538,6 +538,21 @@ public partial class WordHandler
             sp.After = SpacingConverter.ParseWordSpacing(sSAfter).ToString();
             hasPPr = true;
         }
+        // CONSISTENCY(add-set-symmetry): mirror SetStylePath's lineSpacing case
+        // (WordHandler.Set.Dispatch.cs:1403). Without this, `add /styles … --prop
+        // lineSpacing=1.5x` was silent-dropped while `set /styles/X --prop
+        // lineSpacing=1.5x` worked, breaking dump → batch round-trip on style
+        // entries (BUG-R2-08 / BT-8).
+        if (properties.TryGetValue("linespacing", out var sLineSpacing) || properties.TryGetValue("lineSpacing", out sLineSpacing))
+        {
+            var sp = stylePPr.SpacingBetweenLines ?? (stylePPr.SpacingBetweenLines = new SpacingBetweenLines());
+            var (twips, isMultiplier) = SpacingConverter.ParseWordLineSpacing(sLineSpacing);
+            sp.Line = twips.ToString();
+            sp.LineRule = isMultiplier
+                ? new DocumentFormat.OpenXml.EnumValue<LineSpacingRuleValues>(LineSpacingRuleValues.Auto)
+                : new DocumentFormat.OpenXml.EnumValue<LineSpacingRuleValues>(LineSpacingRuleValues.Exact);
+            hasPPr = true;
+        }
         // Reading direction: <w:bidi/> on style pPr (mirrors AddParagraph).
         // Without this, `add /styles --prop direction=rtl` either fell through
         // to the dotted-key probe (which writes <w:rtl/> on rPr but skips
@@ -711,7 +726,8 @@ public partial class WordHandler
             "name", "styleName", "stylename",
             "type", "basedon", "basedOn", "next",
             "align", "alignment", "spacebefore", "spaceBefore",
-            "spaceafter", "spaceAfter", "font", "size", "bold", "italic", "color",
+            "spaceafter", "spaceAfter", "linespacing", "lineSpacing",
+            "font", "size", "bold", "italic", "color",
             "direction", "dir", "bidi",
             "font.ascii", "font.hAnsi", "font.eastAsia", "font.cs",
             "numId", "numid", "ilvl", "numLevel", "numlevel",

--- a/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
@@ -544,14 +544,12 @@ public partial class WordHandler
                 $"Style with name '{styleName}' already exists. Pick a unique --prop name.");
 
         // Built-in styles must not have customStyle=true, or Word won't recognize them
-        // (e.g. TOC won't find Heading1 if it's marked as custom)
-        var builtInIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "Normal", "Heading1", "Heading2", "Heading3", "Heading4", "Heading5",
-            "Heading6", "Heading7", "Heading8", "Heading9", "Title", "Subtitle",
-            "Quote", "IntenseQuote", "ListParagraph", "NoSpacing", "TOCHeading"
-        };
-        var isBuiltIn = builtInIds.Contains(styleId);
+        // (e.g. TOC won't find Heading1 if it's marked as custom).
+        // BUG-023 — single source of truth: reuse the upsert set above so that
+        // DefaultParagraphFont / TableNormal / NoList (idempotent re-adds on
+        // dump→batch) don't get stamped customStyle=true and break Word's
+        // run-style fallback chain.
+        var isBuiltIn = builtInIdsForUpsert.Contains(styleId);
 
         var newStyle = new Style
         {

--- a/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Structure.cs
@@ -389,6 +389,14 @@ public partial class WordHandler
         var instrBuilder = new StringBuilder($" TOC \\o \"{levels}\"");
         if (hyperlinks) instrBuilder.Append(" \\h");
         if (!pageNumbers) instrBuilder.Append(" \\z");
+        // BUG-R5-03: \t = custom-style→level mapping (Word's "Style; level"
+        // syntax, e.g. "MyHeading,1,MySub,2"); \b = bookmark scope (single
+        // bookmark name). Both round-trip through dump→add and were
+        // silently dropped before, breaking custom TOC layouts.
+        if (properties.TryGetValue("customStyles", out var cs) && !string.IsNullOrEmpty(cs))
+            instrBuilder.Append($" \\t \"{cs}\"");
+        if (properties.TryGetValue("bookmark", out var bm) && !string.IsNullOrEmpty(bm))
+            instrBuilder.Append($" \\b \"{bm}\"");
         instrBuilder.Append(" \\u ");
 
         var tocPara = new Paragraph();

--- a/src/officecli/Handlers/Word/WordHandler.Add.Table.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Table.cs
@@ -184,8 +184,13 @@ public partial class WordHandler
                 if (!string.IsNullOrEmpty(cellText))
                     cellPara.AppendChild(new Run(new Text(cellText) { Space = SpaceProcessingModeValues.Preserve }));
                 var cell = new TableCell(cellPara);
-                if (colWidthArr != null && c < colWidthArr.Length)
-                    cell.PrependChild(new TableCellProperties(new TableCellWidth { Width = colWidthArr[c].ToString(), Type = TableWidthUnitValues.Dxa }));
+                // BUG-R6-06 / BUG-R6-01: do NOT stamp an explicit
+                // <w:tcW> on every cell when the user supplied colWidths
+                // — w:tblGrid/w:gridCol already encodes the column
+                // widths, and per-cell tcW makes dump→batch→dump
+                // non-idempotent (each round-trip emits N×M extra
+                // `set width=…` commands). Cells without a tcW inherit
+                // the column width from tblGrid as the schema intends.
                 row.AppendChild(cell);
             }
             table.AppendChild(row);

--- a/src/officecli/Handlers/Word/WordHandler.Add.Table.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Table.cs
@@ -173,8 +173,13 @@ public partial class WordHandler
             {
                 var cellText = tableData != null && r < tableData.Length && c < tableData[r].Length
                     ? tableData[r][c] : (properties.TryGetValue($"r{r + 1}c{c + 1}", out var rc) ? rc : "");
-                var cellPara = new Paragraph(new ParagraphProperties(
-                    new SpacingBetweenLines { After = "0", Line = "240", LineRule = LineSpacingRuleValues.Auto }));
+                // CONSISTENCY(table-cell-defaults): do not stamp explicit
+                // spaceAfter=0 / lineSpacing=240 Auto on freshly-created cell
+                // paragraphs — let them inherit from style/docDefaults like
+                // regular body paragraphs. Otherwise dump→batch round-trip
+                // grows 67 extra `set spaceAfter=0pt lineSpacing=1x` commands
+                // per cell (BUG-R3-3).
+                var cellPara = new Paragraph();
                 AssignParaId(cellPara);
                 if (!string.IsNullOrEmpty(cellText))
                     cellPara.AppendChild(new Run(new Text(cellText) { Space = SpaceProcessingModeValues.Preserve }));

--- a/src/officecli/Handlers/Word/WordHandler.Add.Table.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Table.cs
@@ -18,23 +18,40 @@ public partial class WordHandler
     private string AddTable(OpenXmlElement parent, string parentPath, int? index, Dictionary<string, string> properties)
     {
         var table = new Table();
-        var tblProps = new TableProperties(
-            new TableBorders(
-                new TopBorder { Val = BorderValues.Single, Size = 4 },
-                new LeftBorder { Val = BorderValues.Single, Size = 4 },
-                new BottomBorder { Val = BorderValues.Single, Size = 4 },
-                new RightBorder { Val = BorderValues.Single, Size = 4 },
-                new InsideHorizontalBorder { Val = BorderValues.Single, Size = 4 },
-                new InsideVerticalBorder { Val = BorderValues.Single, Size = 4 }
-            )
-        );
-        table.AppendChild(tblProps);
-
-        // Apply border properties from Add parameters
-        foreach (var (bk, bv) in properties)
+        // BUG-R7-03: Previously this always seeded all 6 borders (top/bottom/
+        // left/right/insideH/insideV) and then applied user props on top —
+        // which corrupted three-line tables (top+bottom only) on round-trip
+        // because dump emits only the user-set sides. When the caller passes
+        // ANY border.* prop, treat it as an explicit specification: start
+        // with an empty TableBorders and apply only the requested sides.
+        // Otherwise (no border props at all), keep the historical default
+        // grid look so bare `add table` still produces a visible table.
+        var hasExplicitBorders = properties.Keys.Any(k =>
+            k.StartsWith("border", StringComparison.OrdinalIgnoreCase));
+        TableProperties tblProps;
+        if (hasExplicitBorders)
         {
-            if (bk.StartsWith("border", StringComparison.OrdinalIgnoreCase))
-                ApplyTableBorders(tblProps, bk, bv);
+            tblProps = new TableProperties(new TableBorders());
+            table.AppendChild(tblProps);
+            foreach (var (bk, bv) in properties)
+            {
+                if (bk.StartsWith("border", StringComparison.OrdinalIgnoreCase))
+                    ApplyTableBorders(tblProps, bk, bv);
+            }
+        }
+        else
+        {
+            tblProps = new TableProperties(
+                new TableBorders(
+                    new TopBorder { Val = BorderValues.Single, Size = 4 },
+                    new LeftBorder { Val = BorderValues.Single, Size = 4 },
+                    new BottomBorder { Val = BorderValues.Single, Size = 4 },
+                    new RightBorder { Val = BorderValues.Single, Size = 4 },
+                    new InsideHorizontalBorder { Val = BorderValues.Single, Size = 4 },
+                    new InsideVerticalBorder { Val = BorderValues.Single, Size = 4 }
+                )
+            );
+            table.AppendChild(tblProps);
         }
 
         // Parse data if provided: "H1,H2;R1C1,R1C2;R2C1,R2C2" or CSV file/URL/data-URI

--- a/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
@@ -654,6 +654,25 @@ public partial class WordHandler
                 ?? pProps.AppendChild(new ParagraphMarkRunProperties());
             if (Core.TypedAttributeFallback.TrySet(paraMarkRPr, key, value)) continue;
             if (paraMarkRPr.ChildElements.Count == 0) paraMarkRPr.Remove();
+            // BUG-R5-04 / BUG-R5-05: bare-key val-leaves (textboxTightWrap,
+            // divId, …) had no fallback path on Add — only TypedAttributeFallback,
+            // which requires dotted keys. dump→batch round-trip emits these
+            // as bare keys on `add p`, so they were silently dropped. Try
+            // TryCreateTypedChild on pPr first (paragraph-scope leaves like
+            // textboxTightWrap, divId), then on the run rPr / paragraph-mark
+            // rPr for run-scope leaves (webHidden — BUG-R5-06: dump misplaces
+            // it onto the paragraph, but accepting it on either container
+            // here lets dump→replay succeed without losing the property).
+            if (!key.Contains('.'))
+            {
+                if (Core.GenericXmlQuery.TryCreateTypedChild(pProps, key, value)) continue;
+                if (rPropsForFallback != null
+                    && Core.GenericXmlQuery.TryCreateTypedChild(rPropsForFallback, key, value)) continue;
+                var fallbackMarkRPr = pProps.GetFirstChild<ParagraphMarkRunProperties>()
+                    ?? pProps.AppendChild(new ParagraphMarkRunProperties());
+                if (Core.GenericXmlQuery.TryCreateTypedChild(fallbackMarkRPr, key, value)) continue;
+                if (fallbackMarkRPr.ChildElements.Count == 0) fallbackMarkRPr.Remove();
+            }
             LastAddUnsupportedProps.Add(key);
         }
 

--- a/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
@@ -207,6 +207,16 @@ public partial class WordHandler
             spacing.Line = twips.ToString();
             spacing.LineRule = isMultiplier ? LineSpacingRuleValues.Auto : LineSpacingRuleValues.Exact;
         }
+        // BUG-019: lineSpacing alone cannot distinguish AtLeast from Exact —
+        // both serialize as "Npt" via SpacingConverter. Accept an explicit
+        // `lineRule` prop (auto/exact/atLeast) so dump→batch round-trips
+        // preserve the rule. Without this, AtLeast spacing silently
+        // downgraded to Exact, producing glyph clipping on tall content.
+        if (properties.TryGetValue("lineRule", out var pLineRule) || properties.TryGetValue("linerule", out pLineRule))
+        {
+            var spacing = pProps.SpacingBetweenLines ?? (pProps.SpacingBetweenLines = new SpacingBetweenLines());
+            spacing.LineRule = ParseLineRule(pLineRule);
+        }
         // Numbering properties. Parallel branches so `ilvl` alone still
         // emits <w:ilvl> (matching `set --prop ilvl=N` behaviour); both
         // inputs are range-checked so schema-invalid values never reach XML.

--- a/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
@@ -405,6 +405,18 @@ public partial class WordHandler
                 if (rfCs != null) rFonts.ComplexScript = rfCs;
                 rProps.AppendChild(rFonts);
             }
+            // BUG-R6-03 / F-3: rStyle binds the paragraph mark above (so the
+            // style sticks to the paragraph) but the implicit text run
+            // rendered alongside `text=…` previously inherited Normal —
+            // every dump→batch round-trip silently dropped run-style
+            // formatting from headings (`add p text=… rStyle=Strong`).
+            // Apply rStyle to the implicit run rPr too so the visible text
+            // picks up the character style in addition to the mark.
+            if (properties.TryGetValue("rStyle", out var pRunRStyle)
+                || properties.TryGetValue("rstyle", out pRunRStyle))
+            {
+                rProps.RunStyle = new RunStyle { Val = pRunRStyle };
+            }
             if (properties.TryGetValue("size", out var size) || properties.TryGetValue("font.size", out size) || properties.TryGetValue("fontsize", out size))
             {
                 rProps.AppendChild(new FontSize { Val = ((int)Math.Round(ParseFontSize(size) * 2, MidpointRounding.AwayFromZero)).ToString() });

--- a/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
@@ -227,6 +227,32 @@ public partial class WordHandler
             ind.FirstLine = null;
         }
         // firstlineindent already handled above (line ~66-74) with × 480 conversion
+        // BUG-R5-F3: Get already exposes char-based indent values that
+        // CJK Word documents emit heavily (firstLineChars, leftChars,
+        // rightChars, hangingChars — w:ind/@w:firstLineChars etc., units
+        // of 1/100 of a Chinese-character width). Add ignored them, so
+        // dump→replay produced 750+ UNSUPPORTED warnings on Chinese docs
+        // and lost the chars-based indent silently. Accept them on Add.
+        if (properties.TryGetValue("firstLineChars", out var addFLC) || properties.TryGetValue("firstlinechars", out addFLC))
+        {
+            var ind = pProps.Indentation ?? (pProps.Indentation = new Indentation());
+            ind.FirstLineChars = ParseHelpers.SafeParseInt(addFLC, "firstLineChars");
+        }
+        if (properties.TryGetValue("leftChars", out var addLC) || properties.TryGetValue("leftchars", out addLC))
+        {
+            var ind = pProps.Indentation ?? (pProps.Indentation = new Indentation());
+            ind.LeftChars = ParseHelpers.SafeParseInt(addLC, "leftChars");
+        }
+        if (properties.TryGetValue("rightChars", out var addRC) || properties.TryGetValue("rightchars", out addRC))
+        {
+            var ind = pProps.Indentation ?? (pProps.Indentation = new Indentation());
+            ind.RightChars = ParseHelpers.SafeParseInt(addRC, "rightChars");
+        }
+        if (properties.TryGetValue("hangingChars", out var addHC) || properties.TryGetValue("hangingchars", out addHC))
+        {
+            var ind = pProps.Indentation ?? (pProps.Indentation = new Indentation());
+            ind.HangingChars = ParseHelpers.SafeParseInt(addHC, "hangingChars");
+        }
         if ((properties.TryGetValue("keepnext", out var addKN) || properties.TryGetValue("keepNext", out addKN)) && IsTruthy(addKN))
             pProps.KeepNext = new KeepNext();
         if ((properties.TryGetValue("keeplines", out var addKL) || properties.TryGetValue("keeptogether", out addKL) || properties.TryGetValue("keepLines", out addKL) || properties.TryGetValue("keepTogether", out addKL)) && IsTruthy(addKL))
@@ -546,6 +572,11 @@ public partial class WordHandler
             "style", "styleid", "stylename",
             "align", "alignment", "direction", "dir", "bidi",
             "firstlineindent", "leftindent", "indentleft", "indent",
+            // BUG-R5-F3: chars-based indent variants consumed above.
+            "firstlinechars", "firstLineChars",
+            "leftchars", "leftChars",
+            "rightchars", "rightChars",
+            "hangingchars", "hangingChars",
             "rightindent", "indentright", "hangingindent", "hanging",
             "spacebefore", "spaceafter", "linespacing", "lineSpacing",
             "keepnext", "keepwithnext", "keeplines", "keeptogether",

--- a/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
@@ -277,8 +277,15 @@ public partial class WordHandler
             // CONSISTENCY(add-set-symmetry): Set accepts border.top/bottom/left/right/between/bar
             // (and bare "border"/"border.all"); Add must accept the same vocabulary so the
             // Add → Get → verify lifecycle works without a follow-up Set call.
-            if (pk.StartsWith("pbdr", StringComparison.OrdinalIgnoreCase)
-                || pk.StartsWith("border", StringComparison.OrdinalIgnoreCase))
+            // 3-segment keys (pbdr.top.sz / pbdr.top.color / pbdr.top.space)
+            // surface in Get readback but Set's TrySetParagraphProp switch
+            // doesn't model them either — calling ApplyParagraphBorders with a
+            // 3-segment key drives ParseBorderValue with the sub-attribute
+            // value (e.g. "4"), which throws "Invalid border style: '4'".
+            // Skip them here to keep Add/Set symmetry (BUG-R2-02 / BT-2).
+            if ((pk.StartsWith("pbdr", StringComparison.OrdinalIgnoreCase)
+                 || pk.StartsWith("border", StringComparison.OrdinalIgnoreCase))
+                && pk.Count(ch => ch == '.') < 2)
                 ApplyParagraphBorders(pProps, pk, pv);
         }
         if (properties.TryGetValue("liststyle", out var listStyle) || properties.TryGetValue("listStyle", out listStyle))
@@ -506,6 +513,7 @@ public partial class WordHandler
             "spacebefore", "spaceafter", "linespacing", "lineSpacing",
             "keepnext", "keepwithnext", "keeplines", "keeptogether",
             "pagebreakbefore", "break",
+            "widowcontrol", "widowControl",
             "numid", "numId", "ilvl", "numlevel", "numLevel",
             "liststyle", "listStyle", "start", "level", "listLevel", "listlevel",
             "outlinelevel", "outlineLevel",
@@ -888,6 +896,15 @@ public partial class WordHandler
             newRProps.Imprint = new Imprint();
         if (properties.TryGetValue("noproof", out var rNoProof) && IsTruthy(rNoProof))
             newRProps.NoProof = new NoProof();
+        // CONSISTENCY(add-set-symmetry): Set surfaces rStyle via the typed-attr
+        // fallback; Add must accept it explicitly because the bare-key fallback
+        // below skips dotless keys without warning. Without this, dump → batch
+        // round-trips silently strip every <w:rStyle/> (BUG-R2-05 / BT-5).
+        if (properties.TryGetValue("rStyle", out var rRStyle) || properties.TryGetValue("rstyle", out rRStyle))
+        {
+            if (!string.IsNullOrEmpty(rRStyle))
+                newRProps.RunStyle = new RunStyle { Val = rRStyle };
+        }
         if (properties.TryGetValue("rtl", out var rRtl) && IsTruthy(rRtl))
             ApplyRunFormatting(newRProps, "rtl", "true");
         // CONSISTENCY(canonical-key): accept "direction"=rtl|ltr as the

--- a/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
@@ -383,11 +383,21 @@ public partial class WordHandler
                 // way ApplyRunFormatting (Set path) does — otherwise
                 // Add(.., {color=accent1}) would call SanitizeHex on the
                 // scheme name and produce garbage hex.
-                var pSchemeName = OfficeCli.Core.ParseHelpers.NormalizeSchemeColorName(pColor);
-                if (pSchemeName != null)
-                    rProps.Color = new Color { Val = "auto", ThemeColor = new EnumValue<ThemeColorValues>(new ThemeColorValues(pSchemeName)) };
+                // CONSISTENCY(color-auto): bare "auto" is a legal Color val
+                // (Word's "automatic" text color); short-circuit before the
+                // scheme branch since "auto" is not a ThemeColorValues enum.
+                if (string.Equals(pColor, "auto", StringComparison.OrdinalIgnoreCase))
+                {
+                    rProps.Color = new Color { Val = "auto" };
+                }
                 else
-                    rProps.Color = new Color { Val = SanitizeHex(pColor) };
+                {
+                    var pSchemeName = OfficeCli.Core.ParseHelpers.NormalizeSchemeColorName(pColor);
+                    if (pSchemeName != null)
+                        rProps.Color = new Color { Val = "auto", ThemeColor = new EnumValue<ThemeColorValues>(new ThemeColorValues(pSchemeName)) };
+                    else
+                        rProps.Color = new Color { Val = SanitizeHex(pColor) };
+                }
             }
             if (properties.TryGetValue("underline", out var pUnderline) || properties.TryGetValue("font.underline", out pUnderline))
             {
@@ -854,11 +864,19 @@ public partial class WordHandler
             // CONSISTENCY(theme-color): Add run color accepts scheme color
             // names (accent1, dark2, hyperlink, …); same logic as
             // ApplyRunFormatting in WordHandler.Helpers.cs.
-            var rSchemeName = OfficeCli.Core.ParseHelpers.NormalizeSchemeColorName(rColor);
-            if (rSchemeName != null)
-                newRProps.Color = new Color { Val = "auto", ThemeColor = new EnumValue<ThemeColorValues>(new ThemeColorValues(rSchemeName)) };
+            // CONSISTENCY(color-auto): see WordHandler.Helpers.cs ApplyRunFormatting.
+            if (string.Equals(rColor, "auto", StringComparison.OrdinalIgnoreCase))
+            {
+                newRProps.Color = new Color { Val = "auto" };
+            }
             else
-                newRProps.Color = new Color { Val = SanitizeHex(rColor) };
+            {
+                var rSchemeName = OfficeCli.Core.ParseHelpers.NormalizeSchemeColorName(rColor);
+                if (rSchemeName != null)
+                    newRProps.Color = new Color { Val = "auto", ThemeColor = new EnumValue<ThemeColorValues>(new ThemeColorValues(rSchemeName)) };
+                else
+                    newRProps.Color = new Color { Val = SanitizeHex(rColor) };
+            }
         }
         if (properties.TryGetValue("underline", out var rUnderline) || properties.TryGetValue("font.underline", out rUnderline))
         {

--- a/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
@@ -108,6 +108,76 @@ public partial class WordHandler
             var markRPr = pProps.ParagraphMarkRunProperties ?? pProps.AppendChild(new ParagraphMarkRunProperties());
             ApplyRunFormatting(markRPr, "size.cs", paraSizeCs);
         }
+        // BUG-R7-07: when the paragraph has no `text` prop, no run is created
+        // — yet style-overriding run-level props (size, italic=false,
+        // bold=false, color, font.* …) must still ride on the paragraph mark
+        // rPr so they survive the next dump. Without this hoist, dump→batch
+        // round-trip silently drops the override and the style's defaults
+        // re-emerge (e.g. `style=TOC2 size=11pt` → 12pt because TOC2's
+        // base size is 12pt). Mirrors the size.cs/italic.cs/bold.cs hoist
+        // above. Only applied when there is no text run carrier.
+        if (!properties.ContainsKey("text"))
+        {
+            ParagraphMarkRunProperties? noTextMarkRPr = null;
+            ParagraphMarkRunProperties EnsureNoTextMarkRPr() =>
+                noTextMarkRPr ??= (pProps.ParagraphMarkRunProperties
+                    ?? pProps.AppendChild(new ParagraphMarkRunProperties()));
+            if (properties.TryGetValue("size", out var ntSize)
+                || properties.TryGetValue("font.size", out ntSize)
+                || properties.TryGetValue("fontsize", out ntSize))
+                ApplyRunFormatting(EnsureNoTextMarkRPr(), "size", ntSize);
+            // BUG-R7-07 / F-7: explicit `false` must produce <w:b w:val="false"/>
+            // (resp. <w:i w:val="false"/>) so it overrides a style that sets
+            // bold/italic=true. ApplyRunFormatting on its own removes the
+            // element entirely on a falsy value — that contract is preserved
+            // for the Set-after-create call sites (existing R25/R26 tests
+            // depend on it). Only the Add path needs the explicit-override
+            // semantics, so emit the val=false form directly here.
+            if (properties.TryGetValue("bold", out var ntBold)
+                || properties.TryGetValue("font.bold", out ntBold))
+            {
+                var rp = EnsureNoTextMarkRPr();
+                rp.RemoveAllChildren<Bold>();
+                if (IsTruthy(ntBold))
+                    InsertRunPropInSchemaOrder(rp, new Bold());
+                else if (IsExplicitFalseAddOverride(ntBold))
+                    InsertRunPropInSchemaOrder(rp, new Bold { Val = OnOffValue.FromBoolean(false) });
+            }
+            if (properties.TryGetValue("italic", out var ntItalic)
+                || properties.TryGetValue("font.italic", out ntItalic))
+            {
+                var rp = EnsureNoTextMarkRPr();
+                rp.RemoveAllChildren<Italic>();
+                if (IsTruthy(ntItalic))
+                    InsertRunPropInSchemaOrder(rp, new Italic());
+                else if (IsExplicitFalseAddOverride(ntItalic))
+                    InsertRunPropInSchemaOrder(rp, new Italic { Val = OnOffValue.FromBoolean(false) });
+            }
+            if (properties.TryGetValue("color", out var ntColor)
+                || properties.TryGetValue("font.color", out ntColor))
+                ApplyRunFormatting(EnsureNoTextMarkRPr(), "color", ntColor);
+            if (properties.TryGetValue("underline", out var ntUl)
+                || properties.TryGetValue("font.underline", out ntUl))
+                ApplyRunFormatting(EnsureNoTextMarkRPr(), "underline", ntUl);
+            if (properties.TryGetValue("strike", out var ntStrike)
+                || properties.TryGetValue("font.strike", out ntStrike)
+                || properties.TryGetValue("strikethrough", out ntStrike)
+                || properties.TryGetValue("font.strikethrough", out ntStrike))
+                ApplyRunFormatting(EnsureNoTextMarkRPr(), "strike", ntStrike);
+            if (properties.TryGetValue("font", out var ntFont)
+                || properties.TryGetValue("font.name", out ntFont))
+                ApplyRunFormatting(EnsureNoTextMarkRPr(), "font", ntFont);
+            if (properties.TryGetValue("font.latin", out var ntFontLatin))
+                ApplyRunFormatting(EnsureNoTextMarkRPr(), "font.latin", ntFontLatin);
+            if (properties.TryGetValue("font.ea", out var ntFontEa)
+                || properties.TryGetValue("font.eastasia", out ntFontEa)
+                || properties.TryGetValue("font.eastasian", out ntFontEa))
+                ApplyRunFormatting(EnsureNoTextMarkRPr(), "font.ea", ntFontEa);
+            if (properties.TryGetValue("font.cs", out var ntFontCs)
+                || properties.TryGetValue("font.complexscript", out ntFontCs)
+                || properties.TryGetValue("font.complex", out ntFontCs))
+                ApplyRunFormatting(EnsureNoTextMarkRPr(), "font.cs", ntFontCs);
+        }
         if (properties.TryGetValue("firstlineindent", out var indent) || properties.TryGetValue("firstLineIndent", out indent))
         {
             // Lenient input: accept "2cm", "0.5in", "18pt", or bare twips (backward compat).
@@ -609,6 +679,11 @@ public partial class WordHandler
             "caps", "smallcaps",
             "boldcs", "italiccs", "sizecs",
             "field", "formula", "ref", "id",
+            // BUG-R7-06: bdr (character border) and kern (kerning) are
+            // run-level OOXML keys — handled via ApplyRunFormatting on the
+            // bare-key fallback path below. Listing them here just prevents
+            // double-routing through TypedAttributeFallback.
+            "bdr", "kern",
         };
         foreach (var (key, value) in properties)
         {
@@ -1115,6 +1190,35 @@ public partial class WordHandler
         // gets routed through TypedAttributeFallback; failures land in
         // LastAddUnsupportedProps so the CLI surfaces a WARNING instead
         // of silently dropping. CONSISTENCY(add-set-symmetry).
+        // BUG-R7-06: bare run-level keys (bdr / kern / lang shortcuts) that
+        // the curated AddRun block above did not consume — route through
+        // ApplyRunFormatting so batch replay actually applies them instead
+        // of silently dropping. Mirrors the bare-key fallback in
+        // AddParagraph (line 670). CONSISTENCY(add-set-symmetry).
+        var addRunCuratedBare = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "type", "text", "html", "anchor", "anchorid",
+            "font", "size", "bold", "italic", "color", "highlight",
+            "underline", "strike", "strikethrough", "doublestrike", "dstrike",
+            "vanish", "outline", "shadow", "emboss", "imprint", "noproof",
+            "rtl", "vertalign", "superscript", "subscript",
+            "charspacing", "letterspacing",
+            "caps", "smallcaps", "allcaps",
+            "boldcs", "italiccs", "sizecs",
+            "shd", "shading",
+            "rstyle", "rStyle",
+            "textoutline", "textfill", "w14shadow", "w14glow", "w14reflection",
+            "field", "formula", "ref", "id",
+        };
+        foreach (var (key, value) in properties)
+        {
+            if (key.Contains('.')) continue;
+            if (addRunCuratedBare.Contains(key)) continue;
+            if (ApplyRunFormatting(newRProps, key, value)) continue;
+            // ApplyRunFormatting returned false → genuinely unsupported.
+            // Mark for the CLI WARNING surface (LastAddUnsupportedProps).
+            LastAddUnsupportedProps.Add(key);
+        }
         foreach (var (key, value) in properties)
         {
             if (!key.Contains('.')) continue;

--- a/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
@@ -272,6 +272,33 @@ public partial class WordHandler
             pProps.ContextualSpacing = IsTruthy(addCS)
                 ? new ContextualSpacing()
                 : new ContextualSpacing { Val = false };
+        // CONSISTENCY(add-set-symmetry): Set supports outlineLvl via the
+        // schema fallback (TrySetParagraphProp + TypedAttributeFallback);
+        // Add must accept the same canonical key so dump round-trip stays
+        // lossless — the dump emitter pulls outlineLvl from paragraph Get
+        // readback (WordHandler.Navigation.cs:1265-1266) and surfaces it as
+        // an Add prop. BUG-R4-BT4.
+        if (properties.TryGetValue("outlineLvl", out var addOLvl)
+            || properties.TryGetValue("outlinelvl", out addOLvl)
+            || properties.TryGetValue("outlineLevel", out addOLvl)
+            || properties.TryGetValue("outlinelevel", out addOLvl))
+        {
+            if (int.TryParse(addOLvl, out var olvl) && olvl >= 0 && olvl <= 9)
+                pProps.OutlineLevel = new OutlineLevel { Val = olvl };
+        }
+        // CONSISTENCY(add-set-symmetry): paragraph rStyle binds the paragraph
+        // mark's run style. Run Add already supports rStyle; paragraph dump
+        // emit echoes it back from Get (mark rPr.rStyle) and the value
+        // applies to all runs the paragraph carries via its mark inheritance.
+        // BUG-R4-BT4. Stored in ParagraphMarkRunProperties so the run-style
+        // sticks to the paragraph mark itself (not just any subsequently
+        // added run).
+        if (properties.TryGetValue("rStyle", out var addPRStyle) || properties.TryGetValue("rstyle", out addPRStyle))
+        {
+            var pmrp = pProps.ParagraphMarkRunProperties ?? pProps.AppendChild(new ParagraphMarkRunProperties());
+            pmrp.RemoveAllChildren<RunStyle>();
+            pmrp.PrependChild(new RunStyle { Val = addPRStyle });
+        }
         foreach (var (pk, pv) in properties)
         {
             // CONSISTENCY(add-set-symmetry): Set accepts border.top/bottom/left/right/between/bar
@@ -527,6 +554,8 @@ public partial class WordHandler
             "numid", "numId", "ilvl", "numlevel", "numLevel",
             "liststyle", "listStyle", "start", "level", "listLevel", "listlevel",
             "outlinelevel", "outlineLevel",
+            "outlinelvl", "outlineLvl",
+            "rstyle", "rStyle",
             "tabs", "tabstops",
             "border", "borders", "shd", "shading",
             "font", "size", "bold", "italic", "color", "highlight",

--- a/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
@@ -491,14 +491,28 @@ public partial class WordHandler
             {
                 rProps.AppendChild(new FontSize { Val = ((int)Math.Round(ParseFontSize(size) * 2, MidpointRounding.AwayFromZero)).ToString() });
             }
-            if ((properties.TryGetValue("bold", out var bold) || properties.TryGetValue("font.bold", out bold)) && IsTruthy(bold))
-                rProps.Bold = new Bold();
+            // CONSISTENCY(toggle-explicit-false): match the no-text branch
+            // (BUG-R7-07) — explicit `false` must emit <w:b w:val="false"/>
+            // so a run can override a style-asserted toggle. IsTruthy alone
+            // would silently drop the override and the run would re-inherit
+            // bold/italic from the style chain (e.g. non-bold span inside
+            // Heading1, non-italic citation inside Quote).
+            if (properties.TryGetValue("bold", out var bold) || properties.TryGetValue("font.bold", out bold))
+            {
+                if (IsTruthy(bold)) rProps.Bold = new Bold();
+                else if (IsExplicitFalseAddOverride(bold))
+                    rProps.Bold = new Bold { Val = OnOffValue.FromBoolean(false) };
+            }
             if ((properties.TryGetValue("bold.cs", out var boldCs)
                     || properties.TryGetValue("font.bold.cs", out boldCs))
                 && IsTruthy(boldCs))
                 rProps.BoldComplexScript = new BoldComplexScript();
-            if ((properties.TryGetValue("italic", out var pItalic) || properties.TryGetValue("font.italic", out pItalic)) && IsTruthy(pItalic))
-                rProps.Italic = new Italic();
+            if (properties.TryGetValue("italic", out var pItalic) || properties.TryGetValue("font.italic", out pItalic))
+            {
+                if (IsTruthy(pItalic)) rProps.Italic = new Italic();
+                else if (IsExplicitFalseAddOverride(pItalic))
+                    rProps.Italic = new Italic { Val = OnOffValue.FromBoolean(false) };
+            }
             if ((properties.TryGetValue("italic.cs", out var italicCs)
                     || properties.TryGetValue("font.italic.cs", out italicCs))
                 && IsTruthy(italicCs))
@@ -539,37 +553,74 @@ public partial class WordHandler
                 var ulVal = NormalizeUnderlineValue(pUnderline);
                 rProps.Underline = new Underline { Val = new UnderlineValues(ulVal) };
             }
-            if ((properties.TryGetValue("strike", out var pStrike)
+            // CONSISTENCY(toggle-explicit-false): see bold/italic above.
+            if (properties.TryGetValue("strike", out var pStrike)
                     || properties.TryGetValue("strikethrough", out pStrike)
                     || properties.TryGetValue("font.strike", out pStrike)
                     || properties.TryGetValue("font.strikethrough", out pStrike))
-                && IsTruthy(pStrike))
-                rProps.Strike = new Strike();
+            {
+                if (IsTruthy(pStrike)) rProps.Strike = new Strike();
+                else if (IsExplicitFalseAddOverride(pStrike))
+                    rProps.Strike = new Strike { Val = OnOffValue.FromBoolean(false) };
+            }
             if (properties.TryGetValue("highlight", out var pHighlight))
                 rProps.Highlight = new Highlight { Val = ParseHighlightColor(pHighlight) };
-            if ((properties.TryGetValue("caps", out var pCaps)
+            if (properties.TryGetValue("caps", out var pCaps)
                     || properties.TryGetValue("allcaps", out pCaps)
                     || properties.TryGetValue("allCaps", out pCaps))
-                && IsTruthy(pCaps))
-                rProps.Caps = new Caps();
+            {
+                if (IsTruthy(pCaps)) rProps.Caps = new Caps();
+                else if (IsExplicitFalseAddOverride(pCaps))
+                    rProps.Caps = new Caps { Val = OnOffValue.FromBoolean(false) };
+            }
             if (properties.TryGetValue("smallcaps", out var pSmallCaps) || properties.TryGetValue("smallCaps", out pSmallCaps))
             {
                 if (IsTruthy(pSmallCaps)) rProps.SmallCaps = new SmallCaps();
+                else if (IsExplicitFalseAddOverride(pSmallCaps))
+                    rProps.SmallCaps = new SmallCaps { Val = OnOffValue.FromBoolean(false) };
             }
-            if (properties.TryGetValue("dstrike", out var pDstrike) && IsTruthy(pDstrike))
-                rProps.DoubleStrike = new DoubleStrike();
-            if (properties.TryGetValue("vanish", out var pVanish) && IsTruthy(pVanish))
-                rProps.Vanish = new Vanish();
-            if (properties.TryGetValue("outline", out var pOutline) && IsTruthy(pOutline))
-                rProps.Outline = new Outline();
-            if (properties.TryGetValue("shadow", out var pShadow) && IsTruthy(pShadow))
-                rProps.Shadow = new Shadow();
-            if (properties.TryGetValue("emboss", out var pEmboss) && IsTruthy(pEmboss))
-                rProps.Emboss = new Emboss();
-            if (properties.TryGetValue("imprint", out var pImprint) && IsTruthy(pImprint))
-                rProps.Imprint = new Imprint();
-            if (properties.TryGetValue("noproof", out var pNoProof) && IsTruthy(pNoProof))
-                rProps.NoProof = new NoProof();
+            if (properties.TryGetValue("dstrike", out var pDstrike))
+            {
+                if (IsTruthy(pDstrike)) rProps.DoubleStrike = new DoubleStrike();
+                else if (IsExplicitFalseAddOverride(pDstrike))
+                    rProps.DoubleStrike = new DoubleStrike { Val = OnOffValue.FromBoolean(false) };
+            }
+            if (properties.TryGetValue("vanish", out var pVanish))
+            {
+                if (IsTruthy(pVanish)) rProps.Vanish = new Vanish();
+                else if (IsExplicitFalseAddOverride(pVanish))
+                    rProps.Vanish = new Vanish { Val = OnOffValue.FromBoolean(false) };
+            }
+            if (properties.TryGetValue("outline", out var pOutline))
+            {
+                if (IsTruthy(pOutline)) rProps.Outline = new Outline();
+                else if (IsExplicitFalseAddOverride(pOutline))
+                    rProps.Outline = new Outline { Val = OnOffValue.FromBoolean(false) };
+            }
+            if (properties.TryGetValue("shadow", out var pShadow))
+            {
+                if (IsTruthy(pShadow)) rProps.Shadow = new Shadow();
+                else if (IsExplicitFalseAddOverride(pShadow))
+                    rProps.Shadow = new Shadow { Val = OnOffValue.FromBoolean(false) };
+            }
+            if (properties.TryGetValue("emboss", out var pEmboss))
+            {
+                if (IsTruthy(pEmboss)) rProps.Emboss = new Emboss();
+                else if (IsExplicitFalseAddOverride(pEmboss))
+                    rProps.Emboss = new Emboss { Val = OnOffValue.FromBoolean(false) };
+            }
+            if (properties.TryGetValue("imprint", out var pImprint))
+            {
+                if (IsTruthy(pImprint)) rProps.Imprint = new Imprint();
+                else if (IsExplicitFalseAddOverride(pImprint))
+                    rProps.Imprint = new Imprint { Val = OnOffValue.FromBoolean(false) };
+            }
+            if (properties.TryGetValue("noproof", out var pNoProof))
+            {
+                if (IsTruthy(pNoProof)) rProps.NoProof = new NoProof();
+                else if (IsExplicitFalseAddOverride(pNoProof))
+                    rProps.NoProof = new NoProof { Val = OnOffValue.FromBoolean(false) };
+            }
             // Run-level rtl: explicit `rtl=true` OR cascaded from paragraph
             // direction=rtl above. Skipping the cascade would leave Latin
             // character order inside an RTL paragraph (broken Arabic).
@@ -1008,13 +1059,26 @@ public partial class WordHandler
         }
         if (properties.TryGetValue("size", out var rSize) || properties.TryGetValue("font.size", out rSize) || properties.TryGetValue("fontsize", out rSize))
             newRProps.AppendChild(new FontSize { Val = ((int)Math.Round(ParseFontSize(rSize) * 2, MidpointRounding.AwayFromZero)).ToString() });
-        if ((properties.TryGetValue("bold", out var rBold) || properties.TryGetValue("font.bold", out rBold)) && IsTruthy(rBold))
-            newRProps.Bold = new Bold();
+        // CONSISTENCY(toggle-explicit-false): mirror AddParagraph text-bearing
+        // (BUG-018) — explicit `false` must emit <w:b w:val="false"/> so the
+        // run can override a style-asserted toggle. AddRun reaches this block
+        // via dump→batch replay of any docx with run-level toggle overrides
+        // (Heading1 + non-bold span, Quote + non-italic citation, …).
+        if (properties.TryGetValue("bold", out var rBold) || properties.TryGetValue("font.bold", out rBold))
+        {
+            if (IsTruthy(rBold)) newRProps.Bold = new Bold();
+            else if (IsExplicitFalseAddOverride(rBold))
+                newRProps.Bold = new Bold { Val = OnOffValue.FromBoolean(false) };
+        }
         if ((properties.TryGetValue("bold.cs", out var rBoldCs) || properties.TryGetValue("font.bold.cs", out rBoldCs))
             && IsTruthy(rBoldCs))
             newRProps.BoldComplexScript = new BoldComplexScript();
-        if ((properties.TryGetValue("italic", out var rItalic) || properties.TryGetValue("font.italic", out rItalic)) && IsTruthy(rItalic))
-            newRProps.Italic = new Italic();
+        if (properties.TryGetValue("italic", out var rItalic) || properties.TryGetValue("font.italic", out rItalic))
+        {
+            if (IsTruthy(rItalic)) newRProps.Italic = new Italic();
+            else if (IsExplicitFalseAddOverride(rItalic))
+                newRProps.Italic = new Italic { Val = OnOffValue.FromBoolean(false) };
+        }
         if ((properties.TryGetValue("italic.cs", out var rItalicCs) || properties.TryGetValue("font.italic.cs", out rItalicCs))
             && IsTruthy(rItalicCs))
             newRProps.ItalicComplexScript = new ItalicComplexScript();
@@ -1049,37 +1113,74 @@ public partial class WordHandler
             var ulVal = NormalizeUnderlineValue(rUnderline);
             newRProps.Underline = new Underline { Val = new UnderlineValues(ulVal) };
         }
-        if ((properties.TryGetValue("strike", out var rStrike)
+        // CONSISTENCY(toggle-explicit-false): see bold/italic above.
+        if (properties.TryGetValue("strike", out var rStrike)
                 || properties.TryGetValue("strikethrough", out rStrike)
                 || properties.TryGetValue("font.strike", out rStrike)
                 || properties.TryGetValue("font.strikethrough", out rStrike))
-            && IsTruthy(rStrike))
-            newRProps.Strike = new Strike();
+        {
+            if (IsTruthy(rStrike)) newRProps.Strike = new Strike();
+            else if (IsExplicitFalseAddOverride(rStrike))
+                newRProps.Strike = new Strike { Val = OnOffValue.FromBoolean(false) };
+        }
         if (properties.TryGetValue("highlight", out var rHighlight))
             newRProps.Highlight = new Highlight { Val = ParseHighlightColor(rHighlight) };
-        if ((properties.TryGetValue("caps", out var rCaps)
+        if (properties.TryGetValue("caps", out var rCaps)
                 || properties.TryGetValue("allcaps", out rCaps)
                 || properties.TryGetValue("allCaps", out rCaps))
-            && IsTruthy(rCaps))
-            newRProps.Caps = new Caps();
+        {
+            if (IsTruthy(rCaps)) newRProps.Caps = new Caps();
+            else if (IsExplicitFalseAddOverride(rCaps))
+                newRProps.Caps = new Caps { Val = OnOffValue.FromBoolean(false) };
+        }
         if (properties.TryGetValue("smallcaps", out var rSmallCaps) || properties.TryGetValue("smallCaps", out rSmallCaps))
         {
             if (IsTruthy(rSmallCaps)) newRProps.SmallCaps = new SmallCaps();
+            else if (IsExplicitFalseAddOverride(rSmallCaps))
+                newRProps.SmallCaps = new SmallCaps { Val = OnOffValue.FromBoolean(false) };
         }
-        if (properties.TryGetValue("dstrike", out var rDstrike) && IsTruthy(rDstrike))
-            newRProps.DoubleStrike = new DoubleStrike();
-        if (properties.TryGetValue("vanish", out var rVanish) && IsTruthy(rVanish))
-            newRProps.Vanish = new Vanish();
-        if (properties.TryGetValue("outline", out var rOutline) && IsTruthy(rOutline))
-            newRProps.Outline = new Outline();
-        if (properties.TryGetValue("shadow", out var rShadow) && IsTruthy(rShadow))
-            newRProps.Shadow = new Shadow();
-        if (properties.TryGetValue("emboss", out var rEmboss) && IsTruthy(rEmboss))
-            newRProps.Emboss = new Emboss();
-        if (properties.TryGetValue("imprint", out var rImprint) && IsTruthy(rImprint))
-            newRProps.Imprint = new Imprint();
-        if (properties.TryGetValue("noproof", out var rNoProof) && IsTruthy(rNoProof))
-            newRProps.NoProof = new NoProof();
+        if (properties.TryGetValue("dstrike", out var rDstrike))
+        {
+            if (IsTruthy(rDstrike)) newRProps.DoubleStrike = new DoubleStrike();
+            else if (IsExplicitFalseAddOverride(rDstrike))
+                newRProps.DoubleStrike = new DoubleStrike { Val = OnOffValue.FromBoolean(false) };
+        }
+        if (properties.TryGetValue("vanish", out var rVanish))
+        {
+            if (IsTruthy(rVanish)) newRProps.Vanish = new Vanish();
+            else if (IsExplicitFalseAddOverride(rVanish))
+                newRProps.Vanish = new Vanish { Val = OnOffValue.FromBoolean(false) };
+        }
+        if (properties.TryGetValue("outline", out var rOutline))
+        {
+            if (IsTruthy(rOutline)) newRProps.Outline = new Outline();
+            else if (IsExplicitFalseAddOverride(rOutline))
+                newRProps.Outline = new Outline { Val = OnOffValue.FromBoolean(false) };
+        }
+        if (properties.TryGetValue("shadow", out var rShadow))
+        {
+            if (IsTruthy(rShadow)) newRProps.Shadow = new Shadow();
+            else if (IsExplicitFalseAddOverride(rShadow))
+                newRProps.Shadow = new Shadow { Val = OnOffValue.FromBoolean(false) };
+        }
+        if (properties.TryGetValue("emboss", out var rEmboss))
+        {
+            if (IsTruthy(rEmboss)) newRProps.Emboss = new Emboss();
+            else if (IsExplicitFalseAddOverride(rEmboss))
+                newRProps.Emboss = new Emboss { Val = OnOffValue.FromBoolean(false) };
+        }
+        if (properties.TryGetValue("imprint", out var rImprint))
+        {
+            if (IsTruthy(rImprint)) newRProps.Imprint = new Imprint();
+            else if (IsExplicitFalseAddOverride(rImprint))
+                newRProps.Imprint = new Imprint { Val = OnOffValue.FromBoolean(false) };
+        }
+        if (properties.TryGetValue("noproof", out var rNoProof))
+        {
+            if (IsTruthy(rNoProof)) newRProps.NoProof = new NoProof();
+            else if (IsExplicitFalseAddOverride(rNoProof))
+                newRProps.NoProof = new NoProof { Val = OnOffValue.FromBoolean(false) };
+        }
         // CONSISTENCY(add-set-symmetry): Set surfaces rStyle via the typed-attr
         // fallback; Add must accept it explicitly because the bare-key fallback
         // below skips dotless keys without warning. Without this, dump → batch

--- a/src/officecli/Handlers/Word/WordHandler.Add.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.cs
@@ -204,6 +204,14 @@ public partial class WordHandler
             "ins" or "del" or "moveto" or "movefrom" =>
                 throw new ArgumentException(
                     $"Cannot add '{type}' directly. Tracked revisions (<w:ins>/<w:del>/<w:moveTo>/<w:moveFrom>) are authored by word processors with track-changes enabled. To insert content that reviewers see as a tracked change, add the run normally (--type run --prop text=...) and enable track-changes in Word."),
+            // Reject standalone comment range markers. Falling through to
+            // AddDefault triggers schema-aware insertion via Particle.Set
+            // which CLEARS existing run children of the paragraph (data
+            // loss). The atomic, safe path is `add --type comment` which
+            // creates both range markers + comment text together.
+            "commentrangestart" or "commentrangeend" or "commentreference" =>
+                throw new ArgumentException(
+                    $"Cannot add '{type}' directly. Adding a bare comment range marker into a paragraph destroys existing runs (schema-aware sequence reset). Use `add --type comment --prop start=... --prop end=... --prop text=...` to create the comment atomically."),
             _ => AddDefault(parent, parentPath, index, properties, type),
         };
         }

--- a/src/officecli/Handlers/Word/WordHandler.Helpers.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Helpers.cs
@@ -127,6 +127,24 @@ public partial class WordHandler
     }
 
     /// <summary>
+    /// Parse a lineRule prop value (auto / exact / atLeast) into the OOXML
+    /// enum. BUG-019 — needed to distinguish AtLeast from Exact since
+    /// SpacingConverter.FormatWordLineSpacing serializes both as "Npt".
+    /// </summary>
+    internal static LineSpacingRuleValues ParseLineRule(string value)
+    {
+        var v = (value ?? "").Trim().ToLowerInvariant();
+        return v switch
+        {
+            "auto" => LineSpacingRuleValues.Auto,
+            "exact" => LineSpacingRuleValues.Exact,
+            "atleast" => LineSpacingRuleValues.AtLeast,
+            _ => throw new ArgumentException(
+                $"Invalid lineRule '{value}'. Expected: auto, exact, or atLeast."),
+        };
+    }
+
+    /// <summary>
     /// Read a w:val OnOff attribute defensively. Returns null when the
     /// attribute is absent OR when the stored text is not a valid OnOff
     /// token (e.g. <c>&lt;w:bidi w:val="garbage"/&gt;</c>). Default-on

--- a/src/officecli/Handlers/Word/WordHandler.Helpers.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Helpers.cs
@@ -1141,15 +1141,28 @@ public partial class WordHandler
                 // ThemeColor attribute instead of Val; Val is left at "auto"
                 // per ECMA-376 §17.3.2.6 (Excel rejects Val=accent1).
                 {
-                    var schemeName = OfficeCli.Core.ParseHelpers.NormalizeSchemeColorName(value);
                     Color colorEl;
-                    if (schemeName != null)
+                    // Bare "auto" is a legal Color val per ECMA-376 §17.3.2.6 —
+                    // it tells Word to use the document's automatic text color.
+                    // SchemeColorNames includes "auto" for the cross-handler
+                    // input lenience pass, but new ThemeColorValues("auto")
+                    // throws (no such enum). Short-circuit before the scheme
+                    // branch so dump-emitted color=auto round-trips correctly.
+                    if (string.Equals(value, "auto", StringComparison.OrdinalIgnoreCase))
                     {
-                        colorEl = new Color { Val = "auto", ThemeColor = new EnumValue<ThemeColorValues>(new ThemeColorValues(schemeName)) };
+                        colorEl = new Color { Val = "auto" };
                     }
                     else
                     {
-                        colorEl = new Color { Val = SanitizeHex(value) };
+                        var schemeName = OfficeCli.Core.ParseHelpers.NormalizeSchemeColorName(value);
+                        if (schemeName != null)
+                        {
+                            colorEl = new Color { Val = "auto", ThemeColor = new EnumValue<ThemeColorValues>(new ThemeColorValues(schemeName)) };
+                        }
+                        else
+                        {
+                            colorEl = new Color { Val = SanitizeHex(value) };
+                        }
                     }
                     InsertRunPropInSchemaOrder(props, colorEl);
                 }

--- a/src/officecli/Handlers/Word/WordHandler.Helpers.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Helpers.cs
@@ -189,8 +189,24 @@ public partial class WordHandler
     /// Sanitize a hex color for Word OOXML (ST_HexColorRGB = exactly 6-char RGB).
     /// Strips # prefix, uppercases, and handles 8-char AARRGGBB by extracting RGB portion.
     /// </summary>
-    private static string SanitizeHex(string value) =>
-        ParseHelpers.SanitizeColorForOoxml(value).Rgb;
+    private static string SanitizeHex(string value)
+    {
+        var (rgb, alphaPercent) = ParseHelpers.SanitizeColorForOoxml(value);
+        // BUG-R6-07: ARGB input (e.g. `80FF0000`) was silently truncated to
+        // RGB. OOXML's w:color stores only 6-digit RGB so the alpha
+        // channel cannot be preserved here. Emit a stderr warning so
+        // callers know the input was lossy rather than rejected.
+        if (alphaPercent.HasValue)
+        {
+            try
+            {
+                Console.Error.WriteLine(
+                    $"WARNING: color value '{value}' has an alpha component which OOXML w:color cannot store. Stored as #{rgb} (alpha discarded).");
+            }
+            catch { /* best effort — never fail the operation over a warning */ }
+        }
+        return rgb;
+    }
 
     /// <summary>
     /// Sanitize a font name input for the per-script font slots. Strips

--- a/src/officecli/Handlers/Word/WordHandler.Helpers.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Helpers.cs
@@ -111,6 +111,22 @@ public partial class WordHandler
         ParseHelpers.IsTruthy(value);
 
     /// <summary>
+    /// BUG-R7-07: a value the user explicitly typed as "false"/"0"/"off" — not
+    /// just any non-truthy input (null/empty count as "no override"). Used by
+    /// AddParagraph's no-text fallback to decide whether to emit
+    /// <c>&lt;w:b w:val="false"/&gt;</c> as an explicit style override vs.
+    /// simply removing the element. Set-style call sites continue to use
+    /// ApplyRunFormatting's "remove on falsy" semantics so existing tests
+    /// (R25/R26 EmptyRpr_NotSurfaced) keep passing.
+    /// </summary>
+    internal static bool IsExplicitFalseAddOverride(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return false;
+        var v = value.Trim().ToLowerInvariant();
+        return v is "false" or "0" or "off" or "no" or "n";
+    }
+
+    /// <summary>
     /// Read a w:val OnOff attribute defensively. Returns null when the
     /// attribute is absent OR when the stored text is not a valid OnOff
     /// token (e.g. <c>&lt;w:bidi w:val="garbage"/&gt;</c>). Default-on
@@ -182,7 +198,22 @@ public partial class WordHandler
             "center" => JustificationValues.Center,
             "right" => JustificationValues.Right,
             "justify" or "both" => JustificationValues.Both,
-            _ => throw new ArgumentException($"Invalid alignment value: '{value}'. Valid values: left, center, right, justify.")
+            // BUG-R7-04 (F-4): w:jc="distribute" stretches every line
+            // (including the last) — used in CJK/Thai documents to fill
+            // the column. Was rejected by the white-list even though
+            // OOXML / Word accept it (see HtmlPreview.Css distribute
+            // branch). Mirror Word's tolerant parser for the rest of the
+            // ECMA-376 ST_Jc enum: highKashida/mediumKashida/lowKashida
+            // (Arabic), thaiDistribute, numTab.
+            "distribute" => JustificationValues.Distribute,
+            "thaidistribute" => JustificationValues.ThaiDistribute,
+            "highkashida" => JustificationValues.HighKashida,
+            "mediumkashida" => JustificationValues.MediumKashida,
+            "lowkashida" => JustificationValues.LowKashida,
+            "numtab" => JustificationValues.NumTab,
+            "start" => JustificationValues.Left, // bidi-aware alias
+            "end" => JustificationValues.Right,
+            _ => throw new ArgumentException($"Invalid alignment value: '{value}'. Valid values: left, center, right, justify, distribute, thaiDistribute, start, end.")
         };
 
     /// <summary>
@@ -1283,6 +1314,30 @@ public partial class WordHandler
             case "vanish":
                 props.RemoveAllChildren<Vanish>();
                 if (IsTruthy(value)) InsertRunPropInSchemaOrder(props, new Vanish());
+                return true;
+            case "bdr":
+                // BUG-R7-06: character border <w:bdr/> — round-trip captured
+                // it from real docs but Add/Set rejected it as UNSUPPORTED.
+                // Accept the same colon-encoded form as paragraph borders
+                // (STYLE[;SIZE[;COLOR[;SPACE]]]). Empty/none/false clears.
+                props.RemoveAllChildren<Border>();
+                if (!string.IsNullOrEmpty(value)
+                    && !string.Equals(value, "none", StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase))
+                {
+                    var (bStyle, bSize, bColor, bSpace) = ParseBorderValue(value);
+                    var bdr = new Border { Val = bStyle, Size = bSize, Space = bSpace };
+                    if (bColor != null) bdr.Color = bColor;
+                    InsertRunPropInSchemaOrder(props, bdr);
+                }
+                return true;
+            case "kern":
+                // BUG-R7-06: <w:kern w:val="N"/> (kerning threshold in
+                // half-points). Get exposes it; Add/Set silently dropped.
+                props.RemoveAllChildren<Kern>();
+                if (!string.IsNullOrEmpty(value)
+                    && uint.TryParse(value, out var kernVal))
+                    InsertRunPropInSchemaOrder(props, new Kern { Val = kernVal });
                 return true;
             case "lang" or "lang.latin" or "lang.val":
             case "lang.ea" or "lang.eastasia" or "lang.eastasian":

--- a/src/officecli/Handlers/Word/WordHandler.ImageHelpers.cs
+++ b/src/officecli/Handlers/Word/WordHandler.ImageHelpers.cs
@@ -235,7 +235,12 @@ public partial class WordHandler
             if (hPos != null)
             {
                 var offset = hPos.GetFirstChild<DW.PositionOffset>();
-                if (offset != null && long.TryParse(offset.Text, out var hEmu))
+                // BUG-R7-11: skip zero-valued offsets. AddPicture defaults the
+                // PositionOffset to 0 when no hPosition prop is given, so a
+                // dump that originally omitted hPosition would jitter to
+                // hPosition=0.0cm after round-trip. Treat 0 as "no
+                // positional override" to keep dump→batch idempotent.
+                if (offset != null && long.TryParse(offset.Text, out var hEmu) && hEmu != 0)
                     node.Format["hPosition"] = $"{hEmu / 360000.0:F1}cm";
                 if (hPos.RelativeFrom?.HasValue == true)
                     node.Format["hRelative"] = hPos.RelativeFrom.InnerText;
@@ -245,7 +250,8 @@ public partial class WordHandler
             if (vPos != null)
             {
                 var offset = vPos.GetFirstChild<DW.PositionOffset>();
-                if (offset != null && long.TryParse(offset.Text, out var vEmu))
+                // BUG-R7-11: see hPosition note above.
+                if (offset != null && long.TryParse(offset.Text, out var vEmu) && vEmu != 0)
                     node.Format["vPosition"] = $"{vEmu / 360000.0:F1}cm";
                 if (vPos.RelativeFrom?.HasValue == true)
                     node.Format["vRelative"] = vPos.RelativeFrom.InnerText;

--- a/src/officecli/Handlers/Word/WordHandler.ImageHelpers.cs
+++ b/src/officecli/Handlers/Word/WordHandler.ImageHelpers.cs
@@ -222,6 +222,11 @@ public partial class WordHandler
         }
         else if (anchorEl != null)
         {
+            // Surface anchor=true so dump→batch round-trip recreates a
+            // floating picture. AddPicture's wrapImpliesAnchor heuristic
+            // is false for wrap=none, so without this explicit flag the
+            // replay produces an inline picture (BUG-R6-1).
+            node.Format["anchor"] = true;
             node.Format["wrap"] = DetectWrapType(anchorEl);
             if (anchorEl.BehindDoc?.Value == true)
                 node.Format["behindText"] = true;

--- a/src/officecli/Handlers/Word/WordHandler.Mutations.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Mutations.cs
@@ -586,6 +586,20 @@ public partial class WordHandler
             throw new ArgumentException(
                 "Cannot move a run (w:r) directly to /body. Runs must live inside a paragraph.");
 
+        // CONSISTENCY(word-schema): w:p cannot be nested inside w:p.
+        // Without this guard, `move /body/p[1] --to /body/p[3]` happily
+        // appends the source paragraph as a child of the target paragraph,
+        // producing schema-invalid <w:p><w:p>...</w:p></w:p>. Users almost
+        // always meant "place after", so steer them toward --after.
+        if (element.LocalName == "p" && targetParent.LocalName == "p")
+            throw new ArgumentException(
+                "Cannot move a paragraph into another paragraph (would create invalid <w:p><w:p>). " +
+                "To place after a paragraph, use `--after <path>`; to reorder within /body, omit --to.");
+        // Same guard for moving table/tbl into a paragraph.
+        if ((element.LocalName == "tbl" || element.LocalName == "table") && targetParent.LocalName == "p")
+            throw new ArgumentException(
+                "Cannot move a table into a paragraph. Use `--after <paragraph-path>` to place it after.");
+
         element.Remove();
 
         // Insert at the resolved position

--- a/src/officecli/Handlers/Word/WordHandler.Navigation.DocSettings.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Navigation.DocSettings.cs
@@ -119,6 +119,8 @@ public partial class WordHandler
             node.Format["bookFoldPrintingSheets"] = (int)bookFoldSheets.Val.Value;
         if (settings.GetFirstChild<EvenAndOddHeaders>() != null)
             node.Format["evenAndOddHeaders"] = true;
+        if (settings.GetFirstChild<AutoHyphenation>() != null)
+            node.Format["autoHyphenation"] = true;
         var defTabStop = settings.GetFirstChild<DefaultTabStop>();
         if (defTabStop?.Val?.Value != null)
             node.Format["defaultTabStop"] = FormatTwipsToCm((uint)defTabStop.Val.Value);

--- a/src/officecli/Handlers/Word/WordHandler.Navigation.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Navigation.cs
@@ -1541,22 +1541,21 @@ public partial class WordHandler
             // didn't consume. Symmetric with the Set-side TryCreateTypedChild
             // fallback in SetElementRun (WordHandler.Set.Element.cs).
             FillUnknownChildProps(run.RunProperties, node);
-            // Image properties if run contains a Drawing
+            // Image properties if run contains a Drawing.
+            // BUG-R5-T3: previously this branch wrote only id/name/alt/width/
+            // height/relId — wrap/hPosition/vPosition/hRelative/vRelative/
+            // behindText for floating pictures were silently dropped, which
+            // also broke dump→batch round-trip (BatchEmitter relies on Get).
+            // Reuse CreateImageNode (the canonical picture-node builder) and
+            // merge its Format bag into the run node.
             var runDrawing = run.GetFirstChild<Drawing>();
             if (runDrawing != null)
             {
-                node.Type = "picture";
-                var docProps = runDrawing.Descendants<DW.DocProperties>().FirstOrDefault();
-                if (docProps?.Id?.HasValue == true) node.Format["id"] = docProps.Id.Value;
-                if (docProps?.Name?.Value != null) node.Format["name"] = docProps.Name.Value;
-                if (docProps?.Description?.Value != null) node.Format["alt"] = docProps.Description.Value;
-                var extent = runDrawing.Descendants<DW.Extent>().FirstOrDefault();
-                if (extent?.Cx != null) node.Format["width"] = $"{extent.Cx.Value / 360000.0:F1}cm";
-                if (extent?.Cy != null) node.Format["height"] = $"{extent.Cy.Value / 360000.0:F1}cm";
-                // Expose the image part rel id so `get --save` can extract it.
-                var runBlip = runDrawing.Descendants<DocumentFormat.OpenXml.Drawing.Blip>().FirstOrDefault();
-                if (runBlip?.Embed?.Value != null)
-                    node.Format["relId"] = runBlip.Embed.Value;
+                var picNode = CreateImageNode(runDrawing, run, path);
+                node.Type = picNode.Type;
+                if (!string.IsNullOrEmpty(picNode.Text)) node.Text = picNode.Text;
+                foreach (var kv in picNode.Format)
+                    node.Format[kv.Key] = kv.Value;
             }
             // OLE object if run contains an EmbeddedObject. The underlying
             // logic is the same as CreateOleNode — reuse it so Get/Query

--- a/src/officecli/Handlers/Word/WordHandler.Navigation.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Navigation.cs
@@ -14,6 +14,28 @@ public partial class WordHandler
 {
     // ==================== Navigation ====================
 
+    /// <summary>
+    /// OOXML toggle element (Bold, Italic, Strike, Caps, …) is "ON" when the
+    /// element exists AND its <c>w:val</c> attribute is either absent or
+    /// truthy. <c>&lt;w:b/&gt;</c> means ON; <c>&lt;w:b w:val="0"/&gt;</c>
+    /// and <c>&lt;w:b w:val="false"/&gt;</c> mean explicitly OFF. Pure
+    /// null-checks on the element flip the OFF case back to ON, corrupting
+    /// canonical Get readback (BUG-R2-04). Use this helper at every
+    /// toggle-readback site so the override is honored.
+    /// </summary>
+    private static bool IsToggleOn(Bold? t)   => t != null && (t.Val == null || t.Val.Value);
+    private static bool IsToggleOn(Italic? t) => t != null && (t.Val == null || t.Val.Value);
+    private static bool IsToggleOn(Strike? t) => t != null && (t.Val == null || t.Val.Value);
+    private static bool IsToggleOn(DoubleStrike? t) => t != null && (t.Val == null || t.Val.Value);
+    private static bool IsToggleOn(Caps? t) => t != null && (t.Val == null || t.Val.Value);
+    private static bool IsToggleOn(SmallCaps? t) => t != null && (t.Val == null || t.Val.Value);
+    private static bool IsToggleOn(Vanish? t) => t != null && (t.Val == null || t.Val.Value);
+    private static bool IsToggleOn(Outline? t) => t != null && (t.Val == null || t.Val.Value);
+    private static bool IsToggleOn(Shadow? t) => t != null && (t.Val == null || t.Val.Value);
+    private static bool IsToggleOn(Emboss? t) => t != null && (t.Val == null || t.Val.Value);
+    private static bool IsToggleOn(Imprint? t) => t != null && (t.Val == null || t.Val.Value);
+    private static bool IsToggleOn(NoProof? t) => t != null && (t.Val == null || t.Val.Value);
+
     private DocumentNode GetRootNode(int depth)
     {
         var node = new DocumentNode { Path = "/", Type = "document" };
@@ -1380,11 +1402,11 @@ public partial class WordHandler
                 if (fsVal != null && !node.Format.ContainsKey("size"))
                     node.Format["size"] = $"{int.Parse(fsVal) / 2.0:0.##}pt";
 
-                var boldEl = rp?.Bold ?? (OpenXmlLeafElement?)markRp?.GetFirstChild<Bold>();
-                if (boldEl != null && !node.Format.ContainsKey("bold")) node.Format["bold"] = true;
+                var boldEl = rp?.Bold ?? markRp?.GetFirstChild<Bold>();
+                if (boldEl != null && !node.Format.ContainsKey("bold")) node.Format["bold"] = IsToggleOn(boldEl);
 
-                var italicEl = rp?.Italic ?? (OpenXmlLeafElement?)markRp?.GetFirstChild<Italic>();
-                if (italicEl != null && !node.Format.ContainsKey("italic")) node.Format["italic"] = true;
+                var italicEl = rp?.Italic ?? markRp?.GetFirstChild<Italic>();
+                if (italicEl != null && !node.Format.ContainsKey("italic")) node.Format["italic"] = IsToggleOn(italicEl);
 
                 // Complex-script readback (font.cs / size.cs / bold.cs / italic.cs).
                 // See WordHandler.I18n.cs.
@@ -1470,8 +1492,8 @@ public partial class WordHandler
             }
             var size = GetRunFontSize(run);
             if (size != null) node.Format["size"] = size;
-            if (run.RunProperties?.Bold != null) node.Format["bold"] = true;
-            if (run.RunProperties?.Italic != null) node.Format["italic"] = true;
+            if (run.RunProperties?.Bold != null) node.Format["bold"] = IsToggleOn(run.RunProperties.Bold);
+            if (run.RunProperties?.Italic != null) node.Format["italic"] = IsToggleOn(run.RunProperties.Italic);
             // Complex-script readback (font.cs / size.cs / bold.cs / italic.cs).
             // See WordHandler.I18n.cs.
             ReadComplexScriptRunFormatting(run.RunProperties, null, node.Format);
@@ -1481,17 +1503,17 @@ public partial class WordHandler
             // CONSISTENCY(underline-color): backfilled from style Get edc8f884.
             if (run.RunProperties?.Underline?.Color?.Value != null)
                 node.Format["underline.color"] = ParseHelpers.FormatHexColor(run.RunProperties.Underline.Color.Value);
-            if (run.RunProperties?.Strike != null) node.Format["strike"] = true;
+            if (run.RunProperties?.Strike != null) node.Format["strike"] = IsToggleOn(run.RunProperties.Strike);
             if (run.RunProperties?.Highlight?.Val != null) node.Format["highlight"] = run.RunProperties.Highlight.Val.InnerText;
-            if (run.RunProperties?.Caps != null) node.Format["caps"] = true;
-            if (run.RunProperties?.SmallCaps != null) node.Format["smallcaps"] = true;
-            if (run.RunProperties?.DoubleStrike != null) node.Format["dstrike"] = true;
-            if (run.RunProperties?.Vanish != null) node.Format["vanish"] = true;
-            if (run.RunProperties?.Outline != null) node.Format["outline"] = true;
-            if (run.RunProperties?.Shadow != null) node.Format["shadow"] = true;
-            if (run.RunProperties?.Emboss != null) node.Format["emboss"] = true;
-            if (run.RunProperties?.Imprint != null) node.Format["imprint"] = true;
-            if (run.RunProperties?.NoProof != null) node.Format["noproof"] = true;
+            if (run.RunProperties?.Caps != null) node.Format["caps"] = IsToggleOn(run.RunProperties.Caps);
+            if (run.RunProperties?.SmallCaps != null) node.Format["smallcaps"] = IsToggleOn(run.RunProperties.SmallCaps);
+            if (run.RunProperties?.DoubleStrike != null) node.Format["dstrike"] = IsToggleOn(run.RunProperties.DoubleStrike);
+            if (run.RunProperties?.Vanish != null) node.Format["vanish"] = IsToggleOn(run.RunProperties.Vanish);
+            if (run.RunProperties?.Outline != null) node.Format["outline"] = IsToggleOn(run.RunProperties.Outline);
+            if (run.RunProperties?.Shadow != null) node.Format["shadow"] = IsToggleOn(run.RunProperties.Shadow);
+            if (run.RunProperties?.Emboss != null) node.Format["emboss"] = IsToggleOn(run.RunProperties.Emboss);
+            if (run.RunProperties?.Imprint != null) node.Format["imprint"] = IsToggleOn(run.RunProperties.Imprint);
+            if (run.RunProperties?.NoProof != null) node.Format["noproof"] = IsToggleOn(run.RunProperties.NoProof);
             if (run.RunProperties?.RightToLeftText != null)
             {
                 // <w:rtl/> with no Val attribute implies true; <w:rtl w:val="0"/>
@@ -1735,15 +1757,15 @@ public partial class WordHandler
                 if (rp.RunFonts?.Ascii?.Value != null) node.Format["font"] = rp.RunFonts.Ascii.Value;
                 if (rp.FontSize?.Val?.Value != null)
                     node.Format["size"] = $"{int.Parse(rp.FontSize.Val.Value) / 2.0:0.##}pt";
-                if (rp.Bold != null) node.Format["bold"] = true;
-                if (rp.Italic != null) node.Format["italic"] = true;
+                if (rp.Bold != null) node.Format["bold"] = IsToggleOn(rp.Bold);
+                if (rp.Italic != null) node.Format["italic"] = IsToggleOn(rp.Italic);
                 if (rp.Color?.ThemeColor?.HasValue == true) node.Format["color"] = rp.Color.ThemeColor.InnerText;
                 else if (rp.Color?.Val?.Value != null) node.Format["color"] = ParseHelpers.FormatHexColor(rp.Color.Val.Value);
                 if (rp.Underline?.Val != null) node.Format["underline"] = rp.Underline.Val.InnerText;
                 // CONSISTENCY(underline-color): backfilled from style Get edc8f884.
                 if (rp.Underline?.Color?.Value != null)
                     node.Format["underline.color"] = ParseHelpers.FormatHexColor(rp.Underline.Color.Value);
-                if (rp.Strike != null) node.Format["strike"] = true;
+                if (rp.Strike != null) node.Format["strike"] = IsToggleOn(rp.Strike);
                 if (rp.Highlight?.Val != null) node.Format["highlight"] = rp.Highlight.Val.InnerText;
             }
         }
@@ -2299,8 +2321,8 @@ public partial class WordHandler
             var rPr = firstRun.RunProperties;
             if (rPr.RunFonts?.Ascii?.Value != null) node.Format["font"] = rPr.RunFonts.Ascii.Value;
             if (rPr.FontSize?.Val?.Value != null) node.Format["size"] = $"{int.Parse(rPr.FontSize.Val.Value) / 2.0:0.##}pt";
-            if (rPr.Bold != null) node.Format["bold"] = true;
-            if (rPr.Italic != null) node.Format["italic"] = true;
+            if (rPr.Bold != null) node.Format["bold"] = IsToggleOn(rPr.Bold);
+            if (rPr.Italic != null) node.Format["italic"] = IsToggleOn(rPr.Italic);
             if (rPr.Color?.Val?.Value != null) node.Format["color"] = ParseHelpers.FormatHexColor(rPr.Color.Val.Value);
             else if (rPr.Color?.ThemeColor?.HasValue == true) node.Format["color"] = rPr.Color.ThemeColor.InnerText;
             if (rPr.Underline?.Val != null) node.Format["underline"] = rPr.Underline.Val.InnerText;

--- a/src/officecli/Handlers/Word/WordHandler.Navigation.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Navigation.cs
@@ -2006,7 +2006,17 @@ public partial class WordHandler
                 var listItems = ddl?.Elements<ListItem>() ?? combo?.Elements<ListItem>();
                 if (listItems != null)
                 {
-                    var items = listItems.Select(li => li.DisplayText?.Value ?? li.Value?.Value ?? "").ToList();
+                    // BUG-R5-07: SDT ListItems carry distinct DisplayText and
+                    // Value attrs. Real Word docs commonly differ (e.g.
+                    // "Draft|DRAFT"). Emit the pipe form when value !=
+                    // displayText so dump→add round-trips. ParseSdtItems on
+                    // the Add side accepts both bare and piped forms.
+                    var items = listItems.Select(li =>
+                    {
+                        var disp = li.DisplayText?.Value ?? li.Value?.Value ?? "";
+                        var val = li.Value?.Value ?? li.DisplayText?.Value ?? "";
+                        return disp == val ? disp : $"{disp}|{val}";
+                    }).ToList();
                     if (items.Count > 0) node.Format["items"] = string.Join(",", items);
                 }
             }
@@ -2052,7 +2062,17 @@ public partial class WordHandler
                 var listItems = ddl?.Elements<ListItem>() ?? combo?.Elements<ListItem>();
                 if (listItems != null)
                 {
-                    var items = listItems.Select(li => li.DisplayText?.Value ?? li.Value?.Value ?? "").ToList();
+                    // BUG-R5-07: SDT ListItems carry distinct DisplayText and
+                    // Value attrs. Real Word docs commonly differ (e.g.
+                    // "Draft|DRAFT"). Emit the pipe form when value !=
+                    // displayText so dump→add round-trips. ParseSdtItems on
+                    // the Add side accepts both bare and piped forms.
+                    var items = listItems.Select(li =>
+                    {
+                        var disp = li.DisplayText?.Value ?? li.Value?.Value ?? "";
+                        var val = li.Value?.Value ?? li.DisplayText?.Value ?? "";
+                        return disp == val ? disp : $"{disp}|{val}";
+                    }).ToList();
                     if (items.Count > 0) node.Format["items"] = string.Join(",", items);
                 }
             }

--- a/src/officecli/Handlers/Word/WordHandler.Navigation.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Navigation.cs
@@ -2390,6 +2390,15 @@ public partial class WordHandler
         // left behind by Set bold=false (etc.) would surface as `rPr: true` via
         // the long-tail fallback. fuzz-1.
         "rPr",
+        // BUG-R7-09 / F-3: <w:lang/> is a multi-slot element (val=latin /
+        // eastAsia / bidi). The curated reader emits each slot as
+        // lang.latin / lang.ea / lang.cs. Word/WPS occasionally write a bare
+        // <w:lang/> with no attributes as a "reset to default language"
+        // sentinel — the long-tail fallback would then surface that as
+        // `lang: true`, which Set parses as a BCP-47 tag and rejects with
+        // "Invalid BCP-47 'true'". Skip lang here so the canonical .latin/
+        // .ea/.cs reader stays the single source of truth.
+        "lang",
     };
 
     // Long-tail OOXML fallback: walk a properties container (rPr/pPr/...) and

--- a/src/officecli/Handlers/Word/WordHandler.Query.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Query.cs
@@ -521,6 +521,17 @@ public partial class WordHandler
                 chartNode.Format["id"] = chartInfo.DocProperties.Id.Value;
             if (chartInfo.DocProperties?.Name?.Value != null)
                 chartNode.Format["name"] = chartInfo.DocProperties.Name.Value;
+            // BUG-R7-06: width/height live on the wp:extent of the inline
+            // wrapper, not on the chart space itself. Schema declares both as
+            // [add/set/get] and Set actually mutates the extent — but Get
+            // never exposed them. dump→batch round-trip therefore always
+            // dropped frame dimensions and replay used the 15×10cm default.
+            // pptx already returns them; this aligns docx with that contract.
+            var inlineExtent = chartInfo.Inline?.Extent;
+            if (inlineExtent?.Cx?.HasValue == true)
+                chartNode.Format["width"] = $"{inlineExtent.Cx.Value / 360000.0:F1}cm";
+            if (inlineExtent?.Cy?.HasValue == true)
+                chartNode.Format["height"] = $"{inlineExtent.Cy.Value / 360000.0:F1}cm";
 
             if (chartInfo.IsExtended)
             {

--- a/src/officecli/Handlers/Word/WordHandler.Query.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Query.cs
@@ -734,16 +734,8 @@ public partial class WordHandler
                 // CONSISTENCY(outline-lvl): outlineLvl not yet exposed by paragraph Get.
                 if (pPr.OutlineLevel?.Val?.Value != null) styleNode.Format["outlineLvl"] = (int)pPr.OutlineLevel.Val.Value;
 
-                // Numbering linkage on the style itself (numPr in style/pPr).
-                // Mirrors paragraph-level numId/ilvl readback in Navigation.cs.
-                if (pPr.NumberingProperties != null)
-                {
-                    var sNumPr = pPr.NumberingProperties;
-                    if (sNumPr.NumberingId?.Val?.Value != null)
-                        styleNode.Format["numId"] = sNumPr.NumberingId.Val.Value.ToString();
-                    if (sNumPr.NumberingLevelReference?.Val?.Value != null)
-                        styleNode.Format["ilvl"] = sNumPr.NumberingLevelReference.Val.Value.ToString();
-                }
+                // Numbering linkage on the style itself emitted below as numId/numLevel
+                // (CONSISTENCY(canonical-keys): paragraph Get also emits numLevel, not ilvl).
 
                 // Toggle props: respect explicit val="false" instead of treating presence as true.
                 if (pPr.KeepNext != null)

--- a/src/officecli/Handlers/Word/WordHandler.Set.Dispatch.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.Dispatch.cs
@@ -1501,6 +1501,42 @@ public partial class WordHandler
                     ApplyStyleParagraphBorders(pPrB, key, value);
                     break;
                 }
+                // CONSISTENCY(style-indent): list-family styles (List, List Paragraph,
+                // List 2/3, List Continue 1/2/3, Intense Quote) carry their indent on
+                // the style definition. Without these cases the BatchEmitter dump emits
+                // leftIndent / hangingIndent / firstLineIndent / rightIndent on /styles
+                // and Set rejects them as UNSUPPORTED — list styles round-trip with
+                // their indent erased (BUG BT-5). StyleUnsupportedHints' "set indent at
+                // paragraph level" hint covered the user-typed-by-hand case but is
+                // wrong for round-trip.
+                case "leftindent" or "leftIndent":
+                {
+                    var pPrLi = style.StyleParagraphProperties ?? EnsureStyleParagraphProperties(style);
+                    var indLi = pPrLi.Indentation ?? (pPrLi.Indentation = new Indentation());
+                    indLi.Left = SpacingConverter.ParseWordSpacing(value).ToString();
+                    break;
+                }
+                case "rightindent" or "rightIndent":
+                {
+                    var pPrRi = style.StyleParagraphProperties ?? EnsureStyleParagraphProperties(style);
+                    var indRi = pPrRi.Indentation ?? (pPrRi.Indentation = new Indentation());
+                    indRi.Right = SpacingConverter.ParseWordSpacing(value).ToString();
+                    break;
+                }
+                case "firstlineindent" or "firstLineIndent":
+                {
+                    var pPrFli = style.StyleParagraphProperties ?? EnsureStyleParagraphProperties(style);
+                    var indFli = pPrFli.Indentation ?? (pPrFli.Indentation = new Indentation());
+                    indFli.FirstLine = SpacingConverter.ParseWordSpacing(value).ToString();
+                    break;
+                }
+                case "hangingindent" or "hangingIndent":
+                {
+                    var pPrHi = style.StyleParagraphProperties ?? EnsureStyleParagraphProperties(style);
+                    var indHi = pPrHi.Indentation ?? (pPrHi.Indentation = new Indentation());
+                    indHi.Hanging = SpacingConverter.ParseWordSpacing(value).ToString();
+                    break;
+                }
                 // Per-script font split. Each w:rFonts attr is independent and
                 // unset attrs fall back through the style chain / docDefaults,
                 // so writing only the requested attr is correct — no need to

--- a/src/officecli/Handlers/Word/WordHandler.Set.Dispatch.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.Dispatch.cs
@@ -1455,6 +1455,15 @@ public partial class WordHandler
                         : new DocumentFormat.OpenXml.EnumValue<LineSpacingRuleValues>(LineSpacingRuleValues.Exact);
                     break;
                 }
+                case "linerule" or "lineRule":
+                {
+                    // BUG-019: explicit override needed — lineSpacing alone
+                    // cannot distinguish AtLeast from Exact.
+                    var pPr5 = style.StyleParagraphProperties ?? EnsureStyleParagraphProperties(style);
+                    var sp5 = pPr5.SpacingBetweenLines ?? (pPr5.SpacingBetweenLines = new SpacingBetweenLines());
+                    sp5.LineRule = ParseLineRule(value);
+                    break;
+                }
                 case "contextualspacing" or "contextualSpacing":
                 {
                     var pPrCs = style.StyleParagraphProperties ?? EnsureStyleParagraphProperties(style);

--- a/src/officecli/Handlers/Word/WordHandler.Set.Dispatch.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.Dispatch.cs
@@ -1239,9 +1239,34 @@ public partial class WordHandler
             ?? throw new ArgumentException(
                 $"num with id={numId} not found. Use `add /numbering --type num --prop abstractNumId=N` first.");
 
+        // BUG-R5-T1: Add and Get both support `start` / `startOverride.N`,
+        // but Set previously only handled abstractNumId — the symmetry break
+        // forced callers to delete + re-Add a num just to bump a level
+        // override. Mirror Add's parsing: `start` = shorthand for
+        // `startOverride.0`; `startOverride.N` (0..8) creates or updates the
+        // <w:lvlOverride><w:startOverride/></w:lvlOverride> child.
+        void SetStartOverride(int lvl, int startVal)
+        {
+            if (lvl < 0 || lvl > 8)
+                throw new ArgumentException($"startOverride level must be 0..8 (got {lvl}).");
+            var lvlOverride = inst.Elements<LevelOverride>()
+                .FirstOrDefault(o => o.LevelIndex?.Value == lvl);
+            if (lvlOverride == null)
+            {
+                lvlOverride = new LevelOverride { LevelIndex = lvl };
+                inst.AppendChild(lvlOverride);
+            }
+            var sov = lvlOverride.GetFirstChild<StartOverrideNumberingValue>();
+            if (sov == null)
+                lvlOverride.AppendChild(new StartOverrideNumberingValue { Val = startVal });
+            else
+                sov.Val = startVal;
+        }
+
         foreach (var (key, value) in properties)
         {
-            switch (key.ToLowerInvariant())
+            var keyLower = key.ToLowerInvariant();
+            switch (keyLower)
             {
                 case "abstractnumid":
                     var aidVal = ParseHelpers.SafeParseInt(value, "abstractNumId");
@@ -1254,8 +1279,20 @@ public partial class WordHandler
                     var aid = inst.AbstractNumId ?? (inst.AbstractNumId = new AbstractNumId());
                     aid.Val = aidVal;
                     break;
+                case "start":
+                    SetStartOverride(0, ParseHelpers.SafeParseInt(value, "start"));
+                    break;
                 default:
-                    unsupported.Add(key);
+                    if (keyLower.StartsWith("startoverride."))
+                    {
+                        var lvlStr = key.Substring("startOverride.".Length);
+                        var lvl = ParseHelpers.SafeParseInt(lvlStr, key);
+                        SetStartOverride(lvl, ParseHelpers.SafeParseInt(value, key));
+                    }
+                    else
+                    {
+                        unsupported.Add(key);
+                    }
                     break;
             }
         }

--- a/src/officecli/Handlers/Word/WordHandler.Set.Dispatch.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.Dispatch.cs
@@ -1003,8 +1003,15 @@ public partial class WordHandler
                             "right" or "end" => LevelJustificationValues.Right,
                             _ => throw new ArgumentException($"Invalid justification '{value}'. Valid: left, center, right.")
                         };
+                        // BUG-R5-T4: CT_Lvl schema order is start, numFmt,
+                        // lvlRestart, pStyle, isLgl, suff, lvlText,
+                        // lvlPicBulletId, legacy, lvlJc, pPr, rPr — Word
+                        // silently ignores out-of-order children. Use the
+                        // schema-aware insertion helper instead of raw
+                        // AppendChild (which always tacks elements at the
+                        // end, regardless of where they belong).
                         var jc = level.GetFirstChild<LevelJustification>();
-                        if (jc == null) level.AppendChild(new LevelJustification { Val = jcV });
+                        if (jc == null) InsertLevelChildInOrder(level, new LevelJustification { Val = jcV });
                         else jc.Val = jcV;
                         break;
                     case "suff":
@@ -1016,7 +1023,7 @@ public partial class WordHandler
                             _ => throw new ArgumentException($"Invalid suff '{value}'. Valid: tab, space, nothing.")
                         };
                         var su = level.GetFirstChild<LevelSuffix>();
-                        if (su == null) level.AppendChild(new LevelSuffix { Val = sV });
+                        if (su == null) InsertLevelChildInOrder(level, new LevelSuffix { Val = sV });
                         else su.Val = sV;
                         break;
                     case "indent":

--- a/src/officecli/Handlers/Word/WordHandler.Set.DocDefaults.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.DocDefaults.cs
@@ -32,8 +32,21 @@ public partial class WordHandler
             {
                 var rPr = EnsureRunPropsDefault();
                 var fonts = rPr.GetFirstChild<RunFonts>() ?? rPr.AppendChild(new RunFonts());
-                fonts.Ascii = value;
-                fonts.HighAnsi = value;
+                // BUG-R6-05: empty value means "remove this slot" so dump
+                // can clear blank-template defaults (Times New Roman) when
+                // the source doc had no explicit docDefaults.font.latin.
+                // Without this, dump→batch leaks the blank's TNR into the
+                // round-tripped doc.
+                if (string.IsNullOrEmpty(value))
+                {
+                    fonts.Ascii = null;
+                    fonts.HighAnsi = null;
+                }
+                else
+                {
+                    fonts.Ascii = value;
+                    fonts.HighAnsi = value;
+                }
                 SaveStyles();
                 return true;
             }

--- a/src/officecli/Handlers/Word/WordHandler.Set.DocSettings.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.DocSettings.cs
@@ -154,6 +154,10 @@ public partial class WordHandler
                 SetOnOffSetting<EvenAndOddHeaders>(EnsureSettings(), IsTruthy(value));
                 EnsureSettings().Save();
                 return true;
+            case "autohyphenation":
+                SetOnOffSetting<AutoHyphenation>(EnsureSettings(), IsTruthy(value));
+                EnsureSettings().Save();
+                return true;
             case "defaulttabstop":
             {
                 var settings = EnsureSettings();

--- a/src/officecli/Handlers/Word/WordHandler.Set.Element.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.Element.cs
@@ -966,6 +966,28 @@ public partial class WordHandler
                 case "start":
                     SetListStartValue(para, ParseHelpers.SafeParseInt(value, "start"));
                     break;
+                case "rstyle":
+                {
+                    // BUG-R6-04 / F-4: Set on paragraph rStyle previously
+                    // returned UNSUPPORTED, breaking dump→batch round-trip
+                    // for table cell paragraphs that carry character
+                    // styles (Set is the natural emit since the cell
+                    // paragraph already exists). Mirror AddParagraph:
+                    // store on the paragraph mark rPr AND propagate to
+                    // all existing runs so visible text picks up the
+                    // character style.
+                    var pmrp = pProps.ParagraphMarkRunProperties
+                        ?? pProps.AppendChild(new ParagraphMarkRunProperties());
+                    pmrp.RemoveAllChildren<RunStyle>();
+                    pmrp.PrependChild(new RunStyle { Val = value });
+                    foreach (var pRun in para.Descendants<Run>())
+                    {
+                        var pRP = EnsureRunProperties(pRun);
+                        pRP.RemoveAllChildren<RunStyle>();
+                        pRP.PrependChild(new RunStyle { Val = value });
+                    }
+                    break;
+                }
                 case "size" or "font" or "bold" or "italic" or "color" or "highlight" or "underline" or "strike"
                   or "font.latin" or "font.ea" or "font.eastasia" or "font.eastasian"
                   or "font.cs" or "font.complexscript" or "font.complex"

--- a/src/officecli/Handlers/Word/WordHandler.Set.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.cs
@@ -687,6 +687,12 @@ public partial class WordHandler
                 spacingLine.Line = lsTwips.ToString();
                 spacingLine.LineRule = lsIsMultiplier ? LineSpacingRuleValues.Auto : LineSpacingRuleValues.Exact;
                 return true;
+            case "linerule":
+                // BUG-019: explicit override needed to distinguish AtLeast
+                // from Exact — both serialize as "Npt" via SpacingConverter.
+                var spacingRule = pProps.SpacingBetweenLines ?? (pProps.SpacingBetweenLines = new SpacingBetweenLines());
+                spacingRule.LineRule = ParseLineRule(value);
+                return true;
             case "numId" or "numid":
                 var numPr = pProps.NumberingProperties ?? (pProps.NumberingProperties = new NumberingProperties());
                 var numIdVal = ParseHelpers.SafeParseInt(value, "numId");

--- a/src/officecli/Handlers/Word/WordHandler.Set.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.cs
@@ -552,7 +552,14 @@ public partial class WordHandler
         }
         else
             size = style == BorderValues.Nil ? 0u : style == BorderValues.Thick ? 12u : 4u;
-        string? color = parts.Length > 2 ? SanitizeHex(parts[2]) : null;
+        // BUG-R7-02: dump emits "nil;0;;0" for nil borders (empty color
+        // segment). SanitizeHex rejects empty input with "Invalid color
+        // value: ''", breaking round-trip on any docx with nil paragraph
+        // borders. Treat an empty color segment as "no color" (null) rather
+        // than a parse error — this matches dump's emit semantics.
+        string? color = (parts.Length > 2 && !string.IsNullOrEmpty(parts[2]))
+            ? SanitizeHex(parts[2])
+            : null;
         uint space = 0u;
         if (parts.Length > 3 && !uint.TryParse(parts[3], out space))
             throw new ArgumentException($"Invalid border space '{parts[3]}', expected integer. Format: STYLE[;SIZE[;COLOR[;SPACE]]]");

--- a/src/officecli/Handlers/Word/WordHandler.Set.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.cs
@@ -528,7 +528,12 @@ public partial class WordHandler
         var parts = value.Split(';');
         var style = ParseBorderStyle(parts[0]);
         uint size;
-        if (parts.Length > 1)
+        // CONSISTENCY(border-empty-segment): mirror the empty-color tolerance
+        // below — BatchEmitter's border fold emits "STYLE;;COLOR" whenever a
+        // side has color but no explicit sz attribute (very common in real
+        // .docx files where w:sz is inherited via the style chain). Treat an
+        // empty SIZE segment as "use default" instead of throwing.
+        if (parts.Length > 1 && !string.IsNullOrEmpty(parts[1].Trim()))
         {
             // OOXML stores border size in eighth-of-a-point units. Accept bare
             // integer (already in eighths) plus unit-qualified lengths
@@ -561,7 +566,10 @@ public partial class WordHandler
             ? SanitizeHex(parts[2])
             : null;
         uint space = 0u;
-        if (parts.Length > 3 && !uint.TryParse(parts[3], out space))
+        // CONSISTENCY(border-empty-segment): symmetric with the SIZE/COLOR
+        // tolerance — empty SPACE segment means "no override".
+        if (parts.Length > 3 && !string.IsNullOrEmpty(parts[3])
+            && !uint.TryParse(parts[3], out space))
             throw new ArgumentException($"Invalid border space '{parts[3]}', expected integer. Format: STYLE[;SIZE[;COLOR[;SPACE]]]");
         return (style, size, color, space);
     }

--- a/src/officecli/Handlers/WordHandler.cs
+++ b/src/officecli/Handlers/WordHandler.cs
@@ -248,7 +248,11 @@ public partial class WordHandler : IDocumentHandler
         // across the same _usedParaIds set. Re-run EnsureAllParaIds after
         // every successful raw mutation so the global pool stays accurate.
         EnsureAllParaIds();
-        Console.WriteLine($"raw-set: {affected} element(s) affected");
+        // BUG-R5-01: do not emit chatter from inside the handler — the CLI
+        // wrappers (CommandBuilder.Raw raw-set + batch run raw-set) print
+        // their own structured message. Writing here pollutes batch --json
+        // output (extra stdout lines escaped into result.message strings).
+        _ = affected;
     }
 
     public List<ValidationError> Validate() => RawXmlHelper.ValidateDocument(_doc);

--- a/src/officecli/Handlers/WordHandler.cs
+++ b/src/officecli/Handlers/WordHandler.cs
@@ -176,11 +176,35 @@ public partial class WordHandler : IDocumentHandler
         else if (lowerPath is "/settings")
             rootElement = mainPart.DocumentSettingsPart?.Settings ?? throw new InvalidOperationException("No settings part");
         else if (lowerPath is "/numbering")
-            rootElement = mainPart.NumberingDefinitionsPart?.Numbering ?? throw new InvalidOperationException("No numbering part");
+        {
+            // CONSISTENCY(raw-set-create-missing-part): see /theme branch.
+            var numPart = mainPart.NumberingDefinitionsPart ?? mainPart.AddNewPart<NumberingDefinitionsPart>();
+            if (numPart.Numbering == null)
+            {
+                numPart.Numbering = new Numbering();
+                numPart.Numbering.Save();
+            }
+            rootElement = numPart.Numbering;
+        }
         else if (lowerPath is "/comments")
             rootElement = mainPart.WordprocessingCommentsPart?.Comments ?? throw new InvalidOperationException("No comments part");
         else if (lowerPath is "/theme")
-            rootElement = mainPart.ThemePart?.Theme ?? throw new InvalidOperationException("No theme part");
+        {
+            // CONSISTENCY(raw-set-create-missing-part): blank docs created via
+            // BlankDocCreator have no ThemePart; dump→batch round-trip from a
+            // real Word/python-docx file emits raw-set /theme replace which
+            // would otherwise abort the whole batch. Lazily add the theme part
+            // and an empty <a:theme> root so RawXmlHelper.Execute can match
+            // /a:theme and replace it with the dumped XML.
+            var themePart = mainPart.ThemePart ?? mainPart.AddNewPart<ThemePart>();
+            if (themePart.Theme == null)
+            {
+                themePart.Theme = new DocumentFormat.OpenXml.Drawing.Theme(
+                    new DocumentFormat.OpenXml.Drawing.ThemeElements());
+                themePart.Theme.Save();
+            }
+            rootElement = themePart.Theme;
+        }
         else if (lowerPath.StartsWith("/header"))
         {
             var idx = 0;

--- a/src/officecli/ResidentServer.cs
+++ b/src/officecli/ResidentServer.cs
@@ -728,9 +728,16 @@ public class ResidentServer : IDisposable
     {
         _lastBatchHadFailure = false;
         var batchJson = request.GetArg("batchJson");
+        // BUG-R4-BT2: stopOnError is now an explicit arg from the client.
+        // For older clients that only send "force", fall back to the legacy
+        // semantics (force=true ⇒ continue-on-error). Newer clients always
+        // send stopOnError so the legacy fallback never fires.
         var force = request.GetArg("force", "false")
             .Equals("true", StringComparison.OrdinalIgnoreCase);
-        var stopOnError = !force;
+        var hasStopArg = request.Args?.ContainsKey("stopOnError") == true;
+        var stopOnError = hasStopArg
+            ? request.GetArg("stopOnError", "false").Equals("true", StringComparison.OrdinalIgnoreCase)
+            : !force;
         var json = request.Json;
 
         var items = System.Text.Json.JsonSerializer.Deserialize<List<BatchItem>>(


### PR DESCRIPTION
## Summary
Bundles 59 fix/feat commits accumulated on local main since `origin/main`, mostly Word/docx correctness work plus a few schema and batch-mode fixes. Pushed to a branch so `/ultrareview <PR#>` can run against it.

Highlights:
- docx dump round-trip fidelity: tabs, SDT, fields, columns, section.type, footnote refs, header role, style tab stops, table row props, ptab, field DATE switch, w14 effects, numbering suff/jc order, ListItem value, TOC \t/\b, equation-adjacent paths
- paragraph/run Add+Set parity: rStyle, outlineLvl, widowControl, chars-based indent, color=auto, leftIndent/rightIndent/firstLine/hangingIndent, pbdr on style
- numbering: AddLvl font/size/color/bold/italic/underline, start / startOverride.N on Set
- picture: floating wrap/position Get, anchor=true on Get, sanitize alt/name for data: URIs, skip zero-valued anchor hPos/vPos
- chart: width/height on docx Get, name prop on Add, title.bold/size/color/font + chartFill full add/set/get
- batch: continue-on-error default + `--stop-on-error` opt-in, JSON envelope parity, friendlier edge-input errors, after/before serialization
- misc: validate crash → clean error, dump --out - → stdout, theme color aliases, ARGB alpha warning, AddStyle idempotent for built-in ids

No uncommitted application code; only `examples/word/tables.docx` is dirty in the worktree and intentionally left out.

## Test plan
- [ ] `/ultrareview` flags no regressions
- [ ] Existing functional tests pass (`dotnet test`)
- [ ] Spot-check dump→batch round-trip on a few real .docx files