### PR TITLE
feat(html-preview): Track Changes rendering + Watch revision API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+# PR submission attachments (keep outside repo)
+pr-screenshots/
+pr-descriptions/
+screenshots/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 pr-screenshots/
 pr-descriptions/
 screenshots/
+
+# Build output
+**/bin/
+**/obj/
+
+# Temp files
+pr-review-report.md

--- a/SKILL.md
+++ b/SKILL.md
@@ -357,28 +357,51 @@ When the user asks to review, audit, redline, or revise a document with tracked 
 
 **Do NOT use bare `add run --prop trackChange=del/ins` on an existing paragraph** — it appends to the end, producing: `original text ~~deleted~~ <u>inserted</u>`. This duplicates text instead of marking the original.
 
-For each change (e.g. replacing "3个工作日" with "5个工作日"):
+### Step-by-step: Replace text with tracked change
+
+For each change (e.g. replacing "8" with "4"):
 
 ```bash
-# Step 1: Use `set` with `find` to split the target text into its own run.
-officecli set "$FILE" '/body/p[N]' --prop find="3个工作日" --prop color=auto
-#   Result: r[1]="...前" r[2]="3个工作日" r[3]="后..."
+# Step 0: Read the paragraph run structure FIRST
+officecli get "$FILE" '/body/p[N]' --depth 2
+# This shows each run and its text. The target may be split
+# across runs (e.g. "8" in r[3], "小时" in r[4]).
+
+# Step 1: Use `set` with `find` to isolate the target into its own run.
+# find only matches within a SINGLE run. Use the minimal unique text.
+# If the target is a number like "8" already in its own run, find="8" works.
+officecli set "$FILE" '/body/p[N]' --prop find="8" --prop color=auto
+#   Result: r[1]="...前" r[2]="8" r[3]="...后"
 
 # Step 2: Remove the original (unmarked) run.
 officecli remove "$FILE" '/body/p[N]/r[2]'
-#   Result: r[1]="...前" r[2]="后..."
 
 # Step 3: Add ins run AFTER the preceding run (r[1]).
 officecli add "$FILE" '/body/p[N]' --type run --after '/body/p[N]/r[1]' \
-  --prop trackChange=ins --prop trackChange.author=AI --prop text="5个工作日"
-#   Result: r[1]="...前" r[2]=<ins>"5个工作日"</ins> r[3]="后..."
+  --prop trackChange=ins --prop trackChange.author=AI --prop text="4"
 
 # Step 4: Add del run AFTER the same preceding run (r[1]).
-#   Both use --after r[1]; the second add pushes the first forward.
 officecli add "$FILE" '/body/p[N]' --type run --after '/body/p[N]/r[1]' \
-  --prop trackChange=del --prop trackChange.author=AI --prop text="3个工作日"
-#   Result: r[1]="...前" r[2]=<ins>"5个工作日"</ins> r[3]=<del>"3个工作日"</del> r[4]="后..."
+  --prop trackChange=del --prop trackChange.author=AI --prop text="8"
+# Final: r[1]="...前" r[2]=<ins>"4"</ins> r[3]=<del>"8"</del> r[4]="...后"
 ```
+
+### Handling cross-run text
+
+Real-world documents often split text across runs (e.g. `"【"` + `"8"` + `"】小时"`). Strategy:
+
+1. **Read run structure first** with `officecli get '/body/p[N]' --depth 2`
+2. **Find the smallest unique portion** that exists in a single run
+3. For numbers in brackets like `【8】`, the number `8` is typically its own run — just `find="8"`
+4. If `find` fails, try a shorter/adjacent portion within one run
+5. **NEVER fall back to unpack/pack or python-docx** — always find a way with officecli
+
+### When find doesn't match
+
+If `find` reports 0 matches:
+- The text is split across runs. Use `get --depth 2` to see actual run boundaries
+- Try just the number or keyword (e.g. `find="8"` instead of `find="8小时"`)
+- If multiple runs contain the same text, add enough context to be unique within a single run
 
 ### Other revision operations
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -353,27 +353,49 @@ officecli add-part <file> <parent>                   # create new document part 
 
 When the user asks to review, audit, redline, or revise a document with tracked changes, you MUST use `--prop trackChange=...`. Do NOT use python-docx, unpack/pack, raw-set, or any other approach for creating revision marks — the CLI handles OOXML revision markup natively.
 
-### Creating revisions
+### CRITICAL: In-place revision workflow
+
+**Do NOT use bare `add run --prop trackChange=del/ins` on an existing paragraph** — it appends to the end, producing: `original text ~~deleted~~ <u>inserted</u>`. This duplicates text instead of marking the original.
+
+For each change (e.g. replacing "3个工作日" with "5个工作日"):
 
 ```bash
-# Insert revision (green underline in Word/preview)
-officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="new clause"
+# Step 1: Use `set` with `find` to split the target text into its own run.
+officecli set "$FILE" '/body/p[N]' --prop find="3个工作日" --prop color=auto
+#   Result: r[1]="...前" r[2]="3个工作日" r[3]="后..."
 
-# Delete revision (red strikethrough in Word/preview)
-officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="removed text"
+# Step 2: Remove the original (unmarked) run.
+officecli remove "$FILE" '/body/p[N]/r[2]'
+#   Result: r[1]="...前" r[2]="后..."
 
-# Format change revision
-officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=format --prop trackChange.author=AI --prop bold=true --prop text="formatted"
+# Step 3: Add ins run AFTER the preceding run (r[1]).
+officecli add "$FILE" '/body/p[N]' --type run --after '/body/p[N]/r[1]' \
+  --prop trackChange=ins --prop trackChange.author=AI --prop text="5个工作日"
+#   Result: r[1]="...前" r[2]=<ins>"5个工作日"</ins> r[3]="后..."
+
+# Step 4: Add del run AFTER the same preceding run (r[1]).
+#   Both use --after r[1]; the second add pushes the first forward.
+officecli add "$FILE" '/body/p[N]' --type run --after '/body/p[N]/r[1]' \
+  --prop trackChange=del --prop trackChange.author=AI --prop text="3个工作日"
+#   Result: r[1]="...前" r[2]=<ins>"5个工作日"</ins> r[3]=<del>"3个工作日"</del> r[4]="后..."
+```
+
+### Other revision operations
+
+```bash
+# Format change revision (append at end is OK for new paragraphs)
+officecli add "$FILE" /body --type paragraph --prop trackChange=format --prop trackChange.author=AI --prop text="reformatted paragraph"
 
 # Move revision
 officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=moveFrom --prop trackChange.author=AI --prop text="moved text"
 officecli add "$FILE" '/body/p[2]' --type run --prop trackChange=moveTo --prop trackChange.author=AI --prop text="moved text"
 
-# Paragraph-level format revision
-officecli add "$FILE" /body --type paragraph --prop trackChange=format --prop trackChange.author=AI --prop text="reformatted paragraph"
-
 # Enable Track Changes mode (new edits auto-tracked in Word)
 officecli set "$FILE" / --prop trackRevisions=true
+
+# Accept or reject all revisions
+officecli set "$FILE" / --prop acceptallchanges=all
+officecli set "$FILE" / --prop rejectallchanges=all
 ```
 
 ### trackChange properties
@@ -385,22 +407,11 @@ officecli set "$FILE" / --prop trackRevisions=true
 | `trackChange.date` | ISO 8601 (default: now) | add run/paragraph |
 | `trackChange.id` | Integer (default: auto) | add run/paragraph |
 
-### Revision workflow
+### Verify
 
 ```bash
-# 1. Read the document
-officecli view "$FILE" text
-
-# 2. For each change: delete old text, insert new text
-officecli add "$FILE" '/body/p[3]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="3个工作日"
-officecli add "$FILE" '/body/p[3]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="5个工作日"
-
-# 3. Verify revisions
-officecli query "$FILE" revision
-
-# 4. Accept or reject all
-officecli set "$FILE" / --prop acceptallchanges=all
-officecli set "$FILE" / --prop rejectallchanges=all
+officecli query "$FILE" revision          # list all revisions
+officecli view "$FILE" html               # visual: green underline=ins, red strikethrough=del
 ```
 
 ### Contract review pattern (common task)
