### PR TITLE
docs(skill): Track Changes documentation for AI agents

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -357,28 +357,51 @@ When the user asks to review, audit, redline, or revise a document with tracked 
 
 **Do NOT use bare `add run --prop trackChange=del/ins` on an existing paragraph** — it appends to the end, producing: `original text ~~deleted~~ <u>inserted</u>`. This duplicates text instead of marking the original.
 
-For each change (e.g. replacing "3个工作日" with "5个工作日"):
+### Step-by-step: Replace text with tracked change
+
+For each change (e.g. replacing "8" with "4"):
 
 ```bash
-# Step 1: Use `set` with `find` to split the target text into its own run.
-officecli set "$FILE" '/body/p[N]' --prop find="3个工作日" --prop color=auto
-#   Result: r[1]="...前" r[2]="3个工作日" r[3]="后..."
+# Step 0: Read the paragraph run structure FIRST
+officecli get "$FILE" '/body/p[N]' --depth 2
+# This shows each run and its text. The target may be split
+# across runs (e.g. "8" in r[3], "小时" in r[4]).
+
+# Step 1: Use `set` with `find` to isolate the target into its own run.
+# find only matches within a SINGLE run. Use the minimal unique text.
+# If the target is a number like "8" already in its own run, find="8" works.
+officecli set "$FILE" '/body/p[N]' --prop find="8" --prop color=auto
+#   Result: r[1]="...前" r[2]="8" r[3]="...后"
 
 # Step 2: Remove the original (unmarked) run.
 officecli remove "$FILE" '/body/p[N]/r[2]'
-#   Result: r[1]="...前" r[2]="后..."
 
 # Step 3: Add ins run AFTER the preceding run (r[1]).
 officecli add "$FILE" '/body/p[N]' --type run --after '/body/p[N]/r[1]' \
-  --prop trackChange=ins --prop trackChange.author=AI --prop text="5个工作日"
-#   Result: r[1]="...前" r[2]=<ins>"5个工作日"</ins> r[3]="后..."
+  --prop trackChange=ins --prop trackChange.author=AI --prop text="4"
 
 # Step 4: Add del run AFTER the same preceding run (r[1]).
-#   Both use --after r[1]; the second add pushes the first forward.
 officecli add "$FILE" '/body/p[N]' --type run --after '/body/p[N]/r[1]' \
-  --prop trackChange=del --prop trackChange.author=AI --prop text="3个工作日"
-#   Result: r[1]="...前" r[2]=<ins>"5个工作日"</ins> r[3]=<del>"3个工作日"</del> r[4]="后..."
+  --prop trackChange=del --prop trackChange.author=AI --prop text="8"
+# Final: r[1]="...前" r[2]=<ins>"4"</ins> r[3]=<del>"8"</del> r[4]="...后"
 ```
+
+### Handling cross-run text
+
+Real-world documents often split text across runs (e.g. `"【"` + `"8"` + `"】小时"`). Strategy:
+
+1. **Read run structure first** with `officecli get '/body/p[N]' --depth 2`
+2. **Find the smallest unique portion** that exists in a single run
+3. For numbers in brackets like `【8】`, the number `8` is typically its own run — just `find="8"`
+4. If `find` fails, try a shorter/adjacent portion within one run
+5. **NEVER fall back to unpack/pack or python-docx** — always find a way with officecli
+
+### When find doesn't match
+
+If `find` reports 0 matches:
+- The text is split across runs. Use `get --depth 2` to see actual run boundaries
+- Try just the number or keyword (e.g. `find="8"` instead of `find="8小时"`)
+- If multiple runs contain the same text, add enough context to be unique within a single run
 
 ### Other revision operations
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -353,27 +353,49 @@ officecli add-part <file> <parent>                   # create new document part 
 
 When the user asks to review, audit, redline, or revise a document with tracked changes, you MUST use `--prop trackChange=...`. Do NOT use python-docx, unpack/pack, raw-set, or any other approach for creating revision marks — the CLI handles OOXML revision markup natively.
 
