### PR TITLE
feat(preview+watch): render all revision types in HTML and add accept/reject toolbar

### DIFF
--- a/src/officecli/Core/Watch/WatchServer.cs
+++ b/src/officecli/Core/Watch/WatchServer.cs
@@ -1726,6 +1726,27 @@ internal class WatchServer : IDisposable
                 return;
             }
 
+            if (requestLine.StartsWith("POST /api/revision/accept", StringComparison.Ordinal))
+            {
+                await HandleRevisionAcceptAsync(stream, headers, bodyPrefix, token);
+                client.Close();
+                return;
+            }
+
+            if (requestLine.StartsWith("POST /api/revision/reject", StringComparison.Ordinal))
+            {
+                await HandleRevisionRejectAsync(stream, headers, bodyPrefix, token);
+                client.Close();
+                return;
+            }
+
+            if (requestLine.StartsWith("GET /api/revision/count", StringComparison.Ordinal))
+            {
+                await HandleRevisionCountAsync(stream, headers, bodyPrefix, token);
+                client.Close();
+                return;
+            }
+
             // BUG-TESTER-R503: GET/PUT/etc on /api/selection must return 405,
             // not fall through to the HTML preview. Without this, an API
             // client that uses the wrong verb gets back a 200 HTML page and
@@ -2012,6 +2033,127 @@ internal class WatchServer : IDisposable
         await stream.WriteAsync(resp, token);
     }
 
