### PR TITLE
feat(docx): add trackRevisions toggle for track changes mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+# PR submission attachments (keep outside repo)
+pr-screenshots/
+pr-descriptions/
+screenshots/

--- a/src/officecli/Handlers/Word/WordHandler.Navigation.DocSettings.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Navigation.DocSettings.cs
@@ -132,6 +132,10 @@ public partial class WordHandler
         if (defTabStop?.Val?.Value != null)
             node.Format["defaultTabStop"] = FormatTwipsToCm((uint)defTabStop.Val.Value);
 
+        // ==================== Track Changes ====================
+        if (settings.GetFirstChild<TrackRevisions>() != null)
+            node.Format["trackRevisions"] = true;
+
         // ==================== Theme Font Languages ====================
         // CONSISTENCY(locale-readback): `--locale ar-SA` writes
         // settings/themeFontLang on Set; `Get /` must surface the same

--- a/src/officecli/Handlers/Word/WordHandler.Set.DocSettings.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.DocSettings.cs
@@ -189,6 +189,24 @@ public partial class WordHandler
                 return true;
             }
 
+            // v5.10: set trackRevisions=true/false to toggle <w:trackChanges/> in settings.
+            // When true, Word records subsequent edits as revision marks.
+            case "trackrevisions" or "trackchanges":
+            {
+                var settings = EnsureSettings();
+                if (IsTruthy(value))
+                {
+                    if (settings.GetFirstChild<TrackRevisions>() == null)
+                        settings.AppendChild(new TrackRevisions());
+                }
+                else
+                {
+                    settings.GetFirstChild<TrackRevisions>()?.Remove();
+                }
+                settings.Save();
+                return true;
+            }
+
             default:
                 return false;
         }


### PR DESCRIPTION
# feat(docx): add trackRevisions toggle for track changes mode

## Problem

There was no way to enable or disable Word's track changes mode via CLI. Users could only create individual revision marks, but could not toggle `<w:trackChanges/>` in `settings.xml`.

## Changes

### `WordHandler.Set.DocSettings.cs`
- Added `trackrevisions` / `trackchanges` case in `TrySetDocSetting`:
  - `true` → creates `<w:trackRevisions/>` in document settings
  - `false` → removes `<w:trackRevisions/>` from document settings
- Both `trackRevisions` and `trackChanges` are accepted as property names (aliases)

### `WordHandler.Navigation.DocSettings.cs`
- Added `trackRevisions` read in doc settings navigation output
- `get /` now shows `trackRevisions=true` or `trackRevisions=false`

## Verification

### Enable track changes mode
```
officecli create test.docx
officecli add test.docx /body --type paragraph --prop text=x
officecli set test.docx / --prop trackRevisions=true
officecli close test.docx
```
→ `word/settings.xml` contains `<w:trackRevisions/>`

### Disable track changes mode
```
officecli set test.docx / --prop trackRevisions=false
```
→ `<w:trackRevisions/>` is removed

### Query status
```
officecli get test.docx /
```
→ Output includes `trackRevisions=true` when enabled (follows existing convention of only showing non-default values)

### WPS Office verification

![Track changes mode enabled in WPS](https://github.com/NextDoorLaoHuang-HF/OfficeCLI/releases/download/screenshots-temp/small_s1_ins.png)

Opening the file in WPS shows "Track Changes" mode enabled in status bar.

## Files changed
- `src/officecli/Handlers/Word/WordHandler.Set.DocSettings.cs` — `trackRevisions` set case
- `src/officecli/Handlers/Word/WordHandler.Navigation.DocSettings.cs` — `trackRevisions` read