@@ -409,22 +420,19 @@ officecli set "$FILE" / --prop rejectallchanges=all
 FILE="contract_reviewed.docx"
 cp original.docx "$FILE"
 officecli open "$FILE"
-officecli view "$FILE" text                    # read full text
-officecli view "$FILE" outline                 # see structure
+officecli view "$FILE" outline
+officecli view "$FILE" text
 
-# For each issue found:
-# 1. Mark old text as deleted
-officecli add "$FILE" '/body/p[5]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="old clause"
-# 2. Mark new text as inserted
-officecli add "$FILE" '/body/p[5]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="revised clause"
+# For each change — use the in-place workflow:
+# 1. set find to split  2. remove original run
+# 3. add ins after preceding run  4. add del after preceding run
 
-# After all changes, verify
 officecli query "$FILE" revision
-officecli view "$FILE" html                    # visual check: green=inserted, red=deleted
+officecli view "$FILE" html
 officecli close "$FILE"
 ```
 
-**CRITICAL**: When user mentions "修订模式", "审查", "Track Changes", "redline", "revision", you MUST use `--prop trackChange=ins/del/format`. Never fall back to python-docx, docx.js, unpack/pack, or raw XML for revision marks.
+**CRITICAL**: When user mentions "修订模式", "审查", "Track Changes", "redline", "revision", you MUST use the in-place revision workflow. Never use bare `add run --prop trackChange=del/ins` without first splitting and removing the original run. Never fall back to python-docx, docx.js, unpack/pack, or raw XML.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -349,6 +349,85 @@ officecli add-part <file> <parent>                   # create new document part 
 
 ---
 
+## Track Changes / Revision Mode (Word .docx)
+
+When the user asks to review, audit, redline, or revise a document with tracked changes, you MUST use `--prop trackChange=...`. Do NOT use python-docx, unpack/pack, raw-set, or any other approach for creating revision marks — the CLI handles OOXML revision markup natively.
+
+### Creating revisions
+
+```bash
+# Insert revision (green underline in Word/preview)
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="new clause"
+
+# Delete revision (red strikethrough in Word/preview)
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="removed text"
+
+# Format change revision
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=format --prop trackChange.author=AI --prop bold=true --prop text="formatted"
+
+# Move revision
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=moveFrom --prop trackChange.author=AI --prop text="moved text"
+officecli add "$FILE" '/body/p[2]' --type run --prop trackChange=moveTo --prop trackChange.author=AI --prop text="moved text"
+
+# Paragraph-level format revision
+officecli add "$FILE" /body --type paragraph --prop trackChange=format --prop trackChange.author=AI --prop text="reformatted paragraph"
+
+# Enable Track Changes mode (new edits auto-tracked in Word)
+officecli set "$FILE" / --prop trackRevisions=true
+```
+
+### trackChange properties
+
+| Property | Values | Scope |
+|----------|--------|-------|
+| `trackChange` | `ins`, `del`, `format`, `moveFrom`, `moveTo` | add run/paragraph |
+| `trackChange.author` | Any string | add run/paragraph |
+| `trackChange.date` | ISO 8601 (default: now) | add run/paragraph |
+| `trackChange.id` | Integer (default: auto) | add run/paragraph |
+
+### Revision workflow
+
+```bash
+# 1. Read the document
+officecli view "$FILE" text
+
+# 2. For each change: delete old text, insert new text
+officecli add "$FILE" '/body/p[3]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="3个工作日"
+officecli add "$FILE" '/body/p[3]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="5个工作日"
+
+# 3. Verify revisions
+officecli query "$FILE" revision
+
+# 4. Accept or reject all
+officecli set "$FILE" / --prop acceptallchanges=all
+officecli set "$FILE" / --prop rejectallchanges=all
+```
+
+### Contract review pattern (common task)
+
+```bash
+FILE="contract_reviewed.docx"
+cp original.docx "$FILE"
+officecli open "$FILE"
+officecli view "$FILE" text                    # read full text
+officecli view "$FILE" outline                 # see structure
+
+# For each issue found:
+# 1. Mark old text as deleted
+officecli add "$FILE" '/body/p[5]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="old clause"
+# 2. Mark new text as inserted
+officecli add "$FILE" '/body/p[5]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="revised clause"
+
+# After all changes, verify
+officecli query "$FILE" revision
+officecli view "$FILE" html                    # visual check: green=inserted, red=deleted
+officecli close "$FILE"
+```
+
+**CRITICAL**: When user mentions "修订模式", "审查", "Track Changes", "redline", "revision", you MUST use `--prop trackChange=ins/del/format`. Never fall back to python-docx, docx.js, unpack/pack, or raw XML for revision marks.
+
+---
+
 ## Common Pitfalls
 
 | Pitfall | Correct Approach |

--- a/aionui-skill/README.md
+++ b/aionui-skill/README.md
@@ -1,0 +1,48 @@
+# AionUI Track Changes Skill — 上游合并前的临时方案
+
+> 本文件在 PR 合并后可删除。
+
+## 背景
+
+OfficeCLI v5.10 已完整支持 Track Changes 修订模式（`--prop trackChange=ins/del/format`），但 AionUI 内嵌的 `office-cli` SKILL.md 尚未包含修订章节。导致 Agent 不知道 CLI 支持修订，会回退到 python-docx 等方案产生错误标记。
+
+上游 PR 合并后，AionUI 更新依赖即可自动获得。合并前可通过用户 Skill 临时补齐。
+
+## 安装
+
+```bash
+# 1. 创建 skill 目录
+mkdir -p ~/.aionui-config/skills/officecli-track-changes
+
+# 2. 下载 SKILL.md
+curl -fsSL https://raw.githubusercontent.com/NextDoorLaoHuang-HF/OfficeCLI/feat/schema-track-changes/aionui-skill/SKILL.md \
+  -o ~/.aionui-config/skills/officecli-track-changes/SKILL.md
+```
+
+## 启用
+
+1. 打开 AionUI → 设置 → Skills
+2. 找到 `officecli-track-changes`，确保已启用
+3. 新建会话即可使用
+
+如果使用 Word 文档助手，需要在助手设置中启用该 skill。
+
+## 验证
+
+在 AionUI 中新建 Word 文档助手会话，发送：
+
+> 用修订模式修改 test.docx：插入"新增条款"，删除"旧条款"
+
+Agent 应直接使用 `officecli add ... --prop trackChange=ins` 和 `--prop trackChange=del`，不再尝试 python-docx。
+
+## 卸载
+
+上游合并后，删除即可：
+
+```bash
+rm -rf ~/.aionui-config/skills/officecli-track-changes
+```
+
+## 分发
+
+把 `SKILL.md` 文件发给朋友，放入 `~/.aionui-config/skills/officecli-track-changes/` 目录即可。

--- a/aionui-skill/SKILL.md
+++ b/aionui-skill/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: officecli-track-changes
+description: "Track Changes / 修订模式 for .docx files. Use when the user wants to review, audit, redline, or revise a document with tracked changes (修订模式, 审查, redline, revision). MUST load alongside officecli skill."
+---
+
+# Track Changes / Revision Mode (Word .docx)
+
+When the user asks to review, audit, redline, or revise a document with tracked changes, you MUST use `--prop trackChange=...`. Do NOT use python-docx, unpack/pack, raw-set, or any other approach for creating revision marks — the CLI handles OOXML revision markup natively.
+
+### Creating revisions
+
+```bash
+# Insert revision (green underline in Word/preview)
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="new clause"
+
+# Delete revision (red strikethrough in Word/preview)
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="removed text"
+
+# Format change revision
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=format --prop trackChange.author=AI --prop bold=true --prop text="formatted"
+
+# Move revision
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=moveFrom --prop trackChange.author=AI --prop text="moved text"
+officecli add "$FILE" '/body/p[2]' --type run --prop trackChange=moveTo --prop trackChange.author=AI --prop text="moved text"
+
+# Paragraph-level format revision
+officecli add "$FILE" /body --type paragraph --prop trackChange=format --prop trackChange.author=AI --prop text="reformatted paragraph"
+
+# Enable Track Changes mode (new edits auto-tracked in Word)
+officecli set "$FILE" / --prop trackRevisions=true
+```
+
+### trackChange properties
+
+| Property | Values | Scope |
+|----------|--------|-------|
+| `trackChange` | `ins`, `del`, `format`, `moveFrom`, `moveTo` | add run/paragraph |
+| `trackChange.author` | Any string | add run/paragraph |
+| `trackChange.date` | ISO 8601 (default: now) | add run/paragraph |
+| `trackChange.id` | Integer (default: auto) | add run/paragraph |
+
+### Revision workflow
+
+```bash
+# 1. Read the document
+officecli view "$FILE" text
+
+# 2. For each change: delete old text, insert new text
+officecli add "$FILE" '/body/p[3]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="3个工作日"
+officecli add "$FILE" '/body/p[3]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="5个工作日"
+
+# 3. Verify revisions
+officecli query "$FILE" revision
+
+# 4. Accept or reject all
+officecli set "$FILE" / --prop acceptallchanges=all
+officecli set "$FILE" / --prop rejectallchanges=all
+```
+
+### Contract review pattern (common task)
+
+```bash
+FILE="contract_reviewed.docx"
+cp original.docx "$FILE"
+officecli open "$FILE"
+officecli view "$FILE" text                    # read full text
+officecli view "$FILE" outline                 # see structure
+
+# For each issue found:
+# 1. Mark old text as deleted
+officecli add "$FILE" '/body/p[5]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="old clause"
+# 2. Mark new text as inserted
+officecli add "$FILE" '/body/p[5]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="revised clause"
+
+# After all changes, verify
+officecli query "$FILE" revision
+officecli view "$FILE" html                    # visual check: green=inserted, red=deleted
+officecli close "$FILE"
+```
+
+**CRITICAL**: When user mentions "修订模式", "审查", "Track Changes", "redline", "revision", you MUST use `--prop trackChange=ins/del/format`. Never fall back to python-docx, docx.js, unpack/pack, or raw XML for revision marks.

--- a/schemas/help/docx/document.json
+++ b/schemas/help/docx/document.json
@@ -640,6 +640,12 @@
       "get": true,
       "readback": "BCP-47 locale string",
       "enforcement": "report"
+    },
+    "trackRevisions": {
+      "type": "boolean",
+      "set": true,
+      "get": true,
+      "description": "Toggle track changes mode (w:trackChanges in settings)"
     }
   }
 }

--- a/schemas/help/docx/paragraph.json
+++ b/schemas/help/docx/paragraph.json
@@ -1174,6 +1174,27 @@
       "get": true,
       "readback": "font name",
       "enforcement": "report"
+    },
+    "trackChange": {
+      "type": "enum",
+      "values": ["ins", "del", "format", "moveFrom", "moveTo"],
+      "add": true,
+      "description": "Create revision mark wrapping this paragraph (format for pPrChange)"
+    },
+    "trackChange.author": {
+      "type": "string",
+      "add": true,
+      "description": "Author for the revision mark"
+    },
+    "trackChange.date": {
+      "type": "string",
+      "add": true,
+      "description": "Date/time for the revision mark (ISO 8601)"
+    },
+    "trackChange.id": {
+      "type": "string",
+      "add": true,
+      "description": "Unique revision ID (auto-assigned if omitted)"
     }
   }
 }

--- a/schemas/help/docx/run.json
+++ b/schemas/help/docx/run.json
@@ -701,6 +701,27 @@
       "description": "individual rFonts @hAnsi slot readback. On Add/Set use the unified `font.latin` key (which writes both ascii + hAnsi).",
       "readback": "font family name",
       "enforcement": "report"
+    },
+    "trackChange": {
+      "type": "enum",
+      "values": ["ins", "del", "format", "moveFrom", "moveTo"],
+      "add": true,
+      "description": "Create revision mark wrapping this run"
+    },
+    "trackChange.author": {
+      "type": "string",
+      "add": true,
+      "description": "Author for the revision mark"
+    },
+    "trackChange.date": {
+      "type": "string",
+      "add": true,
+      "description": "Date/time for the revision mark (ISO 8601)"
+    },
+    "trackChange.id": {
+      "type": "string",
+      "add": true,
+      "description": "Unique revision ID (auto-assigned if omitted)"
     }
   }
 }

--- a/schemas/help/docx/table-row.json
+++ b/schemas/help/docx/table-row.json
@@ -51,6 +51,27 @@
       "description": "row height rule readback — `exact` when the row enforces a fixed height, otherwise absent (auto/atLeast).",
       "readback": "`exact` when set",
       "enforcement": "report"
+    },
+    "trackChange": {
+      "type": "enum",
+      "values": ["ins", "del"],
+      "add": true,
+      "description": "Create revision mark for this table row"
+    },
+    "trackChange.author": {
+      "type": "string",
+      "add": true,
+      "description": "Author for the revision mark"
+    },
+    "trackChange.date": {
+      "type": "string",
+      "add": true,
+      "description": "Date/time for the revision mark (ISO 8601)"
+    },
+    "trackChange.id": {
+      "type": "string",
+      "add": true,
+      "description": "Unique revision ID (auto-assigned if omitted)"
     }
   }
 }

--- a/schemas/help/docx/table.json
+++ b/schemas/help/docx/table.json
@@ -141,6 +141,27 @@
       ],
       "readback": "n/a",
       "enforcement": "report"
+    },
+    "trackChange": {
+      "type": "enum",
+      "values": ["format"],
+      "set": true,
+      "description": "Create format-change revision mark for table properties"
+    },
+    "trackChange.author": {
+      "type": "string",
+      "set": true,
+      "description": "Author for the revision mark"
+    },
+    "trackChange.date": {
+      "type": "string",
+      "set": true,
+      "description": "Date/time for the revision mark (ISO 8601)"
+    },
+    "trackChange.id": {
+      "type": "string",
+      "set": true,
+      "description": "Unique revision ID (auto-assigned if omitted)"
     }
   }
 }

--- a/schemas/help/docx/trackedchange.json
+++ b/schemas/help/docx/trackedchange.json
@@ -4,7 +4,7 @@
   "element": "trackedchange",
   "parent": "paragraph|run",
   "operations": {
-    "add": false,
+    "add": true,
     "set": false,
     "get": true,
     "query": true,
@@ -13,37 +13,45 @@
   "paths": {
     "positional": ["/body/p[N]/ins[M]", "/body/p[N]/del[M]"]
   },
-  "note": "Raw revision element. Type selector routes to w:ins / w:del / w:moveTo / w:moveFrom. Tracked revisions are authored by Word itself (File -> Options -> Track Changes). CLI exposes read-only access: use `query revision` or `get /body/p[N]/ins[M]`. Handler also accepts bulk aliases (trackedchanges, acceptallchanges, rejectallchanges, acceptchanges, rejectchanges) for read/query.",
+  "note": "Raw revision element. Type selector routes to w:ins / w:del / w:moveTo / w:moveFrom / w:rPrChange / w:pPrChange. CLI can create revision marks via trackChange property on add run/paragraph. Handler also accepts bulk aliases (trackedchanges, acceptallchanges, rejectallchanges, acceptchanges, rejectchanges) for read/query.",
   "properties": {
     "type": {
       "type": "enum",
-      "values": ["ins", "del", "moveTo", "moveFrom"],
-      "add": false, "set": false, "get": true,
+      "values": ["ins", "del", "format", "moveTo", "moveFrom"],
+      "add": true, "set": false, "get": true,
       "examples": ["--prop type=ins"],
-      "readback": "revision type (read-only)",
+      "readback": "revision type",
       "enforcement": "report"
     },
     "text": {
       "type": "string",
-      "description": "text content for ins / content marker for del (read-only).",
-      "add": false, "set": false, "get": true,
+      "description": "text content for ins / content marker for del.",
+      "add": true, "set": false, "get": true,
       "examples": [],
-      "readback": "concatenated text (read-only)",
+      "readback": "concatenated text",
       "enforcement": "report"
     },
     "author": {
       "type": "string",
-      "add": false, "set": false, "get": true,
+      "add": true, "set": false, "get": true,
       "examples": [],
-      "readback": "revision author (read-only)",
+      "readback": "revision author",
       "enforcement": "report"
     },
     "date": {
       "type": "string",
-      "description": "ISO-8601 timestamp (read-only).",
-      "add": false, "set": false, "get": true,
+      "description": "ISO-8601 timestamp.",
+      "add": true, "set": false, "get": true,
       "examples": [],
-      "readback": "Date attribute (read-only)",
+      "readback": "Date attribute",
+      "enforcement": "report"
+    },
+    "id": {
+      "type": "string",
+      "description": "Unique revision ID (w:id). Auto-assigned if omitted.",
+      "add": true, "set": false, "get": true,
+      "examples": [],
+      "readback": "revision id",
       "enforcement": "report"
     }
   }

--- a/skills/officecli-docx/SKILL.md
+++ b/skills/officecli-docx/SKILL.md
@@ -466,7 +466,52 @@ officecli add "$FILE" "/body/p[3]" --type footnote --prop text="See Appendix A f
 
 **docx vs word-form skill — when to switch.** Stay in docx for any report, letter, memo, or proposal. Switch to `officecli-word-form` when the document's purpose is **data capture** — fillable intake forms, contracts / SOWs with user-fill slots, HR onboarding forms, medical questionnaires, compliance checklists, mail-merge templates. Those carry `<w:sdt>` content controls, `<w:ffData>` legacy form fields, or `documentProtection=forms`, none of which this skill teaches.
 
-**Comments and tracked changes.** Bulk accept/reject: `set / --prop accept-changes=all` (or `reject-changes=all`). Locate individual changes with `query ins` and `query del` — NOT `query trackedchange` (CLI bug C-D-1). Adding an `<w:ins>` or `<w:del>` from scratch requires `raw-set`. Add a comment with `add "/body/p[4]" --type comment --prop author=... --prop text=...`. Reply threading (`parentId`) and `done=true` resolution are UNSUPPORTED — see C-D-2 / C-D-5 for `raw-set` workarounds.
+**Comments and tracked changes.** Bulk accept/reject: `set / --prop acceptallchanges=all` (or `rejectallchanges=all`). Query all revisions: `query revision`.
+
+**Creating revisions (Track Changes mode).** Use `--prop trackChange=...` on `add` and `set` to create tracked insertions, deletions, format changes, and moves. No raw-set needed.
+
+```bash
+# Insert revision (green underline in preview)
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="new clause"
+
+# Delete revision (red strikethrough in preview)
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="removed text"
+
+# Format change revision (yellow highlight in preview)
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=format --prop trackChange.author=AI --prop bold=true --prop text="formatted"
+
+# Move revision (double green underline/strikethrough)
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=moveFrom --prop trackChange.author=AI --prop text="moved text"
+officecli add "$FILE" '/body/p[2]' --type run --prop trackChange=moveTo --prop trackChange.author=AI --prop text="moved text"
+
+# Paragraph-level format revision
+officecli add "$FILE" /body --type paragraph --prop trackChange=format --prop trackChange.author=AI --prop text="reformatted paragraph"
+
+# Toggle Track Changes mode (new edits auto-tracked in Word)
+officecli set "$FILE" / --prop trackRevisions=true
+```
+
+**Revision workflow.** Typical pattern: enable tracking → make changes → query → accept/reject.
+
+```bash
+# 1. See what revisions exist
+officecli query "$FILE" revision
+
+# 2. Accept or reject all
+officecli set "$FILE" / --prop acceptallchanges=all
+officecli set "$FILE" / --prop rejectallchanges=all
+```
+
+**trackChange properties:**
+
+| Property | Values | Scope |
+|----------|--------|-------|
+| `trackChange` | `ins`, `del`, `format`, `moveFrom`, `moveTo` | add run/paragraph |
+| `trackChange.author` | Any string | add run/paragraph |
+| `trackChange.date` | ISO 8601 (default: now) | add run/paragraph |
+| `trackChange.id` | Integer (default: auto) | add run/paragraph |
+
+Add a comment with `add "/body/p[4]" --type comment --prop author=... --prop text=...`. Reply threading (`parentId`) and `done=true` resolution are UNSUPPORTED — see C-D-2 / C-D-5 for `raw-set` workarounds.
 
 **Watermark.** Two steps because `add --prop opacity=...` is UNSUPPORTED (C-D-7): `add / --type watermark --prop text="DRAFT" --prop color=BFBFBF`, then `set /watermark --prop opacity=0.8`. Default opacity is 0.5.
 
@@ -476,7 +521,7 @@ Three tiers of precision; use the lowest that does the job.
 
 - **L1 — high-level props** (`--prop text=...`, `--prop style=Heading1`): your default. Works for 80% of cases.
 - **L2 — dotted-attr fallback** (`pbdr.top=`, `ind.left=`, `padding.top=`, `border.*`, `font.size=`, `font.color=`): when L1 lacks the exact knob. Schema-safe for most props. Example: `--prop pbdr.bottom="single;6;1F4E79;0"`. Prefer this over raw-set when the whitelist covers your need. **Two dotted props emit invalid XML today** — `shd.fill=` (missing `w:val`) and `ind.firstLine=` (placed after `w:jc` in `pPr`). Use the canonical L1 form of these instead: `shd=clear;FFFF00` and `firstLineIndent=360`. See Known Issues → Schema-invalid-on-emit.
-- **L3 — `raw-set` with XML**: last resort. Tied to OOXML knowledge; no schema protection. Use for tracked-change creation, internal hyperlinks, composite PAGE+NUMPAGES, comment `parentId`, `commentsExtended` `done=1`.
+- **L3 — `raw-set` with XML**: last resort. Tied to OOXML knowledge; no schema protection. Use for internal hyperlinks, composite PAGE+NUMPAGES, comment `parentId`, `commentsExtended` `done=1`.
 
 Borders go through the format `style;size;color;space`: `single;4;FF0000;1`. Hex colors never start with `#`: `FF0000`, not `#FF0000`. Scheme color names (`accent1..6`, `dark1`/`dark2`, `light1`/`light2`, `hyperlink`) are also accepted anywhere a hex color is (1.0.60+) — prefer hex when you need stable colors across themes.
 