-### Creating revisions
+### CRITICAL: In-place revision workflow
+
+**Do NOT use bare `add run --prop trackChange=del/ins` on an existing paragraph** — it appends to the end, producing: `original text ~~deleted~~ <u>inserted</u>`. This duplicates text instead of marking the original.
+
+For each change (e.g. replacing "3个工作日" with "5个工作日"):
 
 ```bash
-# Insert revision (green underline in Word/preview)
-officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="new clause"
+# Step 1: Use `set` with `find` to split the target text into its own run.
+officecli set "$FILE" '/body/p[N]' --prop find="3个工作日" --prop color=auto
+#   Result: r[1]="...前" r[2]="3个工作日" r[3]="后..."
 
-# Delete revision (red strikethrough in Word/preview)
-officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="removed text"
+# Step 2: Remove the original (unmarked) run.
+officecli remove "$FILE" '/body/p[N]/r[2]'
+#   Result: r[1]="...前" r[2]="后..."
 
-# Format change revision
-officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=format --prop trackChange.author=AI --prop bold=true --prop text="formatted"
+# Step 3: Add ins run AFTER the preceding run (r[1]).
+officecli add "$FILE" '/body/p[N]' --type run --after '/body/p[N]/r[1]' \
+  --prop trackChange=ins --prop trackChange.author=AI --prop text="5个工作日"
+#   Result: r[1]="...前" r[2]=<ins>"5个工作日"</ins> r[3]="后..."
+
+# Step 4: Add del run AFTER the same preceding run (r[1]).
+#   Both use --after r[1]; the second add pushes the first forward.
+officecli add "$FILE" '/body/p[N]' --type run --after '/body/p[N]/r[1]' \
+  --prop trackChange=del --prop trackChange.author=AI --prop text="3个工作日"
+#   Result: r[1]="...前" r[2]=<ins>"5个工作日"</ins> r[3]=<del>"3个工作日"</del> r[4]="后..."
+```
+
+### Other revision operations
+
+```bash
+# Format change revision (append at end is OK for new paragraphs)
+officecli add "$FILE" /body --type paragraph --prop trackChange=format --prop trackChange.author=AI --prop text="reformatted paragraph"
 
 # Move revision
 officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=moveFrom --prop trackChange.author=AI --prop text="moved text"
 officecli add "$FILE" '/body/p[2]' --type run --prop trackChange=moveTo --prop trackChange.author=AI --prop text="moved text"
 
-# Paragraph-level format revision
-officecli add "$FILE" /body --type paragraph --prop trackChange=format --prop trackChange.author=AI --prop text="reformatted paragraph"
-
 # Enable Track Changes mode (new edits auto-tracked in Word)
 officecli set "$FILE" / --prop trackRevisions=true
+
+# Accept or reject all revisions
+officecli set "$FILE" / --prop acceptallchanges=all
+officecli set "$FILE" / --prop rejectallchanges=all
 ```
 
 ### trackChange properties
@@ -385,22 +407,11 @@ officecli set "$FILE" / --prop trackRevisions=true
 | `trackChange.date` | ISO 8601 (default: now) | add run/paragraph |
 | `trackChange.id` | Integer (default: auto) | add run/paragraph |
 
-### Revision workflow
+### Verify
 
 ```bash
-# 1. Read the document
-officecli view "$FILE" text
-
-# 2. For each change: delete old text, insert new text
-officecli add "$FILE" '/body/p[3]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="3个工作日"
-officecli add "$FILE" '/body/p[3]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="5个工作日"
-
-# 3. Verify revisions
-officecli query "$FILE" revision
-
-# 4. Accept or reject all
-officecli set "$FILE" / --prop acceptallchanges=all
-officecli set "$FILE" / --prop rejectallchanges=all
+officecli query "$FILE" revision          # list all revisions
+officecli view "$FILE" html               # visual: green underline=ins, red strikethrough=del
 ```
 
 ### Contract review pattern (common task)
@@ -409,22 +420,19 @@ officecli set "$FILE" / --prop rejectallchanges=all
 FILE="contract_reviewed.docx"
 cp original.docx "$FILE"
 officecli open "$FILE"
-officecli view "$FILE" text                    # read full text
-officecli view "$FILE" outline                 # see structure
+officecli view "$FILE" outline
+officecli view "$FILE" text
 
