### PR TITLE
feat(docx): revision ID auto-management + moveFrom/moveTo support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+# PR submission attachments (keep outside repo)
+pr-screenshots/
+pr-descriptions/
+screenshots/

--- a/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
@@ -1114,7 +1114,7 @@ public partial class WordHandler
                 pprChange.Date = pTcDt;
             pprChange.Id = !string.IsNullOrEmpty(pTcId)
                 ? pTcId
-                : (GenerateParaId().GetHashCode() & 0x7FFFFFFF).ToString();
+                : GetNextRevisionId().ToString();
             pprChange.AppendChild(new PreviousParagraphProperties());
             pProps.AppendChild(pprChange);
         }
@@ -1862,7 +1862,7 @@ public partial class WordHandler
                 rprChange.Date = tcfDate;
             rprChange.Id = !string.IsNullOrEmpty(trackChangeId)
                 ? trackChangeId
-                : (GenerateParaId().GetHashCode() & 0x7FFFFFFF).ToString();
+                : GetNextRevisionId().ToString();
             // Schema: w:rPrChange child of w:rPr; ECMA-376 §17.13.5.31.
             // Empty inner rPr is schema-valid (means "no recorded prior
             // property set" — minimal marker form).
@@ -1895,9 +1895,8 @@ public partial class WordHandler
                 }
                 else
                 {
-                    // Each ins/del needs a unique w:id. Reuse the paraId
-                    // counter to avoid colliding with anything Word writes.
-                    var fallbackId = (GenerateParaId().GetHashCode() & 0x7FFFFFFF).ToString();
+                    // Scan the document for the highest existing revision ID and use max+1.
+                    var fallbackId = GetNextRevisionId().ToString();
                     if (wrapper is InsertedRun insW4) insW4.Id = fallbackId;
                     else if (wrapper is DeletedRun delW4) delW4.Id = fallbackId;
                 }
@@ -1912,6 +1911,52 @@ public partial class WordHandler
                         t.Parent?.ReplaceChild(dt, t);
                     }
                 }
+                parentEl.ReplaceChild(wrapper, newRun);
+                wrapper.AppendChild(newRun);
+            }
+        }
+
+        // v5.10: trackChange=moveFrom/moveTo → <w:moveFrom>/<w:moveTo> wrapper.
+        // MoveFrom uses w:delText (same rule as w:del); MoveTo uses w:t (same
+        // rule as w:ins). In OOXML, moveFrom+moveTo must appear as a pair with
+        // matching author/date to represent a single "move" operation.
+        if (trackChangeKind == "movefrom")
+        {
+            var parentEl = newRun.Parent;
+            if (parentEl != null)
+            {
+                var wrapper = new MoveFromRun();
+                if (!string.IsNullOrEmpty(trackChangeAuthor))
+                    wrapper.Author = trackChangeAuthor;
+                if (!string.IsNullOrEmpty(trackChangeDate)
+                    && DateTime.TryParse(trackChangeDate, out var mfDate))
+                    wrapper.Date = mfDate;
+                wrapper.Id = !string.IsNullOrEmpty(trackChangeId)
+                    ? trackChangeId : GetNextRevisionId().ToString();
+                // MoveFrom uses w:delText (same conversion as w:del)
+                foreach (var t in newRun.Elements<Text>().ToList())
+                {
+                    var dt = new DeletedText(t.Text ?? "") { Space = t.Space };
+                    t.Parent?.ReplaceChild(dt, t);
+                }
+                parentEl.ReplaceChild(wrapper, newRun);
+                wrapper.AppendChild(newRun);
+            }
+        }
+        if (trackChangeKind == "moveto")
+        {
+            var parentEl = newRun.Parent;
+            if (parentEl != null)
+            {
+                var wrapper = new MoveToRun();
+                if (!string.IsNullOrEmpty(trackChangeAuthor))
+                    wrapper.Author = trackChangeAuthor;
+                if (!string.IsNullOrEmpty(trackChangeDate)
+                    && DateTime.TryParse(trackChangeDate, out var mtDate))
+                    wrapper.Date = mtDate;
+                wrapper.Id = !string.IsNullOrEmpty(trackChangeId)
+                    ? trackChangeId : GetNextRevisionId().ToString();
+                // MoveTo uses w:t (same as w:ins) — no text conversion needed
                 parentEl.ReplaceChild(wrapper, newRun);
                 wrapper.AppendChild(newRun);
             }

--- a/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
@@ -1112,6 +1112,8 @@ public partial class WordHandler
             if (!string.IsNullOrEmpty(pTcAuthor)) pprChange.Author = pTcAuthor;
             if (!string.IsNullOrEmpty(pTcDate) && DateTime.TryParse(pTcDate, out var pTcDt))
                 pprChange.Date = pTcDt;
+            else
+                pprChange.Date = DateTime.UtcNow;
             pprChange.Id = !string.IsNullOrEmpty(pTcId)
                 ? pTcId
                 : GetNextRevisionId().ToString();
@@ -1860,6 +1862,8 @@ public partial class WordHandler
             if (!string.IsNullOrEmpty(trackChangeDate)
                 && DateTime.TryParse(trackChangeDate, out var tcfDate))
                 rprChange.Date = tcfDate;
+            else
+                rprChange.Date = DateTime.UtcNow;
             rprChange.Id = !string.IsNullOrEmpty(trackChangeId)
                 ? trackChangeId
                 : GetNextRevisionId().ToString();
@@ -1887,6 +1891,11 @@ public partial class WordHandler
                 {
                     if (wrapper is InsertedRun insW2) insW2.Date = tcDate;
                     else if (wrapper is DeletedRun delW2) delW2.Date = tcDate;
+                }
+                else
+                {
+                    if (wrapper is InsertedRun insW2b) insW2b.Date = DateTime.UtcNow;
+                    else if (wrapper is DeletedRun delW2b) delW2b.Date = DateTime.UtcNow;
                 }
                 if (!string.IsNullOrEmpty(trackChangeId))
                 {
@@ -1931,6 +1940,8 @@ public partial class WordHandler
                 if (!string.IsNullOrEmpty(trackChangeDate)
                     && DateTime.TryParse(trackChangeDate, out var mfDate))
                     wrapper.Date = mfDate;
+                else
+                    wrapper.Date = DateTime.UtcNow;
                 wrapper.Id = !string.IsNullOrEmpty(trackChangeId)
                     ? trackChangeId : GetNextRevisionId().ToString();
                 // MoveFrom uses w:delText (same conversion as w:del)
@@ -1954,6 +1965,8 @@ public partial class WordHandler
                 if (!string.IsNullOrEmpty(trackChangeDate)
                     && DateTime.TryParse(trackChangeDate, out var mtDate))
                     wrapper.Date = mtDate;
+                else
+                    wrapper.Date = DateTime.UtcNow;
                 wrapper.Id = !string.IsNullOrEmpty(trackChangeId)
                     ? trackChangeId : GetNextRevisionId().ToString();
                 // MoveTo uses w:t (same as w:ins) — no text conversion needed

--- a/src/officecli/Handlers/Word/WordHandler.Helpers.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Helpers.cs
@@ -3728,6 +3728,39 @@ public partial class WordHandler
         }
     }
 