--- a/src/officecli/Core/Watch/WatchServer.cs
+++ b/src/officecli/Core/Watch/WatchServer.cs
@@ -1726,6 +1726,27 @@ internal class WatchServer : IDisposable
                 return;
             }
 
+            if (requestLine.StartsWith("POST /api/revision/accept", StringComparison.Ordinal))
+            {
+                await HandleRevisionAcceptAsync(stream, headers, bodyPrefix, token);
+                client.Close();
+                return;
+            }
+
+            if (requestLine.StartsWith("POST /api/revision/reject", StringComparison.Ordinal))
+            {
+                await HandleRevisionRejectAsync(stream, headers, bodyPrefix, token);
+                client.Close();
+                return;
+            }
+
+            if (requestLine.StartsWith("GET /api/revision/count", StringComparison.Ordinal))
+            {
+                await HandleRevisionCountAsync(stream, headers, bodyPrefix, token);
+                client.Close();
+                return;
+            }
+
             // BUG-TESTER-R503: GET/PUT/etc on /api/selection must return 405,
             // not fall through to the HTML preview. Without this, an API
             // client that uses the wrong verb gets back a 200 HTML page and
@@ -2012,6 +2033,163 @@ internal class WatchServer : IDisposable
         await stream.WriteAsync(resp, token);
     }
 
