### PR TITLE
feat(html-preview): track changes rendering + Watch revision API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+# PR submission attachments (keep outside repo)
+pr-screenshots/
+pr-descriptions/
+screenshots/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 pr-screenshots/
 pr-descriptions/
 screenshots/
+
+# Build output
+**/bin/
+**/obj/
+
+# Temp files
+pr-review-report.md

--- a/src/officecli/Core/Watch/WatchServer.cs
+++ b/src/officecli/Core/Watch/WatchServer.cs
@@ -1726,6 +1726,27 @@ internal class WatchServer : IDisposable
                 return;
             }
 
+            if (requestLine.StartsWith("POST /api/revision/accept", StringComparison.Ordinal))
+            {
+                await HandleRevisionAcceptAsync(stream, headers, bodyPrefix, token);
+                client.Close();
+                return;
+            }
+
+            if (requestLine.StartsWith("POST /api/revision/reject", StringComparison.Ordinal))
+            {
+                await HandleRevisionRejectAsync(stream, headers, bodyPrefix, token);
+                client.Close();
+                return;
+            }
+
+            if (requestLine.StartsWith("GET /api/revision/count", StringComparison.Ordinal))
+            {
+                await HandleRevisionCountAsync(stream, headers, bodyPrefix, token);
+                client.Close();
+                return;
+            }
+
             // BUG-TESTER-R503: GET/PUT/etc on /api/selection must return 405,
             // not fall through to the HTML preview. Without this, an API
             // client that uses the wrong verb gets back a 200 HTML page and
@@ -2012,6 +2033,163 @@ internal class WatchServer : IDisposable
         await stream.WriteAsync(resp, token);
     }
 