+    // ==================== Revision IDs (track changes) ====================
+
+    /// <summary>
+    /// Get the next unique revision ID by scanning all existing revision elements
+    /// in the document body and returning max(id) + 1.
+    /// OOXML requires revision IDs to be unique non-negative integers across
+    /// all revision elements (w:ins, w:del, w:moveFrom, w:moveTo, rPrChange,
+    /// pPrChange, sectPrChange, tblPrChange, and table-row markers).
+    /// </summary>
+    private int GetNextRevisionId()
+    {
+        int maxId = 0;
+        var body = _doc.MainDocumentPart?.Document?.Body;
+        if (body != null)
+        {
+            foreach (var elem in body.Descendants())
+            {
+                if (elem is InsertedRun or DeletedRun or MoveFromRun or MoveToRun
+                    or RunPropertiesChange or ParagraphPropertiesChange
+                    or SectionPropertiesChange or TablePropertiesChange
+                    or Inserted or Deleted
+                    or MoveFrom or MoveTo)
+                {
+                    var idAttr = elem.GetAttributes()
+                        .FirstOrDefault(a => a.LocalName == "id");
+                    if (idAttr.Value != null && int.TryParse(idAttr.Value, out int id) && id > maxId)
+                        maxId = id;
+                }
+            }
+        }
+        return maxId + 1;
+    }
+
     // ==================== SDT IDs (content controls) ====================
 
     /// <summary>

--- a/src/officecli/Handlers/Word/WordHandler.Helpers.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Helpers.cs
@@ -3737,28 +3737,37 @@ public partial class WordHandler
     /// all revision elements (w:ins, w:del, w:moveFrom, w:moveTo, rPrChange,
     /// pPrChange, sectPrChange, tblPrChange, and table-row markers).
     /// </summary>