-# For each issue found:
-# 1. Mark old text as deleted
-officecli add "$FILE" '/body/p[5]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="old clause"
-# 2. Mark new text as inserted
-officecli add "$FILE" '/body/p[5]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="revised clause"
+# For each change — use the in-place workflow:
+# 1. set find to split  2. remove original run
+# 3. add ins after preceding run  4. add del after preceding run
 
-# After all changes, verify
 officecli query "$FILE" revision
-officecli view "$FILE" html                    # visual check: green=inserted, red=deleted
+officecli view "$FILE" html
 officecli close "$FILE"
 ```
 
-**CRITICAL**: When user mentions "修订模式", "审查", "Track Changes", "redline", "revision", you MUST use `--prop trackChange=ins/del/format`. Never fall back to python-docx, docx.js, unpack/pack, or raw XML for revision marks.
+**CRITICAL**: When user mentions "修订模式", "审查", "Track Changes", "redline", "revision", you MUST use the in-place revision workflow. Never use bare `add run --prop trackChange=del/ins` without first splitting and removing the original run. Never fall back to python-docx, docx.js, unpack/pack, or raw XML.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -349,6 +349,85 @@ officecli add-part <file> <parent>                   # create new document part 
 
 ---
 
+## Track Changes / Revision Mode (Word .docx)
+
+When the user asks to review, audit, redline, or revise a document with tracked changes, you MUST use `--prop trackChange=...`. Do NOT use python-docx, unpack/pack, raw-set, or any other approach for creating revision marks — the CLI handles OOXML revision markup natively.
+
+### Creating revisions
+
+```bash
+# Insert revision (green underline in Word/preview)
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="new clause"
+
+# Delete revision (red strikethrough in Word/preview)
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="removed text"
+
+# Format change revision
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=format --prop trackChange.author=AI --prop bold=true --prop text="formatted"
+
+# Move revision
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=moveFrom --prop trackChange.author=AI --prop text="moved text"
+officecli add "$FILE" '/body/p[2]' --type run --prop trackChange=moveTo --prop trackChange.author=AI --prop text="moved text"
+
+# Paragraph-level format revision
+officecli add "$FILE" /body --type paragraph --prop trackChange=format --prop trackChange.author=AI --prop text="reformatted paragraph"
+
+# Enable Track Changes mode (new edits auto-tracked in Word)
+officecli set "$FILE" / --prop trackRevisions=true
+```
+
+### trackChange properties
+
+| Property | Values | Scope |
+|----------|--------|-------|
+| `trackChange` | `ins`, `del`, `format`, `moveFrom`, `moveTo` | add run/paragraph |
+| `trackChange.author` | Any string | add run/paragraph |
+| `trackChange.date` | ISO 8601 (default: now) | add run/paragraph |
+| `trackChange.id` | Integer (default: auto) | add run/paragraph |
+
+### Revision workflow
+
+```bash
+# 1. Read the document
+officecli view "$FILE" text
+
+# 2. For each change: delete old text, insert new text
+officecli add "$FILE" '/body/p[3]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="3个工作日"
+officecli add "$FILE" '/body/p[3]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="5个工作日"
+
+# 3. Verify revisions
+officecli query "$FILE" revision
+
+# 4. Accept or reject all
+officecli set "$FILE" / --prop acceptallchanges=all
+officecli set "$FILE" / --prop rejectallchanges=all
+```
+
+### Contract review pattern (common task)
+
+```bash
+FILE="contract_reviewed.docx"
+cp original.docx "$FILE"
+officecli open "$FILE"
+officecli view "$FILE" text                    # read full text
+officecli view "$FILE" outline                 # see structure
+
+# For each issue found:
+# 1. Mark old text as deleted
+officecli add "$FILE" '/body/p[5]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="old clause"
+# 2. Mark new text as inserted
+officecli add "$FILE" '/body/p[5]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="revised clause"
+
+# After all changes, verify
+officecli query "$FILE" revision
+officecli view "$FILE" html                    # visual check: green=inserted, red=deleted
+officecli close "$FILE"
+```
+
+**CRITICAL**: When user mentions "修订模式", "审查", "Track Changes", "redline", "revision", you MUST use `--prop trackChange=ins/del/format`. Never fall back to python-docx, docx.js, unpack/pack, or raw XML for revision marks.
+
+---
+
 ## Common Pitfalls
 
 | Pitfall | Correct Approach |

--- a/skills/officecli-docx/SKILL.md
+++ b/skills/officecli-docx/SKILL.md
@@ -466,7 +466,52 @@ officecli add "$FILE" "/body/p[3]" --type footnote --prop text="See Appendix A f
 
 **docx vs word-form skill — when to switch.** Stay in docx for any report, letter, memo, or proposal. Switch to `officecli-word-form` when the document's purpose is **data capture** — fillable intake forms, contracts / SOWs with user-fill slots, HR onboarding forms, medical questionnaires, compliance checklists, mail-merge templates. Those carry `<w:sdt>` content controls, `<w:ffData>` legacy form fields, or `documentProtection=forms`, none of which this skill teaches.
 
-**Comments and tracked changes.** Bulk accept/reject: `set / --prop accept-changes=all` (or `reject-changes=all`). Locate individual changes with `query ins` and `query del` — NOT `query trackedchange` (CLI bug C-D-1). Adding an `<w:ins>` or `<w:del>` from scratch requires `raw-set`. Add a comment with `add "/body/p[4]" --type comment --prop author=... --prop text=...`. Reply threading (`parentId`) and `done=true` resolution are UNSUPPORTED — see C-D-2 / C-D-5 for `raw-set` workarounds.
+**Comments and tracked changes.** Bulk accept/reject: `set / --prop acceptallchanges=all` (or `rejectallchanges=all`). Query all revisions: `query revision`.
+
+**Creating revisions (Track Changes mode).** Use `--prop trackChange=...` on `add` and `set` to create tracked insertions, deletions, format changes, and moves. No raw-set needed.
+
+```bash
+# Insert revision (green underline in preview)
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=ins --prop trackChange.author=AI --prop text="new clause"
+
+# Delete revision (red strikethrough in preview)
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=del --prop trackChange.author=AI --prop text="removed text"
+
+# Format change revision (yellow highlight in preview)
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=format --prop trackChange.author=AI --prop bold=true --prop text="formatted"
+
+# Move revision (double green underline/strikethrough)
+officecli add "$FILE" '/body/p[1]' --type run --prop trackChange=moveFrom --prop trackChange.author=AI --prop text="moved text"
+officecli add "$FILE" '/body/p[2]' --type run --prop trackChange=moveTo --prop trackChange.author=AI --prop text="moved text"
+
+# Paragraph-level format revision
+officecli add "$FILE" /body --type paragraph --prop trackChange=format --prop trackChange.author=AI --prop text="reformatted paragraph"
+
+# Toggle Track Changes mode (new edits auto-tracked in Word)
+officecli set "$FILE" / --prop trackRevisions=true
+```
+
+**Revision workflow.** Typical pattern: enable tracking → make changes → query → accept/reject.
+
+```bash
+# 1. See what revisions exist
+officecli query "$FILE" revision
+
+# 2. Accept or reject all
+officecli set "$FILE" / --prop acceptallchanges=all
+officecli set "$FILE" / --prop rejectallchanges=all
+```
+
+**trackChange properties:**
+
+| Property | Values | Scope |
+|----------|--------|-------|
+| `trackChange` | `ins`, `del`, `format`, `moveFrom`, `moveTo` | add run/paragraph |
+| `trackChange.author` | Any string | add run/paragraph |
+| `trackChange.date` | ISO 8601 (default: now) | add run/paragraph |
+| `trackChange.id` | Integer (default: auto) | add run/paragraph |
+
+Add a comment with `add "/body/p[4]" --type comment --prop author=... --prop text=...`. Reply threading (`parentId`) and `done=true` resolution are UNSUPPORTED — see C-D-2 / C-D-5 for `raw-set` workarounds.
 
 **Watermark.** Two steps because `add --prop opacity=...` is UNSUPPORTED (C-D-7): `add / --type watermark --prop text="DRAFT" --prop color=BFBFBF`, then `set /watermark --prop opacity=0.8`. Default opacity is 0.5.
 
@@ -476,7 +521,7 @@ Three tiers of precision; use the lowest that does the job.
 
 - **L1 — high-level props** (`--prop text=...`, `--prop style=Heading1`): your default. Works for 80% of cases.
 - **L2 — dotted-attr fallback** (`pbdr.top=`, `ind.left=`, `padding.top=`, `border.*`, `font.size=`, `font.color=`): when L1 lacks the exact knob. Schema-safe for most props. Example: `--prop pbdr.bottom="single;6;1F4E79;0"`. Prefer this over raw-set when the whitelist covers your need. **Two dotted props emit invalid XML today** — `shd.fill=` (missing `w:val`) and `ind.firstLine=` (placed after `w:jc` in `pPr`). Use the canonical L1 form of these instead: `shd=clear;FFFF00` and `firstLineIndent=360`. See Known Issues → Schema-invalid-on-emit.
-- **L3 — `raw-set` with XML**: last resort. Tied to OOXML knowledge; no schema protection. Use for tracked-change creation, internal hyperlinks, composite PAGE+NUMPAGES, comment `parentId`, `commentsExtended` `done=1`.
+- **L3 — `raw-set` with XML**: last resort. Tied to OOXML knowledge; no schema protection. Use for internal hyperlinks, composite PAGE+NUMPAGES, comment `parentId`, `commentsExtended` `done=1`.
 
 Borders go through the format `style;size;color;space`: `single;4;FF0000;1`. Hex colors never start with `#`: `FF0000`, not `#FF0000`. Scheme color names (`accent1..6`, `dark1`/`dark2`, `light1`/`light2`, `hyperlink`) are also accepted anywhere a hex color is (1.0.60+) — prefer hex when you need stable colors across themes.
 