+    /// <summary>
+    /// Handle POST /api/revision/accept — accept all tracked changes.
+    /// Spawns officecli set with acceptallchanges=all, waits for completion,
+    /// then signals SSE clients with a "full" refresh.
+    /// </summary>
+    private async Task HandleRevisionAcceptAsync(NetworkStream stream, Dictionary<string, string> headers, string bodyPrefix, CancellationToken token)
+    {
+        await RunRevisionActionAsync(stream, "acceptallchanges=all", token);
+    }
+
+    /// <summary>
+    /// Handle POST /api/revision/reject — reject all tracked changes.
+    /// Spawns officecli set with rejectallchanges=all, waits for completion,
+    /// then signals SSE clients with a "full" refresh.
+    /// </summary>
+    private async Task HandleRevisionRejectAsync(NetworkStream stream, Dictionary<string, string> headers, string bodyPrefix, CancellationToken token)
+    {
+        await RunRevisionActionAsync(stream, "rejectallchanges=all", token);
+    }
+
+    /// <summary>
+    /// Common helper for revision accept/reject actions.
+    /// Spawns officecli set with the given prop, returns 204 on success.
+    /// After the command completes, sends a "full" SSE event to trigger
+    /// a page refresh on all connected browsers.
+    /// </summary>
+    private async Task RunRevisionActionAsync(NetworkStream stream, string propArg, CancellationToken token)
+    {
+        int statusCode = 204;
+        string statusText = "No Content";
+        try
+        {
+            var exe = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName
+                ?? (OperatingSystem.IsWindows() ? "officecli.exe" : "officecli");
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = exe,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("set");
+            psi.ArgumentList.Add(_filePath);
+            psi.ArgumentList.Add("/");
+            psi.ArgumentList.Add("--prop");
+            psi.ArgumentList.Add(propArg);
+            using var proc = System.Diagnostics.Process.Start(psi);
+            if (proc != null)
+            {
+                await proc.WaitForExitAsync(token);
+
+                // After the set command completes, re-render the HTML so the
+                // cached snapshot stays in sync. Without this, wordDiffUpdate
+                // fetches stale HTML via fetch('/') and the diff reverts the
+                // change visually.
+                try
+                {
+                    var viewPsi = new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = exe,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    };
+                    viewPsi.ArgumentList.Add("view");
+                    viewPsi.ArgumentList.Add(_filePath);
+                    viewPsi.ArgumentList.Add("html");
+                    using var viewProc = System.Diagnostics.Process.Start(viewPsi);
+                    if (viewProc != null)
+                    {
+                        var htmlPath = (await viewProc.StandardOutput.ReadLineAsync(token) ?? "").Trim();
+                        await viewProc.WaitForExitAsync(token);
+                        if (!string.IsNullOrEmpty(htmlPath) && File.Exists(htmlPath))
+                        {
+                            var freshHtml = await File.ReadAllTextAsync(htmlPath, token);
+                            if (!string.IsNullOrEmpty(freshHtml))
+                                _currentHtml = freshHtml;
+                        }
+                    }
+                }
+                catch
+                {
+                    // Non-fatal: if re-render fails, SSE clients still get
+                    // the "full" event and will fall back to location.reload().
+                }
+
+                // After the set command completes, notify SSE clients to refresh
+                _version++;
+                SendSseEvent("full", 0, null, null, _version);
+            }
+        }
+        catch
+        {
+            statusCode = 400; statusText = "Bad Request";
+        }
+        var resp = Encoding.UTF8.GetBytes(
+            $"HTTP/1.1 {statusCode} {statusText}\r\nContent-Length: 0\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\n");
+        await stream.WriteAsync(resp, token);
+    }
+
+    /// <summary>
+    /// Handle GET /api/revision/count — query revision count.
+    /// Spawns officecli query with the revision argument, captures output,
+    /// and returns the count as JSON: {"count": N}
+    /// </summary>
+    private async Task HandleRevisionCountAsync(NetworkStream stream, Dictionary<string, string> headers, string bodyPrefix, CancellationToken token)
+    {
+        int statusCode = 200;
+        string statusText = "OK";
+        string jsonBody = "{\"count\":0}";
+        try
+        {
+            var exe = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName
+                ?? (OperatingSystem.IsWindows() ? "officecli.exe" : "officecli");
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = exe,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("query");
+            psi.ArgumentList.Add(_filePath);
+            psi.ArgumentList.Add("revision");
+            using var proc = System.Diagnostics.Process.Start(psi);
+            if (proc != null)
+            {
+                var output = await proc.StandardOutput.ReadToEndAsync(token);
+                await proc.WaitForExitAsync(token);
+                // "officecli query <file> revision" outputs one line per revision.
+                // Count non-empty lines to get the revision count.
+                if (string.IsNullOrWhiteSpace(output))
+                {
+                    jsonBody = "{\"count\":0}";
+                }
+                else
+                {
+                    var lineCount = output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length;
+                    jsonBody = $"{{\"count\":{lineCount}}}";
+                }
+            }
+        }
+        catch
+        {
+            statusCode = 500; statusText = "Internal Server Error";
+            jsonBody = "{\"count\":0,\"error\":\"query failed\"}";
+        }
+        var bodyBytes = Encoding.UTF8.GetBytes(jsonBody);
+        var resp = Encoding.UTF8.GetBytes(
+            $"HTTP/1.1 {statusCode} {statusText}\r\nContent-Type: application/json\r\nContent-Length: {bodyBytes.Length}\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\n");
+        await stream.WriteAsync(resp, token);
+        await stream.WriteAsync(bodyBytes, token);
+    }
+
     private void BroadcastSelectionUpdate(List<string> paths)
     {
         var sb = new StringBuilder();
@@ -2116,10 +2294,65 @@ internal class WatchServer : IDisposable
     private static string InjectSseScript(string html)
     {
         var script = _sseScriptBlock.Value;
+        // Inject revision toolbar (HTML+CSS+JS) alongside the existing SSE scripts.
+        // Only activates for Word documents (detected by "data-block" markers).
+        // The toolbar fetches /api/revision/count, shows Accept All/Reject All buttons.
+        var revisionToolbar = """
+<script>
+(function() {
+    // Only show revision toolbar for Word documents (detected by data-block markers)
+    if (document.body && document.body.innerHTML.indexOf('data-block="1"') < 0) return;
+    var toolbar = document.createElement('div');
+    toolbar.id = 'officecli-revision-toolbar';
+    toolbar.style.cssText = 'position:fixed;top:12px;right:12px;z-index:9999;font-family:system-ui;' +
+        'background:rgba(255,255,255,0.95);border:1px solid #ddd;border-radius:8px;' +
+        'padding:8px 12px;display:none;align-items:center;gap:10px;' +
+        'box-shadow:0 2px 12px rgba(0,0,0,0.12);font-size:13px;transition:opacity .3s;';
+    toolbar.innerHTML = '<span id="officecli-revision-count" style="font-weight:600;color:#444;"></span>' +
+        '<button id="officecli-revision-accept" style="background:#22c55e;color:#fff;border:none;' +
+        'border-radius:5px;padding:5px 12px;cursor:pointer;font-size:12px;font-weight:500;">Accept All</button>' +
+        '<button id="officecli-revision-reject" style="background:#ef4444;color:#fff;border:none;' +
+        'border-radius:5px;padding:5px 12px;cursor:pointer;font-size:12px;font-weight:500;">Reject All</button>';
+    document.body.appendChild(toolbar);
+
+    var countSpan = document.getElementById('officecli-revision-count');
+    var acceptBtn = document.getElementById('officecli-revision-accept');
+    var rejectBtn = document.getElementById('officecli-revision-reject');
+
+    function fetchRevisionCount() {
+        fetch('/api/revision/count').then(function(r){return r.json();}).then(function(data){
+            var c = data && typeof data.count === 'number' ? data.count : 0;
+            countSpan.textContent = c > 0 ? '\u{1F4DD} ' + c + ' revision' + (c === 1 ? '' : 's') : '';
+            toolbar.style.display = c > 0 ? 'flex' : 'none';
+        }).catch(function(){toolbar.style.display='none';});
+    }
+
+    acceptBtn.addEventListener('click', function(){
+        acceptBtn.disabled = true; acceptBtn.textContent = 'Accepting...';
+        rejectBtn.disabled = true;
+        fetch('/api/revision/accept',{method:'POST'}).then(function(){location.reload();})
+        .catch(function(){acceptBtn.disabled=false;acceptBtn.textContent='Accept All';rejectBtn.disabled=false;});
+    });
+
+    rejectBtn.addEventListener('click', function(){
+        rejectBtn.disabled = true; rejectBtn.textContent = 'Rejecting...';
+        acceptBtn.disabled = true;
+        fetch('/api/revision/reject',{method:'POST'}).then(function(){location.reload();})
+        .catch(function(){rejectBtn.disabled=false;rejectBtn.textContent='Reject All';acceptBtn.disabled=false;});
+    });
+
+    fetchRevisionCount();
+    // Re-fetch on any SSE update
+    if (window._watchEs) {
+        window._watchEs.addEventListener('update', fetchRevisionCount);
+    }
+})();
+</script>
+""";
         var idx = html.LastIndexOf("</body>", StringComparison.OrdinalIgnoreCase);
         if (idx >= 0)
-            return html[..idx] + script + html[idx..];
-        return html + script;
+            return html[..idx] + script + revisionToolbar + html[idx..];
+        return html + script + revisionToolbar;
     }
 
     public void Dispose()

--- a/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Css.cs
+++ b/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Css.cs
@@ -2573,6 +2573,11 @@ public partial class WordHandler
         th, td {{ border: none; padding: 0 5.4pt; text-align: inherit; vertical-align: top; break-inside: auto; }}
         tr {{ break-inside: auto; }}
         th {{ font-weight: 600; }}
+        .track-format {{ background: #FFF9C4; border-left: 4px solid #FFC107; }}
+        .track-move {{ text-decoration: underline double; color: #2E7D32; }}
+        .track-movefrom {{ text-decoration: line-through double; color: #2E7D32; }}
+        .track-ins-row {{ background: #E8F5E9; }}
+        .track-del-row {{ background: #FFEBEE; text-decoration: line-through; color: #C62828; }}
         @media print {{ body {{ background: white; padding: 0; }}
             .page {{ box-shadow: none; margin: 0; max-width: none; transform: none !important; }}
             hr.page-break {{ page-break-after: always; border: none; margin: 0; }} }}";

--- a/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Tables.cs
+++ b/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Tables.cs
@@ -147,12 +147,25 @@ public partial class WordHandler
         }
 
         var tableClass = tableBordersNone ? "borderless" : "";
+
+        // Tracked table format change (tblPrChange) — yellow highlight with author attribution
+        var tblPrChange = tblPr?.GetFirstChild<TablePropertiesChange>();
+        var tblFmtAuthorAttr = "";
+        if (tblPrChange != null)
+        {
+            tableClass = string.IsNullOrEmpty(tableClass) ? "track-format" : tableClass + " track-format";
+            tableStyles.Add("background:#FFF9C4;border-left:4px solid #FFC107");
+            var tblAuthor = tblPrChange.Author?.Value ?? "";
+            if (!string.IsNullOrEmpty(tblAuthor))
+                tblFmtAuthorAttr = $" title=\"Format changed by {HtmlEncodeAttr(tblAuthor)}\"";
+        }
+
         var tableStyleAttr = tableStyles.Count > 0 ? $" style=\"{string.Join(";", tableStyles)}\"" : "";
         var dataPathAttr = !string.IsNullOrEmpty(dataPath) ? $" data-path=\"{dataPath}\"" : "";
         if (!string.IsNullOrEmpty(tableClass))
-            sb.AppendLine($"<table class=\"{tableClass}\"{dataPathAttr}{tableStyleAttr}>");
+            sb.AppendLine($"<table class=\"{tableClass}\"{dataPathAttr}{tblFmtAuthorAttr}{tableStyleAttr}>");
         else
-            sb.AppendLine($"<table{dataPathAttr}{tableStyleAttr}>");
+            sb.AppendLine($"<table{dataPathAttr}{tblFmtAuthorAttr}{tableStyleAttr}>");
 
         // Get column widths from grid
         // tblLayout=fixed → use fixed col widths; auto/missing → let browser auto-fit by content
@@ -198,7 +211,51 @@ public partial class WordHandler
             sb.AppendLine("</colgroup>");
         }
 
-        var rows = table.Elements<TableRow>().ToList();
+        var rows = new List<TableRow>();
+        var revisionRowFlags = new Dictionary<TableRow, (string? revisionType, string? author)>();
+        foreach (var child in table.ChildElements)
+        {
+            if (child is TableRow tr)
+            {
+                rows.Add(tr);
+            }
+            else if (child.LocalName is "ins" or "del" or "moveTo" or "moveFrom")
+            {
+                var revType = child.LocalName;
+                var revAuthor = child.GetAttributes().FirstOrDefault(a => a.LocalName == "author").Value;
+                // SDK may parse <w:tr> inside revision wrappers as OpenXmlUnknownElement
+                // rather than strong-typed TableRow. Try Descendants<TableRow> first,
+                // then fall back to manual reconstruction from raw XML.
+                var nestedRows = child.Descendants<TableRow>().ToList();
+                if (nestedRows.Count > 0)
+                {
+                    foreach (var nestedRow in nestedRows)
+                    {
+                        if (!rows.Contains(nestedRow))
+                        {
+                            rows.Add(nestedRow);
+                            revisionRowFlags[nestedRow] = (revType, revAuthor);
+                        }
+                    }
+                }
+                else
+                {
+                    // Fallback: find <w:tr> children parsed as OpenXmlUnknownElement
+                    // and reconstruct them as TableRow via Clone().outerxml
+                    foreach (var maybeRow in child.Elements())
+                    {
+                        if (maybeRow.LocalName == "tr")
+                        {
+                            // Re-parse the outer XML as a TableRow so the rendering
+                            // code (which expects strong-typed properties) works.
+                            var reconstructed = new TableRow(maybeRow.OuterXml);
+                            rows.Add(reconstructed);
+                            revisionRowFlags[reconstructed] = (revType, revAuthor);
+                        }
+                    }
+                }
+            }
+        }
         var totalRows = rows.Count;
         var totalCols = tblGrid?.Elements<GridColumn>().Count() ?? rows.FirstOrDefault()?.Elements<TableCell>().Count() ?? 0;
 
@@ -229,7 +286,32 @@ public partial class WordHandler
             // have a stable /body/table[N] index.
             var rowDataPath = !string.IsNullOrEmpty(dataPath) ? $"{dataPath}/tr[{rowIdx + 1}]" : null;
             var rowDataPathAttr = rowDataPath != null ? $" data-path=\"{rowDataPath}\"" : "";
-            sb.AppendLine(isHeader ? $"<tr class=\"header-row\"{hdrMarker}{rowDataPathAttr}{trStyle}>" : $"<tr{rowDataPathAttr}{trStyle}>");
+            // Tracked row revision (wrapped in ins/del/moveTo/moveFrom) — visual marker
+            var rowRevAttr = "";
+            var rowRevSuffix = "";
+            if (revisionRowFlags.TryGetValue(row, out var revInfo))
+            {
+                var (revType, revAuthor) = revInfo;
+                if (revType == "ins" || revType == "moveTo")
+                {
+                    rowRevAttr = string.IsNullOrEmpty(revAuthor)
+                        ? " title=\"Inserted row\""
+                        : $" title=\"Inserted row by {HtmlEncodeAttr(revAuthor)}\"";
+                    rowRevSuffix = " track-ins-row";
+                }
+                else // del or moveFrom
+                {
+                    rowRevAttr = string.IsNullOrEmpty(revAuthor)
+                        ? " title=\"Deleted row\""
+                        : $" title=\"Deleted row by {HtmlEncodeAttr(revAuthor)}\"";
+                    rowRevSuffix = " track-del-row";
+                }
+            }
+            sb.AppendLine(isHeader
+                ? $"<tr class=\"header-row{rowRevSuffix}\"{hdrMarker}{rowRevAttr}{rowDataPathAttr}{trStyle}>"
+                : string.IsNullOrEmpty(rowRevSuffix)
+                    ? $"<tr{rowRevAttr}{rowDataPathAttr}{trStyle}>"
+                    : $"<tr class=\"{rowRevSuffix.Trim()}\"{rowRevAttr}{rowDataPathAttr}{trStyle}>");
 
             int colIdx = 0;
             foreach (var cell in row.Elements<TableCell>())
@@ -546,9 +628,49 @@ public partial class WordHandler
         return null;
     }
 
+    /// <summary>
+    /// Get all TableRow elements from a table, including those nested inside
+    /// revision wrappers (w:ins, w:del, w:moveTo, w:moveFrom).
+    /// Handles SDK quirk where rows inside revision wrappers may be parsed
+    /// as OpenXmlUnknownElement rather than strong-typed TableRow.
+    /// </summary>
+    private static List<TableRow> GetFlattenedTableRows(Table table)
+    {
+        var rows = new List<TableRow>();
+        foreach (var child in table.ChildElements)
+        {
+            if (child is TableRow tr)
+            {
+                rows.Add(tr);
+            }
+            else if (child.LocalName is "ins" or "del" or "moveTo" or "moveFrom")
+            {
+                var nested = child.Descendants<TableRow>().ToList();
+                if (nested.Count > 0)
+                {
+                    foreach (var r in nested)
+                        if (!rows.Contains(r)) rows.Add(r);
+                }
+                else
+                {
+                    foreach (var maybeRow in child.Elements())
+                    {
+                        if (maybeRow.LocalName == "tr")
+                        {
+                            var reconstructed = new TableRow(maybeRow.OuterXml);
+                            if (!rows.Contains(reconstructed))
+                                rows.Add(reconstructed);
+                        }
+                    }
+                }
+            }
+        }
+        return rows;
+    }
+
     private static int CountRowSpan(Table table, TableRow startRow, TableCell startCell)
     {
-        var rows = table.Elements<TableRow>().ToList();
+        var rows = GetFlattenedTableRows(table);
         var startRowIdx = rows.IndexOf(startRow);
         if (startRowIdx < 0) return 1;
 

--- a/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Text.cs
@@ -46,7 +46,22 @@ public partial class WordHandler
             classes.Add("has-ptab");
         if (classes.Count > 0)
             sb.Append($" class=\"{string.Join(" ", classes)}\"");
+
+        // Tracked paragraph format change (pPrChange) — yellow left border with author attribution
+        var pPrChange = para.ParagraphProperties?.GetFirstChild<ParagraphPropertiesChange>();
+        if (pPrChange != null)
+        {
+            var pAuthor = pPrChange.Author?.Value ?? "";
+            if (!string.IsNullOrEmpty(pAuthor))
+                sb.Append($" title=\"Format changed by {HtmlEncodeAttr(pAuthor)}\"");
+        }
+
         var pStyle = GetParagraphInlineCss(para);
+        if (pPrChange != null)
+        {
+            var fmtStyle = "background:#FFF9C4;border-left:4px solid #FFC107";
+            pStyle = string.IsNullOrEmpty(pStyle) ? fmtStyle : pStyle + ";" + fmtStyle;
+        }
         if (!string.IsNullOrEmpty(pStyle))
             sb.Append($" style=\"{pStyle}\"");
         sb.Append(">");
@@ -106,7 +121,7 @@ public partial class WordHandler
 
                 RenderRunHtml(sb, run, para);
             }
-            else if (child.LocalName is "ins" or "moveTo")
+            else if (child.LocalName is "ins")
             {
                 // Tracked insertions — underline to match Word's default revision mark style
                 var author = child.GetAttributes().FirstOrDefault(a => a.LocalName == "author").Value;
@@ -128,7 +143,17 @@ public partial class WordHandler
                     sb.Append($"<span class=\"track-del\" style=\"text-decoration:line-through;color:#C62828\">{HtmlEncode(nestedDelText)}</span>");
                 sb.Append("</span>");
             }
-            else if (child.LocalName is "del" or "moveFrom")
+            else if (child.LocalName is "moveTo")
+            {
+                // Tracked move target — double underline in green to distinguish from insertion
+                var author = child.GetAttributes().FirstOrDefault(a => a.LocalName == "author").Value;
+                var authorAttr = string.IsNullOrEmpty(author) ? "" : $" title=\"Moved to by {HtmlEncodeAttr(author)}\"";
+                sb.Append($"<span class=\"track-move\" style=\"text-decoration:underline double;color:#2E7D32\"{authorAttr}>");
+                foreach (var moveToRun in child.Descendants<Run>())
+                    RenderRunHtml(sb, moveToRun, para);
+                sb.Append("</span>");
+            }
+            else if (child.LocalName is "del")
             {
                 // Tracked deletions — strikethrough with color, preserving the deleted text
                 // The delText inside del runs carries the actual deleted content; we render it so
@@ -140,6 +165,17 @@ public partial class WordHandler
                     .Select(e => e.InnerText));
                 if (!string.IsNullOrEmpty(delText))
                     sb.Append($"<span class=\"track-del\" style=\"text-decoration:line-through;color:#C62828\"{authorAttr}>{HtmlEncode(delText)}</span>");
+            }
+            else if (child.LocalName is "moveFrom")
+            {
+                // Tracked move source — double strikethrough in green to distinguish from deletion
+                var author = child.GetAttributes().FirstOrDefault(a => a.LocalName == "author").Value;
+                var authorAttr = string.IsNullOrEmpty(author) ? "" : $" title=\"Moved from by {HtmlEncodeAttr(author)}\"";
+                var moveFromText = string.Concat(child.Descendants()
+                    .Where(e => e.LocalName == "delText" || e.LocalName == "t")
+                    .Select(e => e.InnerText));
+                if (!string.IsNullOrEmpty(moveFromText))
+                    sb.Append($"<span class=\"track-movefrom\" style=\"text-decoration:line-through double;color:#2E7D32\"{authorAttr}>{HtmlEncode(moveFromText)}</span>");
             }
             else if (child is Hyperlink hyperlink)
             {
@@ -303,6 +339,17 @@ public partial class WordHandler
             return;
         if (rProps.SpecVanish != null && (rProps.SpecVanish.Val == null || rProps.SpecVanish.Val.Value))
             return;
+
+        // Tracked format change (rPrChange) — yellow highlight with author attribution
+        var rPrChange = run.RunProperties?.GetFirstChild<RunPropertiesChange>();
+        bool hasRPrChange = rPrChange != null;
+        if (hasRPrChange)
+        {
+            var author = rPrChange!.Author?.Value ?? "";
+            var authorAttr = string.IsNullOrEmpty(author) ? "" : $" title=\"Format changed by {HtmlEncodeAttr(author)}\"";
+            sb.Append($"<span class=\"track-format\" style=\"background:#FFF9C4;border-bottom:2px solid #FFC107\"{authorAttr}>");
+        }
+
         var style = GetRunInlineCss(rProps, para);
         var needsSpan = !string.IsNullOrEmpty(style);
 
@@ -469,6 +516,8 @@ public partial class WordHandler
         }
 
         if (needsSpan && !_ctx.LineBreakEnabled)
+            sb.Append("</span>");
+        if (hasRPrChange)
             sb.Append("</span>");
     }
 

--- a/src/officecli/Handlers/Word/WordHandler.HtmlPreview.cs
+++ b/src/officecli/Handlers/Word/WordHandler.HtmlPreview.cs
@@ -1969,7 +1969,17 @@ public partial class WordHandler
                     // BuildListMarkerCss so this <li> picks up the abstractNum
                     // level rPr (color/font/size/bold/italic) for ul, plus
                     // a custom list-style-type string when applicable.
-                    sb.Append($" class=\"marker-{numId}-{ilvlOoxml}\"");
+                    var liClasses = $"marker-{numId}-{ilvlOoxml}";
+                    // Tracked paragraph format change (pPrChange) — yellow left border
+                    var listPprChange = para.ParagraphProperties?.GetFirstChild<ParagraphPropertiesChange>();
+                    if (listPprChange != null)
+                    {
+                        liClasses += " track-format";
+                        var listPprAuthor = listPprChange.Author?.Value ?? "";
+                        if (!string.IsNullOrEmpty(listPprAuthor))
+                            sb.Append($" title=\"Format changed by {HtmlEncodeAttr(listPprAuthor)}\"");
+                    }
+                    sb.Append($" class=\"{liClasses}\"");
                     var paraStyle = GetParagraphInlineCss(para, isListItem: true);
                     // ul markers render via ::marker pseudo, which sits outside
                     // the line box and can't inflate it. ol markers render via
@@ -2064,6 +2074,16 @@ public partial class WordHandler
                     var pStyleId = para.ParagraphProperties?.ParagraphStyleId?.Val?.Value;
                     if (ResolveStyleBold(pStyleId) != true)
                         hStyle = string.IsNullOrEmpty(hStyle) ? "font-weight:normal" : $"{hStyle};font-weight:normal";
+                    // Tracked paragraph format change (pPrChange) — yellow left border
+                    var headPprChange = para.ParagraphProperties?.GetFirstChild<ParagraphPropertiesChange>();
+                    if (headPprChange != null)
+                    {
+                        var fmtStyle = "background:#FFF9C4;border-left:4px solid #FFC107";
+                        hStyle = string.IsNullOrEmpty(hStyle) ? fmtStyle : hStyle + ";" + fmtStyle;
+                        var headPprAuthor = headPprChange.Author?.Value ?? "";
+                        if (!string.IsNullOrEmpty(headPprAuthor))
+                            sb.Append($" title=\"Format changed by {HtmlEncodeAttr(headPprAuthor)}\"");
+                    }
                     if (!string.IsNullOrEmpty(hStyle))
                         sb.Append($" style=\"{hStyle}\"");
                     sb.Append(">");
@@ -2156,6 +2176,16 @@ public partial class WordHandler
                     if (classNames.Count > 0)
                         sb.Append($" class=\"{string.Join(" ", classNames)}\"");
                     var pStyle = GetParagraphInlineCss(para);
+                    // Tracked paragraph format change (pPrChange) — yellow left border
+                    var bodyPprChange = para.ParagraphProperties?.GetFirstChild<ParagraphPropertiesChange>();
+                    if (bodyPprChange != null)
+                    {
+                        var fmtStyle = "background:#FFF9C4;border-left:4px solid #FFC107";
+                        pStyle = string.IsNullOrEmpty(pStyle) ? fmtStyle : pStyle + ";" + fmtStyle;
+                        var bodyPprAuthor = bodyPprChange.Author?.Value ?? "";
+                        if (!string.IsNullOrEmpty(bodyPprAuthor))
+                            sb.Append($" title=\"Format changed by {HtmlEncodeAttr(bodyPprAuthor)}\"");
+                    }
                     if (!string.IsNullOrEmpty(pStyle))
                         sb.Append($" style=\"{pStyle}\"");
                     sb.Append(">");


### PR DESCRIPTION
     1|## Summary
     2|
     3|Complete Track Changes rendering in HTML preview and Watch mode, with revision accept/reject API.
     4|
     5|## Changes
     6|
     7|### HTML Preview Rendering (4 revision types)
     8|
     9|| Type | Visual | Selector |
    10||------|--------|----------|
    11|| Insertion (w:ins) | Green underline | `span.track-ins` |
    12|| Deletion (w:del) | Red strikethrough | `span.track-del` |
    13|| Move target (w:moveTo) | Green double underline | `span.track-move` |
    14|| Move source (w:moveFrom) | Green double strikethrough | `span.track-movefrom` |
    15|
    16|### Paragraph Format Change (pPrChange)
    17|
    18|**Root cause**: `RenderBodyHtml` (body paragraphs) did NOT call `RenderParagraphHtml` — it had its own inline rendering that skipped pPrChange detection entirely. Only header/footer rendering went through `RenderParagraphHtml`.
    19|
    20|**Fix**: Added pPrChange detection in all three body rendering paths (normal paragraph, heading, list item), with author tooltip.
    21|
    22|### Run Format Change (rPrChange)
    23|
    24|Yellow highlight with bottom border on run-level format changes.
    25|
    26|### Table Revisions
    27|
    28|- `tblPrChange`: yellow background + left border on table
    29|- Row-level ins/del: `track-ins-row` / `track-del-row` CSS classes
    30|- **SDK quirk**: `<w:tr>` inside `<w:ins>` is parsed as `OpenXmlUnknownElement` not `TableRow`. Fallback: `new TableRow(maybeRow.OuterXml)` reconstruction.
    31|
    32|### Watch Revision API
    33|
    34|| Endpoint | Method | Description |
    35||----------|--------|-------------|
    36|| `/api/revision/count` | GET | Returns `{"count": N}` |
    37|| `/api/revision/accept` | POST | Accept all tracked changes |
    38|| `/api/revision/reject` | POST | Reject all tracked changes |
    39|
    40|After accept/reject, the cached HTML is re-rendered via `officecli view html` before sending SSE refresh — preventing stale-diff rollback.
    41|
    42|### Watch Revision Toolbar
    43|
    44|Injected floating toolbar (top-right) with Accept All / Reject All buttons and revision count badge. Auto-hides when 0 revisions.
    45|
    46|## Screenshots
    47|
    48|### view html — Insertion (green underline) + Deletion (red strikethrough) + Format change (yellow background)
    49|
    51|
    52|### Watch — Revision toolbar + tracked changes rendering
    53|
    55|
    56|## Files Changed
    57|
    58|| File | Delta | Description |
    59||------|-------|-------------|
    60|| `WatchServer.cs` | +237 | Revision API + cache refresh + toolbar JS |
    61|| `HtmlPreview.Css.cs` | +5 | track-move/movefrom/ins-row/del-row CSS |
    62|| `HtmlPreview.Tables.cs` | +132 | Table row revisions + tblPrChange + SDK fallback |
    63|| `HtmlPreview.Text.cs` | +53 | pPrChange + moveTo/moveFrom split + rPrChange |
    64|| `HtmlHandler.HtmlPreview.cs` | +32 | Body/heading/list pPrChange + author tooltip |
    65|| `.gitignore` | +6 | bin/, obj/, temp files |
    66|
    67|## Test Plan
    68|
    69|- [x] `view html` renders ins/del/pPrChange/rPrChange/tblPrChange correctly
    70|- [x] Watch renders all revision types with visual markers
    71|- [x] Accept All: revisions cleared, insertions kept, deletions removed
    72|- [x] Reject All: revisions cleared, insertions removed, deletions restored
    73|- [x] Revision count API returns correct count
    74|- [x] Toolbar auto-hides when 0 revisions
    75|- [x] No debug artifacts (no data-pprchange, no Console.WriteLine)
    76|- [x] Build: 0 errors
    77|