+    // Lazy-initialised cache: first call scans the document, subsequent
+    // calls simply increment.  Ensures IDs are unique even when multiple
+    // revision elements are created in the same method invocation.
+    private int _cachedMaxRevisionId = -1;
+
     private int GetNextRevisionId()
     {
-        int maxId = 0;
-        var body = _doc.MainDocumentPart?.Document?.Body;
-        if (body != null)
+        if (_cachedMaxRevisionId < 0)
         {
-            foreach (var elem in body.Descendants())
+            int maxId = 0;
+            var body = _doc.MainDocumentPart?.Document?.Body;
+            if (body != null)
             {
-                if (elem is InsertedRun or DeletedRun or MoveFromRun or MoveToRun
-                    or RunPropertiesChange or ParagraphPropertiesChange
-                    or SectionPropertiesChange or TablePropertiesChange
-                    or Inserted or Deleted
-                    or MoveFrom or MoveTo)
+                foreach (var elem in body.Descendants())
                 {
-                    var idAttr = elem.GetAttributes()
-                        .FirstOrDefault(a => a.LocalName == "id");
-                    if (idAttr.Value != null && int.TryParse(idAttr.Value, out int id) && id > maxId)
-                        maxId = id;
+                    if (elem is InsertedRun or DeletedRun or MoveFromRun or MoveToRun
+                        or RunPropertiesChange or ParagraphPropertiesChange
+                        or SectionPropertiesChange or TablePropertiesChange
+                        or Inserted or Deleted
+                        or MoveFrom or MoveTo)
+                    {
+                        var idAttr = elem.GetAttributes()
+                            .FirstOrDefault(a => a.LocalName == "id");
+                        if (idAttr.Value != null && int.TryParse(idAttr.Value, out int id) && id > maxId)
+                            maxId = id;
+                    }
                 }
             }
+            _cachedMaxRevisionId = maxId;
         }
-        return maxId + 1;
+        return ++_cachedMaxRevisionId;
     }
 
     // ==================== SDT IDs (content controls) ====================


### PR DESCRIPTION
# feat(docx): revision ID auto-management + moveFrom/moveTo support

## Problem

1. **Revision ID collisions**: When `trackChange.id` is not specified, the fallback logic used `GenerateParaId().GetHashCode() & 0x7FFFFFFF`, which can produce duplicate IDs. Duplicate revision IDs cause Word to incorrectly group Accept/Reject operations.

2. **moveFrom/moveTo silent failure**: `trackChange=moveFrom` and `trackChange=moveTo` silently produced plain `<w:r>` elements instead of `<w:moveFrom>` / `<w:moveTo>` wrappers. This is the most dangerous behavior — an Agent believes it created a move revision, but the output is unmarked text.

3. **Missing date default**: Without `trackChange.date`, Word may not render revision marks correctly in some contexts.

## Changes

### `WordHandler.Helpers.cs`
- Added `GetNextRevisionId()` — scans all revision elements (`w:ins`, `w:del`, `w:moveFrom`, `w:moveTo`, `rPrChange`, `pPrChange`, `sectPrChange`, `tblPrChange`, row-level markers) in the document, finds the maximum `w:id`, and returns `max + 1`.
- Uses `_cachedMaxRevisionId` lazy cache so consecutive calls within the same method produce strictly increasing IDs.

### `WordHandler.Add.Text.cs`
- Replaced 3 instances of `GenerateParaId().GetHashCode() & 0x7FFFFFFF` with `GetNextRevisionId()`.
- Added `moveFrom` / `moveTo` branches in the `trackChange` processing block:
  - `moveFrom`: wraps run in `<w:moveFrom>`, converts `<w:t>` → `<w:delText>` (same as `del`).
  - `moveTo`: wraps run in `<w:moveTo>`, keeps `<w:t>` as-is (same as `ins`).
- Default `DateTime.UtcNow` when `trackChange.date` is omitted (Word requires `w:date` for proper rendering).

## Verification

### Revision ID auto-increment
```
officecli create test.docx
officecli add test.docx /body --type paragraph --prop text=x
officecli add test.docx '/body/p[1]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text=a1
officecli add test.docx '/body/p[1]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text=a2
officecli add test.docx '/body/p[1]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text=a3
officecli close test.docx
```
→ All `w:id` values are sequential: 1, 2, 3

### moveFrom
```
officecli add test.docx '/body/p[1]' --type run --prop trackChange=moveFrom --prop trackChange.author=AI --prop text=moved
```
→ XML contains `<w:moveFrom>` wrapper with `<w:delText>`

### moveTo
```
officecli add test.docx '/body/p[1]' --type run --prop trackChange=moveTo --prop trackChange.author=AI --prop text=moved
```
→ XML contains `<w:moveTo>` wrapper with `<w:t>`

### WPS Office screenshots

**Insertion revision (s1_ins):**

![Insertion revision](https://github.com/NextDoorLaoHuang-HF/OfficeCLI/releases/download/screenshots-temp/small_s1_ins.png)

**Deletion revision (s2_del):**

![Deletion revision](https://github.com/NextDoorLaoHuang-HF/OfficeCLI/releases/download/screenshots-temp/small_s2_del.png)

**Move revision (s4_move):**

![Move revision](https://github.com/NextDoorLaoHuang-HF/OfficeCLI/releases/download/screenshots-temp/small_s4_move.png)

## Files changed
- `src/officecli/Handlers/Word/WordHandler.Helpers.cs` — `GetNextRevisionId()`, `_cachedMaxRevisionId`
- `src/officecli/Handlers/Word/WordHandler.Add.Text.cs` — 3× GetHashCode→GetNextRevisionId, moveFrom/moveTo branches, date defaults