### PR DESCRIPTION
## What

Add Track Changes / Revision Mode documentation to two skill files so AI agents can discover and correctly use `--prop trackChange=ins/del/format/moveFrom/moveTo`.

### `skills/officecli-docx/SKILL.md`

Add a "Track Changes" section explaining:
- `trackChange` properties and their values
- The **in-place revision workflow** (find → remove → add ins → add del) — critical because bare `add run --prop trackChange=del/ins` appends to paragraph end, duplicating text
- Cross-run text handling: `find` only matches within a single run; read `get --depth 2` first to see run boundaries, then find the minimal unique portion
- `query revision` for verification
- `trackRevisions=true/false`, `acceptallchanges=all`, `rejectallchanges=all`

### `SKILL.md` (root)

Add the same "Track Changes / Revision Mode" section as a top-level chapter, mirroring the word-skill content for agents that only load the root SKILL.md.

## Why

Without documentation, AI agents do not know `--prop trackChange` exists. In AionUI, agents fall back to `python-docx` or `unpack/pack + raw XML` for revision tasks, producing broken OOXML (missing namespaces, lost text, duplicate content).

## Validation

```bash
# An AI agent (e.g. in AionUI) should be able to perform in-place
# tracked changes by following the documented workflow:

officecli open contract.docx

# Step 0: read run structure
officecli get contract.docx "/body/p[3]" --depth 2
# → r[1]="甲方应在【" r[2]="8" r[3]="】小时内..."

# Step 1: isolate target (find matches within single run)
officecli set contract.docx "/body/p[3]" --prop find="8" --prop color=auto

# Step 2: remove original unmarked run
officecli remove contract.docx "/body/p[3]/r[2]"

# Step 3: add ins after preceding run
officecli add contract.docx "/body/p[3]" --type run \
  --after "/body/p[3]/r[1]" \
  --prop trackChange=ins --prop trackChange.author=AI --prop text="4"

# Step 4: add del after preceding run
officecli add contract.docx "/body/p[3]" --type run \
  --after "/body/p[3]/r[1]" \
  --prop trackChange=del --prop trackChange.author=AI --prop text="8"

# Verify
officecli query contract.docx revision
# → lists revision with type=ins, author=AI
```

**Screenshot (HTML preview showing rendered revisions):**

![track-changes-rendering](https://github.com/NextDoorLaoHuang-HF/OfficeCLI/releases/download/pr-screenshots-trackchanges/trackchanges-pr-screenshot.png)

## Scope

- `SKILL.md` — add Track Changes section (~110 lines)
- `skills/officecli-docx/SKILL.md` — add Track Changes section (~47 lines)