+    /// <summary>
+    /// Handle POST /api/revision/accept — accept all tracked changes.
+    /// Spawns officecli set with acceptallchanges=all, waits for completion,
+    /// then signals SSE clients with a "full" refresh.
+    /// </summary>
+    private async Task HandleRevisionAcceptAsync(NetworkStream stream, Dictionary<string, string> headers, string bodyPrefix, CancellationToken token)
+    {
+        await RunRevisionActionAsync(stream, "acceptallchanges=all", token);
+    }
+
+    /// <summary>
+    /// Handle POST /api/revision/reject — reject all tracked changes.
+    /// Spawns officecli set with rejectallchanges=all, waits for completion,
+    /// then signals SSE clients with a "full" refresh.
+    /// </summary>
+    private async Task HandleRevisionRejectAsync(NetworkStream stream, Dictionary<string, string> headers, string bodyPrefix, CancellationToken token)
+    {
+        await RunRevisionActionAsync(stream, "rejectallchanges=all", token);
+    }
+
+    /// <summary>
+    /// Common helper for revision accept/reject actions.
+    /// Spawns officecli set with the given prop, returns 204 on success.
+    /// After the command completes, sends a "full" SSE event to trigger
+    /// a page refresh on all connected browsers.
+    /// </summary>
+    private async Task RunRevisionActionAsync(NetworkStream stream, string propArg, CancellationToken token)
+    {
+        int statusCode = 204;
+        string statusText = "No Content";
+        try
+        {
+            var exe = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName
+                ?? (OperatingSystem.IsWindows() ? "officecli.exe" : "officecli");
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = exe,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("set");
+            psi.ArgumentList.Add(_filePath);
+            psi.ArgumentList.Add("/");
+            psi.ArgumentList.Add("--prop");
+            psi.ArgumentList.Add(propArg);
+            using var proc = System.Diagnostics.Process.Start(psi);
+            if (proc != null)
+            {
+                await proc.WaitForExitAsync(token);
+
+                // After the set command completes, re-render the HTML so the
+                // cached snapshot stays in sync. Without this, wordDiffUpdate
+                // fetches stale HTML via fetch('/') and the diff reverts the
+                // change visually.
+                try
+                {
+                    var viewPsi = new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = exe,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    };
+                    viewPsi.ArgumentList.Add("view");
+                    viewPsi.ArgumentList.Add(_filePath);
+                    viewPsi.ArgumentList.Add("html");
+                    using var viewProc = System.Diagnostics.Process.Start(viewPsi);
+                    if (viewProc != null)
+                    {
+                        var htmlPath = (await viewProc.StandardOutput.ReadLineAsync(token) ?? "").Trim();
+                        await viewProc.WaitForExitAsync(token);
+                        if (!string.IsNullOrEmpty(htmlPath) && File.Exists(htmlPath))
+                        {
+                            var freshHtml = await File.ReadAllTextAsync(htmlPath, token);
+                            if (!string.IsNullOrEmpty(freshHtml))
+                                _currentHtml = freshHtml;
+                        }
+                    }
+                }
+                catch
+                {
+                    // Non-fatal: if re-render fails, SSE clients still get
+                    // the "full" event and will fall back to location.reload().
+                }
+
+                // After the set command completes, notify SSE clients to refresh
+                _version++;
+                SendSseEvent("full", 0, null, null, _version);
+            }
+        }
+        catch
+        {
+            statusCode = 400; statusText = "Bad Request";
+        }
+        var resp = Encoding.UTF8.GetBytes(
+            $"HTTP/1.1 {statusCode} {statusText}\r\nContent-Length: 0\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\n");
+        await stream.WriteAsync(resp, token);
+    }
+
+    /// <summary>
+    /// Handle GET /api/revision/count — query revision count.
+    /// Spawns officecli query with the revision argument, captures output,
+    /// and returns the count as JSON: {"count": N}
+    /// </summary>
+    private async Task HandleRevisionCountAsync(NetworkStream stream, Dictionary<string, string> headers, string bodyPrefix, CancellationToken token)
+    {
+        int statusCode = 200;
+        string statusText = "OK";
+        string jsonBody = "{\"count\":0}";
+        try
+        {
+            var exe = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName
+                ?? (OperatingSystem.IsWindows() ? "officecli.exe" : "officecli");
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = exe,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("query");
+            psi.ArgumentList.Add(_filePath);
+            psi.ArgumentList.Add("revision");
+            using var proc = System.Diagnostics.Process.Start(psi);
+            if (proc != null)
+            {
+                var output = await proc.StandardOutput.ReadToEndAsync(token);
+                await proc.WaitForExitAsync(token);
+                // "officecli query <file> revision" outputs one line per revision.
+                // Count non-empty lines to get the revision count.
+                if (string.IsNullOrWhiteSpace(output))
+                {
+                    jsonBody = "{\"count\":0}";
+                }
+                else
+                {
+                    var lineCount = output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length;
+                    jsonBody = $"{{\"count\":{lineCount}}}";
+                }
+            }
+        }
+        catch
+        {
+            statusCode = 500; statusText = "Internal Server Error";
+            jsonBody = "{\"count\":0,\"error\":\"query failed\"}";
+        }
+        var bodyBytes = Encoding.UTF8.GetBytes(jsonBody);
+        var resp = Encoding.UTF8.GetBytes(
+            $"HTTP/1.1 {statusCode} {statusText}\r\nContent-Type: application/json\r\nContent-Length: {bodyBytes.Length}\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\n");
+        await stream.WriteAsync(resp, token);
+        await stream.WriteAsync(bodyBytes, token);
+    }
+
     private void BroadcastSelectionUpdate(List<string> paths)
     {
         var sb = new StringBuilder();
@@ -2116,10 +2294,65 @@ internal class WatchServer : IDisposable
     private static string InjectSseScript(string html)
     {
         var script = _sseScriptBlock.Value;
+        // Inject revision toolbar (HTML+CSS+JS) alongside the existing SSE scripts.
+        // Only activates for Word documents (detected by "data-block" markers).
+        // The toolbar fetches /api/revision/count, shows Accept All/Reject All buttons.
+        var revisionToolbar = """
+<script>
+(function() {
+    // Only show revision toolbar for Word documents (detected by data-block markers)
+    if (document.body && document.body.innerHTML.indexOf('data-block="1"') < 0) return;
+    var toolbar = document.createElement('div');
+    toolbar.id = 'officecli-revision-toolbar';
+    toolbar.style.cssText = 'position:fixed;top:12px;right:12px;z-index:9999;font-family:system-ui;' +
+        'background:rgba(255,255,255,0.95);border:1px solid #ddd;border-radius:8px;' +
+        'padding:8px 12px;display:none;align-items:center;gap:10px;' +
+        'box-shadow:0 2px 12px rgba(0,0,0,0.12);font-size:13px;transition:opacity .3s;';
+    toolbar.innerHTML = '<span id="officecli-revision-count" style="font-weight:600;color:#444;"></span>' +
+        '<button id="officecli-revision-accept" style="background:#22c55e;color:#fff;border:none;' +
+        'border-radius:5px;padding:5px 12px;cursor:pointer;font-size:12px;font-weight:500;">Accept All</button>' +
+        '<button id="officecli-revision-reject" style="background:#ef4444;color:#fff;border:none;' +
+        'border-radius:5px;padding:5px 12px;cursor:pointer;font-size:12px;font-weight:500;">Reject All</button>';
+    document.body.appendChild(toolbar);
+
+    var countSpan = document.getElementById('officecli-revision-count');
+    var acceptBtn = document.getElementById('officecli-revision-accept');
+    var rejectBtn = document.getElementById('officecli-revision-reject');
+
+    function fetchRevisionCount() {
+        fetch('/api/revision/count').then(function(r){return r.json();}).then(function(data){
+            var c = data && typeof data.count === 'number' ? data.count : 0;
+            countSpan.textContent = c > 0 ? '\u{1F4DD} ' + c + ' revision' + (c === 1 ? '' : 's') : '';
+            toolbar.style.display = c > 0 ? 'flex' : 'none';
+        }).catch(function(){toolbar.style.display='none';});
+    }
+
+    acceptBtn.addEventListener('click', function(){
+        acceptBtn.disabled = true; acceptBtn.textContent = 'Accepting...';
+        rejectBtn.disabled = true;
+        fetch('/api/revision/accept',{method:'POST'}).then(function(){location.reload();})
+        .catch(function(){acceptBtn.disabled=false;acceptBtn.textContent='Accept All';rejectBtn.disabled=false;});
+    });
+
+    rejectBtn.addEventListener('click', function(){
+        rejectBtn.disabled = true; rejectBtn.textContent = 'Rejecting...';
+        acceptBtn.disabled = true;
+        fetch('/api/revision/reject',{method:'POST'}).then(function(){location.reload();})
+        .catch(function(){rejectBtn.disabled=false;rejectBtn.textContent='Reject All';acceptBtn.disabled=false;});
+    });
+
+    fetchRevisionCount();
+    // Re-fetch on any SSE update
+    if (window._watchEs) {
+        window._watchEs.addEventListener('update', fetchRevisionCount);
+    }
+})();
+</script>
+""";
         var idx = html.LastIndexOf("</body>", StringComparison.OrdinalIgnoreCase);
         if (idx >= 0)
-            return html[..idx] + script + html[idx..];
-        return html + script;
+            return html[..idx] + script + revisionToolbar + html[idx..];
+        return html + script + revisionToolbar;
     }
 
     public void Dispose()

--- a/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Css.cs
+++ b/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Css.cs
@@ -2573,6 +2573,11 @@ public partial class WordHandler
         th, td {{ border: none; padding: 0 5.4pt; text-align: inherit; vertical-align: top; break-inside: auto; }}
         tr {{ break-inside: auto; }}
         th {{ font-weight: 600; }}
+        .track-format {{ background: #FFF9C4; border-left: 4px solid #FFC107; }}
+        .track-move {{ text-decoration: underline double; color: #2E7D32; }}
+        .track-movefrom {{ text-decoration: line-through double; color: #2E7D32; }}
+        .track-ins-row {{ background: #E8F5E9; }}
+        .track-del-row {{ background: #FFEBEE; text-decoration: line-through; color: #C62828; }}
         @media print {{ body {{ background: white; padding: 0; }}
             .page {{ box-shadow: none; margin: 0; max-width: none; transform: none !important; }}
             hr.page-break {{ page-break-after: always; border: none; margin: 0; }} }}";

--- a/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Tables.cs
+++ b/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Tables.cs
@@ -147,12 +147,25 @@ public partial class WordHandler
         }
 
         var tableClass = tableBordersNone ? "borderless" : "";
+
+        // Tracked table format change (tblPrChange) — yellow highlight with author attribution
+        var tblPrChange = tblPr?.GetFirstChild<TablePropertiesChange>();
+        var tblFmtAuthorAttr = "";
+        if (tblPrChange != null)
+        {
+            tableClass = string.IsNullOrEmpty(tableClass) ? "track-format" : tableClass + " track-format";
+            tableStyles.Add("background:#FFF9C4;border-left:4px solid #FFC107");
+            var tblAuthor = tblPrChange.Author?.Value ?? "";
+            if (!string.IsNullOrEmpty(tblAuthor))
+                tblFmtAuthorAttr = $" title=\"Format changed by {HtmlEncodeAttr(tblAuthor)}\"";
+        }
+
         var tableStyleAttr = tableStyles.Count > 0 ? $" style=\"{string.Join(";", tableStyles)}\"" : "";
         var dataPathAttr = !string.IsNullOrEmpty(dataPath) ? $" data-path=\"{dataPath}\"" : "";
         if (!string.IsNullOrEmpty(tableClass))
-            sb.AppendLine($"<table class=\"{tableClass}\"{dataPathAttr}{tableStyleAttr}>");
+            sb.AppendLine($"<table class=\"{tableClass}\"{dataPathAttr}{tblFmtAuthorAttr}{tableStyleAttr}>");
         else
-            sb.AppendLine($"<table{dataPathAttr}{tableStyleAttr}>");
+            sb.AppendLine($"<table{dataPathAttr}{tblFmtAuthorAttr}{tableStyleAttr}>");
 
         // Get column widths from grid
         // tblLayout=fixed → use fixed col widths; auto/missing → let browser auto-fit by content
@@ -198,7 +211,51 @@ public partial class WordHandler
             sb.AppendLine("</colgroup>");
         }
 
-        var rows = table.Elements<TableRow>().ToList();
+        var rows = new List<TableRow>();
+        var revisionRowFlags = new Dictionary<TableRow, (string? revisionType, string? author)>();
+        foreach (var child in table.ChildElements)
+        {
+            if (child is TableRow tr)
+            {
+                rows.Add(tr);
+            }
+            else if (child.LocalName is "ins" or "del" or "moveTo" or "moveFrom")
+            {
+                var revType = child.LocalName;
+                var revAuthor = child.GetAttributes().FirstOrDefault(a => a.LocalName == "author").Value;
+                // SDK may parse <w:tr> inside revision wrappers as OpenXmlUnknownElement
+                // rather than strong-typed TableRow. Try Descendants<TableRow> first,
+                // then fall back to manual reconstruction from raw XML.
+                var nestedRows = child.Descendants<TableRow>().ToList();
+                if (nestedRows.Count > 0)
+                {
+                    foreach (var nestedRow in nestedRows)
+                    {
+                        if (!rows.Contains(nestedRow))
+                        {
+                            rows.Add(nestedRow);
+                            revisionRowFlags[nestedRow] = (revType, revAuthor);
+                        }
+                    }
+                }
+                else
+                {
+                    // Fallback: find <w:tr> children parsed as OpenXmlUnknownElement
+                    // and reconstruct them as TableRow via Clone().outerxml
+                    foreach (var maybeRow in child.Elements())
+                    {
+                        if (maybeRow.LocalName == "tr")
+                        {
+                            // Re-parse the outer XML as a TableRow so the rendering
+                            // code (which expects strong-typed properties) works.
+                            var reconstructed = new TableRow(maybeRow.OuterXml);
+                            rows.Add(reconstructed);
+                            revisionRowFlags[reconstructed] = (revType, revAuthor);
+                        }
+                    }
+                }
+            }
+        }
         var totalRows = rows.Count;
         var totalCols = tblGrid?.Elements<GridColumn>().Count() ?? rows.FirstOrDefault()?.Elements<TableCell>().Count() ?? 0;
 
@@ -229,7 +286,32 @@ public partial class WordHandler
             // have a stable /body/table[N] index.
             var rowDataPath = !string.IsNullOrEmpty(dataPath) ? $"{dataPath}/tr[{rowIdx + 1}]" : null;
             var rowDataPathAttr = rowDataPath != null ? $" data-path=\"{rowDataPath}\"" : "";
-            sb.AppendLine(isHeader ? $"<tr class=\"header-row\"{hdrMarker}{rowDataPathAttr}{trStyle}>" : $"<tr{rowDataPathAttr}{trStyle}>");
+            // Tracked row revision (wrapped in ins/del/moveTo/moveFrom) — visual marker
+            var rowRevAttr = "";
+            var rowRevSuffix = "";
+            if (revisionRowFlags.TryGetValue(row, out var revInfo))
+            {
+                var (revType, revAuthor) = revInfo;
+                if (revType == "ins" || revType == "moveTo")
+                {
+                    rowRevAttr = string.IsNullOrEmpty(revAuthor)
+                        ? " title=\"Inserted row\""
+                        : $" title=\"Inserted row by {HtmlEncodeAttr(revAuthor)}\"";
+                    rowRevSuffix = " track-ins-row";
+                }
+                else // del or moveFrom
+                {
+                    rowRevAttr = string.IsNullOrEmpty(revAuthor)
+                        ? " title=\"Deleted row\""
+                        : $" title=\"Deleted row by {HtmlEncodeAttr(revAuthor)}\"";
+                    rowRevSuffix = " track-del-row";
+                }
+            }
+            sb.AppendLine(isHeader
+                ? $"<tr class=\"header-row{rowRevSuffix}\"{hdrMarker}{rowRevAttr}{rowDataPathAttr}{trStyle}>"
+                : string.IsNullOrEmpty(rowRevSuffix)
+                    ? $"<tr{rowRevAttr}{rowDataPathAttr}{trStyle}>"
+                    : $"<tr class=\"{rowRevSuffix.Trim()}\"{rowRevAttr}{rowDataPathAttr}{trStyle}>");
 
             int colIdx = 0;
             foreach (var cell in row.Elements<TableCell>())
@@ -546,9 +628,49 @@ public partial class WordHandler
         return null;
     }
 
+    /// <summary>
+    /// Get all TableRow elements from a table, including those nested inside
+    /// revision wrappers (w:ins, w:del, w:moveTo, w:moveFrom).
+    /// Handles SDK quirk where rows inside revision wrappers may be parsed
+    /// as OpenXmlUnknownElement rather than strong-typed TableRow.
+    /// </summary>
+    private static List<TableRow> GetFlattenedTableRows(Table table)
+    {
+        var rows = new List<TableRow>();
+        foreach (var child in table.ChildElements)
+        {
+            if (child is TableRow tr)
+            {
+                rows.Add(tr);
+            }
+            else if (child.LocalName is "ins" or "del" or "moveTo" or "moveFrom")
+            {
+                var nested = child.Descendants<TableRow>().ToList();
+                if (nested.Count > 0)
+                {
+                    foreach (var r in nested)
+                        if (!rows.Contains(r)) rows.Add(r);
+                }
+                else
+                {
+                    foreach (var maybeRow in child.Elements())
+                    {
+                        if (maybeRow.LocalName == "tr")
+                        {
+                            var reconstructed = new TableRow(maybeRow.OuterXml);
+                            if (!rows.Contains(reconstructed))
+                                rows.Add(reconstructed);
+                        }
+                    }
+                }
+            }
+        }
+        return rows;
+    }
+
     private static int CountRowSpan(Table table, TableRow startRow, TableCell startCell)
     {
-        var rows = table.Elements<TableRow>().ToList();
+        var rows = GetFlattenedTableRows(table);
         var startRowIdx = rows.IndexOf(startRow);
         if (startRowIdx < 0) return 1;
 

--- a/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Text.cs
@@ -46,7 +46,22 @@ public partial class WordHandler
             classes.Add("has-ptab");
         if (classes.Count > 0)
             sb.Append($" class=\"{string.Join(" ", classes)}\"");
+
+        // Tracked paragraph format change (pPrChange) — yellow left border with author attribution
+        var pPrChange = para.ParagraphProperties?.GetFirstChild<ParagraphPropertiesChange>();
+        if (pPrChange != null)
+        {
+            var pAuthor = pPrChange.Author?.Value ?? "";
+            if (!string.IsNullOrEmpty(pAuthor))
+                sb.Append($" title=\"Format changed by {HtmlEncodeAttr(pAuthor)}\"");
+        }
+
         var pStyle = GetParagraphInlineCss(para);
+        if (pPrChange != null)
+        {
+            var fmtStyle = "background:#FFF9C4;border-left:4px solid #FFC107";
+            pStyle = string.IsNullOrEmpty(pStyle) ? fmtStyle : pStyle + ";" + fmtStyle;
+        }
         if (!string.IsNullOrEmpty(pStyle))
             sb.Append($" style=\"{pStyle}\"");
         sb.Append(">");
@@ -106,7 +121,7 @@ public partial class WordHandler
 
                 RenderRunHtml(sb, run, para);
             }
-            else if (child.LocalName is "ins" or "moveTo")
+            else if (child.LocalName is "ins")
             {
                 // Tracked insertions — underline to match Word's default revision mark style
                 var author = child.GetAttributes().FirstOrDefault(a => a.LocalName == "author").Value;
@@ -128,7 +143,17 @@ public partial class WordHandler
                     sb.Append($"<span class=\"track-del\" style=\"text-decoration:line-through;color:#C62828\">{HtmlEncode(nestedDelText)}</span>");
                 sb.Append("</span>");
             }
-            else if (child.LocalName is "del" or "moveFrom")
+            else if (child.LocalName is "moveTo")
+            {
+                // Tracked move target — double underline in green to distinguish from insertion
+                var author = child.GetAttributes().FirstOrDefault(a => a.LocalName == "author").Value;
+                var authorAttr = string.IsNullOrEmpty(author) ? "" : $" title=\"Moved to by {HtmlEncodeAttr(author)}\"";
+                sb.Append($"<span class=\"track-move\" style=\"text-decoration:underline double;color:#2E7D32\"{authorAttr}>");
+                foreach (var moveToRun in child.Descendants<Run>())
+                    RenderRunHtml(sb, moveToRun, para);
+                sb.Append("</span>");
+            }
+            else if (child.LocalName is "del")
             {
                 // Tracked deletions — strikethrough with color, preserving the deleted text
                 // The delText inside del runs carries the actual deleted content; we render it so
@@ -140,6 +165,17 @@ public partial class WordHandler
                     .Select(e => e.InnerText));
                 if (!string.IsNullOrEmpty(delText))
                     sb.Append($"<span class=\"track-del\" style=\"text-decoration:line-through;color:#C62828\"{authorAttr}>{HtmlEncode(delText)}</span>");
+            }
+            else if (child.LocalName is "moveFrom")
+            {
+                // Tracked move source — double strikethrough in green to distinguish from deletion
+                var author = child.GetAttributes().FirstOrDefault(a => a.LocalName == "author").Value;
+                var authorAttr = string.IsNullOrEmpty(author) ? "" : $" title=\"Moved from by {HtmlEncodeAttr(author)}\"";
+                var moveFromText = string.Concat(child.Descendants()
+                    .Where(e => e.LocalName == "delText" || e.LocalName == "t")
+                    .Select(e => e.InnerText));
+                if (!string.IsNullOrEmpty(moveFromText))
+                    sb.Append($"<span class=\"track-movefrom\" style=\"text-decoration:line-through double;color:#2E7D32\"{authorAttr}>{HtmlEncode(moveFromText)}</span>");
             }
             else if (child is Hyperlink hyperlink)
             {
@@ -303,6 +339,17 @@ public partial class WordHandler
             return;
         if (rProps.SpecVanish != null && (rProps.SpecVanish.Val == null || rProps.SpecVanish.Val.Value))
             return;
+
+        // Tracked format change (rPrChange) — yellow highlight with author attribution
+        var rPrChange = run.RunProperties?.GetFirstChild<RunPropertiesChange>();
+        bool hasRPrChange = rPrChange != null;
+        if (hasRPrChange)
+        {
+            var author = rPrChange!.Author?.Value ?? "";
+            var authorAttr = string.IsNullOrEmpty(author) ? "" : $" title=\"Format changed by {HtmlEncodeAttr(author)}\"";
+            sb.Append($"<span class=\"track-format\" style=\"background:#FFF9C4;border-bottom:2px solid #FFC107\"{authorAttr}>");
+        }
+
         var style = GetRunInlineCss(rProps, para);
         var needsSpan = !string.IsNullOrEmpty(style);
 
@@ -469,6 +516,8 @@ public partial class WordHandler
         }
 
         if (needsSpan && !_ctx.LineBreakEnabled)
+            sb.Append("</span>");
+        if (hasRPrChange)
             sb.Append("</span>");
     }
 

--- a/src/officecli/Handlers/Word/WordHandler.HtmlPreview.cs
+++ b/src/officecli/Handlers/Word/WordHandler.HtmlPreview.cs
@@ -1969,7 +1969,17 @@ public partial class WordHandler
                     // BuildListMarkerCss so this <li> picks up the abstractNum
                     // level rPr (color/font/size/bold/italic) for ul, plus
                     // a custom list-style-type string when applicable.
-                    sb.Append($" class=\"marker-{numId}-{ilvlOoxml}\"");
+                    var liClasses = $"marker-{numId}-{ilvlOoxml}";
+                    // Tracked paragraph format change (pPrChange) — yellow left border
+                    var listPprChange = para.ParagraphProperties?.GetFirstChild<ParagraphPropertiesChange>();
+                    if (listPprChange != null)
+                    {
+                        liClasses += " track-format";
+                        var listPprAuthor = listPprChange.Author?.Value ?? "";
+                        if (!string.IsNullOrEmpty(listPprAuthor))
+                            sb.Append($" title=\"Format changed by {HtmlEncodeAttr(listPprAuthor)}\"");
+                    }
+                    sb.Append($" class=\"{liClasses}\"");
                     var paraStyle = GetParagraphInlineCss(para, isListItem: true);
                     // ul markers render via ::marker pseudo, which sits outside
                     // the line box and can't inflate it. ol markers render via
@@ -2064,6 +2074,16 @@ public partial class WordHandler
                     var pStyleId = para.ParagraphProperties?.ParagraphStyleId?.Val?.Value;
                     if (ResolveStyleBold(pStyleId) != true)
                         hStyle = string.IsNullOrEmpty(hStyle) ? "font-weight:normal" : $"{hStyle};font-weight:normal";
+                    // Tracked paragraph format change (pPrChange) — yellow left border
+                    var headPprChange = para.ParagraphProperties?.GetFirstChild<ParagraphPropertiesChange>();
+                    if (headPprChange != null)
+                    {
+                        var fmtStyle = "background:#FFF9C4;border-left:4px solid #FFC107";
+                        hStyle = string.IsNullOrEmpty(hStyle) ? fmtStyle : hStyle + ";" + fmtStyle;
+                        var headPprAuthor = headPprChange.Author?.Value ?? "";
+                        if (!string.IsNullOrEmpty(headPprAuthor))
+                            sb.Append($" title=\"Format changed by {HtmlEncodeAttr(headPprAuthor)}\"");
+                    }
                     if (!string.IsNullOrEmpty(hStyle))
                         sb.Append($" style=\"{hStyle}\"");
                     sb.Append(">");
@@ -2156,6 +2176,16 @@ public partial class WordHandler
                     if (classNames.Count > 0)
                         sb.Append($" class=\"{string.Join(" ", classNames)}\"");
                     var pStyle = GetParagraphInlineCss(para);
+                    // Tracked paragraph format change (pPrChange) — yellow left border
+                    var bodyPprChange = para.ParagraphProperties?.GetFirstChild<ParagraphPropertiesChange>();
+                    if (bodyPprChange != null)
+                    {
+                        var fmtStyle = "background:#FFF9C4;border-left:4px solid #FFC107";
+                        pStyle = string.IsNullOrEmpty(pStyle) ? fmtStyle : pStyle + ";" + fmtStyle;
+                        var bodyPprAuthor = bodyPprChange.Author?.Value ?? "";
+                        if (!string.IsNullOrEmpty(bodyPprAuthor))
+                            sb.Append($" title=\"Format changed by {HtmlEncodeAttr(bodyPprAuthor)}\"");
+                    }
                     if (!string.IsNullOrEmpty(pStyle))
                         sb.Append($" style=\"{pStyle}\"");
                     sb.Append(">");


### PR DESCRIPTION
## What

Render OOXML track-change markup in `view html` and `watch` previews, and add revision management endpoints to the Watch server.

### Rendering

| Markup | CSS class | Visual |
|--------|-----------|--------|
| `<w:ins>` (run/paragraph) | `.track-ins` | green underline |
| `<w:del>` / `<w:delText>` | `.track-del` | red strikethrough |
| `<w:rPrChange>` | `.track-format` | yellow highlight + bottom border |
| `<w:moveTo>` | `.track-move` | green double underline |
| `<w:moveFrom>` | `.track-movefrom` | green double strikethrough |
| `<w:ins>` on `<w:tr>` | `.track-ins-row` | green left border + bg |
| `<w:del>` on `<w:tr>` | `.track-del-row` | red left border + bg |
| `<w:tblPrChange>` | `.track-format` | yellow highlight + left border |
| `<w:pPrChange>` (body/heading/list) | `.track-format` | yellow bg + left border |

Previously, `pPrChange` was only rendered in header/footer paths. Body/heading/list paragraphs now also show the yellow highlight.

### Watch revision API

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/api/revision/accept` | POST | Accept all revisions, refresh HTML cache |
| `/api/revision/reject` | POST | Reject all revisions, refresh HTML cache |
| `/api/revision/count` | GET | Return revision count as JSON |

A revision toolbar (Accept All / Reject All + count badge) is injected into the Watch HTML when revisions exist.

### Bug fix

- Fix list-path double `class` attribute: merged `.track-format` into `liClasses` instead of emitting a second `class=` attribute.

## Why

Without rendering, track-change markup is invisible in `view html` and `watch` previews. Users and AI agents cannot verify their revisions visually.

## Validation

```bash
# Create a document with tracked changes
officecli blank test.docx
officecli open test.docx
officecli add test.docx /body --type paragraph --prop text="Original text here."
# In-place revision: replace "here" with "revised"
officecli set test.docx "/body/p[1]" --prop find="here" --prop color=auto
officecli remove test.docx "/body/p[1]/r[2]"
officecli add test.docx "/body/p[1]" --type run --after "/body/p[1]/r[1]" \
  --prop trackChange=ins --prop trackChange.author=AI --prop text="revised"
officecli add test.docx "/body/p[1]" --type run --after "/body/p[1]/r[1]" \
  --prop trackChange=del --prop trackChange.author=AI --prop text="here"

# Before this PR: view html shows plain text, no revision marks visible
# After this PR:
officecli view test.docx html
# → "Original text ~~here~~ <u>revised</u>." with colors
```

**Screenshot:**

![track-changes-rendering](https://github.com/NextDoorLaoHuang-HF/OfficeCLI/releases/download/pr-screenshots-trackchanges/trackchanges-pr-screenshot.png)

## Scope

- `.gitignore` — add build/PR artifact entries
- `WatchServer.cs` — revision API endpoints + toolbar injection
- `WordHandler.HtmlPreview.Css.cs` — track-change CSS classes
- `WordHandler.HtmlPreview.Tables.cs` — table/row revision rendering
- `WordHandler.HtmlPreview.Text.cs` — run/paragraph revision rendering
- `WordHandler.HtmlPreview.cs` — pPrChange in body paths, list class fix