+    /// <summary>
+    /// Handle POST /api/revision/accept — accept all tracked changes.
+    /// Spawns officecli set with acceptallchanges=all, waits for completion,
+    /// then signals SSE clients with a "full" refresh.
+    /// </summary>
+    private async Task HandleRevisionAcceptAsync(NetworkStream stream, Dictionary<string, string> headers, string bodyPrefix, CancellationToken token)
+    {
+        await RunRevisionActionAsync(stream, "acceptallchanges=all", token);
+    }
+
+    /// <summary>
+    /// Handle POST /api/revision/reject — reject all tracked changes.
+    /// Spawns officecli set with rejectallchanges=all, waits for completion,
+    /// then signals SSE clients with a "full" refresh.
+    /// </summary>
+    private async Task HandleRevisionRejectAsync(NetworkStream stream, Dictionary<string, string> headers, string bodyPrefix, CancellationToken token)
+    {
+        await RunRevisionActionAsync(stream, "rejectallchanges=all", token);
+    }
+
+    /// <summary>
+    /// Common helper for revision accept/reject actions.
+    /// Spawns officecli set with the given prop, returns 204 on success.
+    /// After the command completes, sends a "full" SSE event to trigger
+    /// a page refresh on all connected browsers.
+    /// </summary>
+    private async Task RunRevisionActionAsync(NetworkStream stream, string propArg, CancellationToken token)
+    {
+        int statusCode = 204;
+        string statusText = "No Content";
+        try
+        {
+            var exe = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName
+                ?? (OperatingSystem.IsWindows() ? "officecli.exe" : "officecli");
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = exe,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("set");
+            psi.ArgumentList.Add(_filePath);
+            psi.ArgumentList.Add("/");
+            psi.ArgumentList.Add("--prop");
+            psi.ArgumentList.Add(propArg);
+            using var proc = System.Diagnostics.Process.Start(psi);
+            if (proc != null)
+            {
+                await proc.WaitForExitAsync(token);
+                // After the set command completes, notify SSE clients to refresh
+                _version++;
+                SendSseEvent("full", 0, null, null, _version);
+            }
+        }
+        catch
+        {
+            statusCode = 400; statusText = "Bad Request";
+        }
+        var resp = Encoding.UTF8.GetBytes(
+            $"HTTP/1.1 {statusCode} {statusText}\r\nContent-Length: 0\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\n");
+        await stream.WriteAsync(resp, token);
+    }
+
+    /// <summary>
+    /// Handle GET /api/revision/count — query revision count.
+    /// Spawns officecli query with the revision argument, captures output,
+    /// and returns the count as JSON: {"count": N}
+    /// </summary>
+    private async Task HandleRevisionCountAsync(NetworkStream stream, Dictionary<string, string> headers, string bodyPrefix, CancellationToken token)
+    {
+        int statusCode = 200;
+        string statusText = "OK";
+        string jsonBody = "{\"count\":0}";
+        try
+        {
+            var exe = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName
+                ?? (OperatingSystem.IsWindows() ? "officecli.exe" : "officecli");
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = exe,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("query");
+            psi.ArgumentList.Add(_filePath);
+            psi.ArgumentList.Add("revision");
+            using var proc = System.Diagnostics.Process.Start(psi);
+            if (proc != null)
+            {
+                var output = await proc.StandardOutput.ReadToEndAsync(token);
+                await proc.WaitForExitAsync(token);
+                proc.Close();
+                // "officecli query <file> revision" outputs one line per revision.
+                // Count non-empty lines to get the revision count.
+                if (string.IsNullOrWhiteSpace(output))
+                {
+                    jsonBody = "{\"count\":0}";
+                }
+                else
+                {
+                    var lineCount = output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length;
+                    jsonBody = $"{{\"count\":{lineCount}}}";
+                }
+            }
+        }
+        catch
+        {
+            statusCode = 500; statusText = "Internal Server Error";
+            jsonBody = "{\"count\":0,\"error\":\"query failed\"}";
+        }
+        var bodyBytes = Encoding.UTF8.GetBytes(jsonBody);
+        var resp = Encoding.UTF8.GetBytes(
+            $"HTTP/1.1 {statusCode} {statusText}\r\nContent-Type: application/json\r\nContent-Length: {bodyBytes.Length}\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\n");
+        await stream.WriteAsync(resp, token);
+        await stream.WriteAsync(bodyBytes, token);
+    }
+
     private void BroadcastSelectionUpdate(List<string> paths)
     {
         var sb = new StringBuilder();
@@ -2116,10 +2258,65 @@ internal class WatchServer : IDisposable
     private static string InjectSseScript(string html)
     {
         var script = _sseScriptBlock.Value;
+        // Inject revision toolbar (HTML+CSS+JS) alongside the existing SSE scripts.
+        // Only activates for Word documents (detected by "data-block" markers).
+        // The toolbar fetches /api/revision/count, shows Accept All/Reject All buttons.
+        var revisionToolbar = """
+<script>
+(function() {
+    // Only show revision toolbar for Word documents (detected by data-block markers)
+    if (document.body && document.body.innerHTML.indexOf('data-block="1"') < 0) return;
+    var toolbar = document.createElement('div');
+    toolbar.id = 'officecli-revision-toolbar';
+    toolbar.style.cssText = 'position:fixed;top:12px;right:12px;z-index:9999;font-family:system-ui;' +
+        'background:rgba(255,255,255,0.95);border:1px solid #ddd;border-radius:8px;' +
+        'padding:8px 12px;display:none;align-items:center;gap:10px;' +
+        'box-shadow:0 2px 12px rgba(0,0,0,0.12);font-size:13px;transition:opacity .3s;';
+    toolbar.innerHTML = '<span id="officecli-revision-count" style="font-weight:600;color:#444;"></span>' +
+        '<button id="officecli-revision-accept" style="background:#22c55e;color:#fff;border:none;' +
+        'border-radius:5px;padding:5px 12px;cursor:pointer;font-size:12px;font-weight:500;">Accept All</button>' +
+        '<button id="officecli-revision-reject" style="background:#ef4444;color:#fff;border:none;' +
+        'border-radius:5px;padding:5px 12px;cursor:pointer;font-size:12px;font-weight:500;">Reject All</button>';
+    document.body.appendChild(toolbar);
+
+    var countSpan = document.getElementById('officecli-revision-count');
+    var acceptBtn = document.getElementById('officecli-revision-accept');
+    var rejectBtn = document.getElementById('officecli-revision-reject');
+
+    function fetchRevisionCount() {
+        fetch('/api/revision/count').then(function(r){return r.json();}).then(function(data){
+            var c = data && typeof data.count === 'number' ? data.count : 0;
+            countSpan.textContent = c > 0 ? '\u{1F4DD} ' + c + ' revision' + (c === 1 ? '' : 's') : '';
+            toolbar.style.display = c > 0 ? 'flex' : 'none';
+        }).catch(function(){toolbar.style.display='none';});
+    }
+
+    acceptBtn.addEventListener('click', function(){
+        acceptBtn.disabled = true; acceptBtn.textContent = 'Accepting...';
+        rejectBtn.disabled = true;
+        fetch('/api/revision/accept',{method:'POST'}).then(function(){location.reload();})
+        .catch(function(){acceptBtn.disabled=false;acceptBtn.textContent='Accept All';rejectBtn.disabled=false;});
+    });
+
+    rejectBtn.addEventListener('click', function(){
+        rejectBtn.disabled = true; rejectBtn.textContent = 'Rejecting...';
+        acceptBtn.disabled = true;
+        fetch('/api/revision/reject',{method:'POST'}).then(function(){location.reload();})
+        .catch(function(){rejectBtn.disabled=false;rejectBtn.textContent='Reject All';acceptBtn.disabled=false;});
+    });
+
+    fetchRevisionCount();
+    // Re-fetch on any SSE update
+    if (window._watchEs) {
+        window._watchEs.addEventListener('update', fetchRevisionCount);
+    }
+})();
+</script>
+""";
         var idx = html.LastIndexOf("</body>", StringComparison.OrdinalIgnoreCase);
         if (idx >= 0)
-            return html[..idx] + script + html[idx..];
-        return html + script;
+            return html[..idx] + script + revisionToolbar + html[idx..];
+        return html + script + revisionToolbar;
     }
 
     public void Dispose()

--- a/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Css.cs
+++ b/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Css.cs
@@ -2573,6 +2573,9 @@ public partial class WordHandler
         th, td {{ border: none; padding: 0 5.4pt; text-align: inherit; vertical-align: top; break-inside: auto; }}
         tr {{ break-inside: auto; }}
         th {{ font-weight: 600; }}
+        .track-format {{ background: #FFF9C4; border-left: 4px solid #FFC107; }}
+        .track-ins-row {{ background: #E8F5E9; }}
+        .track-del-row {{ background: #FFEBEE; text-decoration: line-through; color: #C62828; }}
         @media print {{ body {{ background: white; padding: 0; }}
             .page {{ box-shadow: none; margin: 0; max-width: none; transform: none !important; }}
             hr.page-break {{ page-break-after: always; border: none; margin: 0; }} }}";

--- a/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Tables.cs
+++ b/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Tables.cs
@@ -147,12 +147,25 @@ public partial class WordHandler
         }
 
         var tableClass = tableBordersNone ? "borderless" : "";
+
+        // Tracked table format change (tblPrChange) — yellow highlight with author attribution
+        var tblPrChange = tblPr?.GetFirstChild<TablePropertiesChange>();
+        var tblFmtAuthorAttr = "";
+        if (tblPrChange != null)
+        {
+            tableClass = string.IsNullOrEmpty(tableClass) ? "track-format" : tableClass + " track-format";
+            tableStyles.Add("background:#FFF9C4;border-left:4px solid #FFC107");
+            var tblAuthor = tblPrChange.Author?.Value ?? "";
+            if (!string.IsNullOrEmpty(tblAuthor))
+                tblFmtAuthorAttr = $" title=\"Format changed by {HtmlEncodeAttr(tblAuthor)}\"";
+        }
+
         var tableStyleAttr = tableStyles.Count > 0 ? $" style=\"{string.Join(";", tableStyles)}\"" : "";
         var dataPathAttr = !string.IsNullOrEmpty(dataPath) ? $" data-path=\"{dataPath}\"" : "";
         if (!string.IsNullOrEmpty(tableClass))
-            sb.AppendLine($"<table class=\"{tableClass}\"{dataPathAttr}{tableStyleAttr}>");
+            sb.AppendLine($"<table class=\"{tableClass}\"{dataPathAttr}{tblFmtAuthorAttr}{tableStyleAttr}>");
         else
-            sb.AppendLine($"<table{dataPathAttr}{tableStyleAttr}>");
+            sb.AppendLine($"<table{dataPathAttr}{tblFmtAuthorAttr}{tableStyleAttr}>");
 
         // Get column widths from grid
         // tblLayout=fixed → use fixed col widths; auto/missing → let browser auto-fit by content
@@ -199,6 +212,24 @@ public partial class WordHandler
         }
 
         var rows = table.Elements<TableRow>().ToList();
+        // Also collect rows from revision wrappers (ins/del/moveTo/moveFrom)
+        var revisionRowFlags = new Dictionary<TableRow, (string? revisionType, string? author)>();
+        foreach (var child in table.ChildElements)
+        {
+            if (child.LocalName is "ins" or "del" or "moveTo" or "moveFrom")
+            {
+                var revType = child.LocalName;
+                var revAuthor = child.GetAttributes().FirstOrDefault(a => a.LocalName == "author").Value;
+                foreach (var nestedRow in child.Descendants<TableRow>())
+                {
+                    if (!rows.Contains(nestedRow))
+                    {
+                        rows.Add(nestedRow);
+                        revisionRowFlags[nestedRow] = (revType, revAuthor);
+                    }
+                }
+            }
+        }
         var totalRows = rows.Count;
         var totalCols = tblGrid?.Elements<GridColumn>().Count() ?? rows.FirstOrDefault()?.Elements<TableCell>().Count() ?? 0;
 
@@ -229,7 +260,32 @@ public partial class WordHandler
             // have a stable /body/table[N] index.
             var rowDataPath = !string.IsNullOrEmpty(dataPath) ? $"{dataPath}/tr[{rowIdx + 1}]" : null;
             var rowDataPathAttr = rowDataPath != null ? $" data-path=\"{rowDataPath}\"" : "";
-            sb.AppendLine(isHeader ? $"<tr class=\"header-row\"{hdrMarker}{rowDataPathAttr}{trStyle}>" : $"<tr{rowDataPathAttr}{trStyle}>");
+            // Tracked row revision (wrapped in ins/del/moveTo/moveFrom) — visual marker
+            var rowRevAttr = "";
+            var rowRevSuffix = "";
+            if (revisionRowFlags.TryGetValue(row, out var revInfo))
+            {
+                var (revType, revAuthor) = revInfo;
+                if (revType == "ins" || revType == "moveTo")
+                {
+                    rowRevAttr = string.IsNullOrEmpty(revAuthor)
+                        ? " title=\"Inserted row\""
+                        : $" title=\"Inserted row by {HtmlEncodeAttr(revAuthor)}\"";
+                    rowRevSuffix = " track-ins-row";
+                }
+                else // del or moveFrom
+                {
+                    rowRevAttr = string.IsNullOrEmpty(revAuthor)
+                        ? " title=\"Deleted row\""
+                        : $" title=\"Deleted row by {HtmlEncodeAttr(revAuthor)}\"";
+                    rowRevSuffix = " track-del-row";
+                }
+            }
+            sb.AppendLine(isHeader
+                ? $"<tr class=\"header-row{rowRevSuffix}\"{hdrMarker}{rowRevAttr}{rowDataPathAttr}{trStyle}>"
+                : string.IsNullOrEmpty(rowRevSuffix)
+                    ? $"<tr{rowRevAttr}{rowDataPathAttr}{trStyle}>"
+                    : $"<tr class=\"{rowRevSuffix.Trim()}\"{rowRevAttr}{rowDataPathAttr}{trStyle}>");
 
             int colIdx = 0;
             foreach (var cell in row.Elements<TableCell>())
@@ -546,9 +602,30 @@ public partial class WordHandler
         return null;
     }
 
-    private static int CountRowSpan(Table table, TableRow startRow, TableCell startCell)
+    /// <summary>
+    /// Get all TableRow elements from a table, including those nested inside
+    /// revision wrappers (w:ins, w:del, w:moveTo, w:moveFrom).
+    /// </summary>
+    private static List<TableRow> GetFlattenedTableRows(Table table)
     {
         var rows = table.Elements<TableRow>().ToList();
+        foreach (var child in table.ChildElements)
+        {
+            if (child.LocalName is "ins" or "del" or "moveTo" or "moveFrom")
+            {
+                foreach (var nestedRow in child.Descendants<TableRow>())
+                {
+                    if (!rows.Contains(nestedRow))
+                        rows.Add(nestedRow);
+                }
+            }
+        }
+        return rows;
+    }
+
+    private static int CountRowSpan(Table table, TableRow startRow, TableCell startCell)
+    {
+        var rows = GetFlattenedTableRows(table);
         var startRowIdx = rows.IndexOf(startRow);
         if (startRowIdx < 0) return 1;
 

--- a/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Text.cs
@@ -46,7 +46,22 @@ public partial class WordHandler
             classes.Add("has-ptab");
         if (classes.Count > 0)
             sb.Append($" class=\"{string.Join(" ", classes)}\"");
+
+        // Tracked paragraph format change (pPrChange) — yellow left border with author attribution
+        var pPrChange = para.ParagraphProperties?.GetFirstChild<ParagraphPropertiesChange>();
+        if (pPrChange != null)
+        {
+            var pAuthor = pPrChange.Author?.Value ?? "";
+            if (!string.IsNullOrEmpty(pAuthor))
+                sb.Append($" title=\"Format changed by {HtmlEncodeAttr(pAuthor)}\"");
+        }
+
         var pStyle = GetParagraphInlineCss(para);
+        if (pPrChange != null)
+        {
+            var fmtStyle = "background:#FFF9C4;border-left:4px solid #FFC107";
+            pStyle = string.IsNullOrEmpty(pStyle) ? fmtStyle : pStyle + ";" + fmtStyle;
+        }
         if (!string.IsNullOrEmpty(pStyle))
             sb.Append($" style=\"{pStyle}\"");
         sb.Append(">");
@@ -303,6 +318,17 @@ public partial class WordHandler
             return;
         if (rProps.SpecVanish != null && (rProps.SpecVanish.Val == null || rProps.SpecVanish.Val.Value))
             return;
+
+        // Tracked format change (rPrChange) — yellow highlight with author attribution
+        var rPrChange = run.RunProperties?.GetFirstChild<RunPropertiesChange>();
+        bool hasRPrChange = rPrChange != null;
+        if (hasRPrChange)
+        {
+            var author = rPrChange!.Author?.Value ?? "";
+            var authorAttr = string.IsNullOrEmpty(author) ? "" : $" title=\"Format changed by {HtmlEncodeAttr(author)}\"";
+            sb.Append($"<span class=\"track-format\" style=\"background:#FFF9C4;border-bottom:2px solid #FFC107\"{authorAttr}>");
+        }
+
         var style = GetRunInlineCss(rProps, para);
         var needsSpan = !string.IsNullOrEmpty(style);
 
@@ -469,6 +495,8 @@ public partial class WordHandler
         }
 
         if (needsSpan && !_ctx.LineBreakEnabled)
+            sb.Append("</span>");
+        if (hasRPrChange)
             sb.Append("</span>");
     }
 


### PR DESCRIPTION
     1|## Summary
     2|
     3|Extend the HTML preview and watch server to fully support Track Changes visualization and one-click accept/reject operations.
     4|
     5|### Part 1: HTML Preview — Render All Revision Types
     6|
     7|Before this PR, only `w:ins` (insertions) and `w:del` (deletions) were visible in the HTML preview. Format changes, table row revisions, and table property changes were silently invisible.
     8|
     9|**New visual indicators:**
    10|
    11|| Revision Type | CSS Class | Visual Style |
    12||---|---|---|
    13|| `rPrChange` (run format) | `.track-format` | Yellow highlight + bottom border |
    14|| `pPrChange` (paragraph format) | `.track-format` | Yellow highlight + left border |
    15|| `tblPrChange` (table format) | `.track-format` | Yellow highlight + left border |
    16|| Table row `ins`/`moveTo` | `.track-ins-row` | Green background |
    17|| Table row `del`/`moveFrom` | `.track-del-row` | Red background + strikethrough |
    18|
    19|**Implementation details:**
    20|- `HtmlPreview.Text.cs`: Detect `rPrChange` in runs and `pPrChange` in paragraphs, wrap with visual markers
    21|- `HtmlPreview.Tables.cs`: Flatten revision-wrapped table rows (via `GetFlattenedTableRows`), add row-level visual markers, detect `tblPrChange`
    22|- `HtmlPreview.Css.cs`: Add `.track-format`, `.track-ins-row`, `.track-del-row` CSS definitions
    23|
    24|### Part 2: Watch Server — Revision API + Floating Toolbar
    25|
    26|Add three new HTTP endpoints to the watch server for revision management:
    27|
    28|| Endpoint | Method | Action |
    29||---|---|---|
    30|| `/api/revision/accept` | POST | Accept all tracked changes |
    31|| `/api/revision/reject` | POST | Reject all tracked changes |
    32|| `/api/revision/count` | GET | Return `{"count": N}` |
    33|
    34|All endpoints follow the existing `/api/edit` subprocess pattern (spawn `officecli`, wait, notify SSE clients).
    35|
    36|**Floating revision toolbar** injected into watch HTML for Word documents:
    37|
    39|
    40|- Shows revision count badge (📝 N revisions)
    41|- Accept All (green) / Reject All (red) buttons
    42|- Auto-hides when no revisions exist
    43|- Only appears for Word documents
    44|- Auto-refreshes via SSE update events
    45|
    46|### Screenshots
    47|
    48|**HTML preview with all revision types visible:**
    49|
    51|
    52|**Watch preview with floating toolbar (3 revisions):**
    53|
    55|
    56|**After clicking "Reject All" (0 revisions, toolbar auto-hides):**
    57|
    59|
    60|### Testing
    61|
    62|```bash
    63|# Build
    64|dotnet build src/officecli/officecli.csproj --no-restore
    65|
    66|# Test revision rendering
    67|officecli create test.docx
    68|officecli add test.docx /body --type paragraph --prop text="Original."
    69|officecli add test.docx "/body/p[1]" --type run --prop trackChange=ins --prop trackChange.author=AI --prop text=" Inserted."
    70|officecli add test.docx "/body/p[1]" --type run --prop trackChange=del --prop trackChange.author=AI --prop text=" Deleted."
    71|officecli add test.docx /body --type paragraph --prop text="Bold" --prop trackChange=format --prop trackChange.author=AI --prop bold=true
    72|officecli close test.docx
    73|officecli view test.docx html    # should show green underline, red strikethrough, yellow highlight
    74|
    75|# Test watch toolbar
    76|officecli watch test.docx --port 18888
    77|# Open http://localhost:18888/ — toolbar should appear with "3 revisions"
    78|# Click "Accept All" or "Reject All" — page refreshes, toolbar hides
    79|curl http://localhost:18888/api/revision/count   # {"count":3} → {"count":0} after accept/reject
    80|```
    81|
    82|### Files Changed
    83|
    84|| File | Lines | Description |
    85||---|---|---|
    86|| `WordHandler.HtmlPreview.Text.cs` | +28 | rPrChange/pPrChange visual markers |
    87|| `WordHandler.HtmlPreview.Tables.cs` | +85/-4 | Revision-wrapped row flattening, row markers, tblPrChange |
    88|| `WordHandler.HtmlPreview.Css.cs` | +3 | CSS classes for new revision types |
    89|| `WatchServer.cs` | +199/-2 | Revision API endpoints + toolbar injection |
    90|
    91|Total: +315/-6 across 4 files.
    92|
    93|### Related PRs
    94|
    95|This PR complements the Track Changes creation features in #119–#122. While those PRs add the ability to *create* revisions, this PR ensures they are *visible* and *actionable* in the preview.
    96|
    97|