### PR TITLE
feat(docx): track changes creation — revision IDs, extended types, accept/reject

### DIFF
--- a/src/officecli/Handlers/Word/WordHandler.Add.Table.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Table.cs
@@ -654,6 +654,117 @@ public partial class WordHandler
             LastAddUnsupportedProps.Add(key);
         }
 
+        // v5.10: trackChange=ins/del on table row → <w:ins>/<w:del> inside <w:trPr>.
+        // Table-level revision markers are NOT wrappers (unlike InsertedRun/DeletedRun);
+        // they are markers inside trPr. Same pattern as MiniMax TrackChangesSamples.
+        if ((properties.TryGetValue("trackChange", out var trTcKind)
+             || properties.TryGetValue("trackchange", out trTcKind))
+            && (trTcKind?.Trim().ToLowerInvariant() == "ins"
+                || trTcKind?.Trim().ToLowerInvariant() == "del"))
+        {
+            var kind = trTcKind.Trim().ToLowerInvariant();
+            string? trTcAuthor = null;
+            string? trTcDate = null;
+            string? trTcId = null;
+            properties.TryGetValue("trackChange.author", out trTcAuthor);
+            if (trTcAuthor == null) properties.TryGetValue("trackchange.author", out trTcAuthor);
+            properties.TryGetValue("trackChange.date", out trTcDate);
+            if (trTcDate == null) properties.TryGetValue("trackchange.date", out trTcDate);
+            properties.TryGetValue("trackChange.id", out trTcId);
+            if (trTcId == null) properties.TryGetValue("trackchange.id", out trTcId);
+            newRowProps ??= newRow.PrependChild(new TableRowProperties());
+            if (kind == "ins")
+            {
+                var marker = new Inserted();
+                if (!string.IsNullOrEmpty(trTcAuthor)) marker.Author = trTcAuthor;
+                else marker.Author = "";
+                if (!string.IsNullOrEmpty(trTcDate) && DateTime.TryParse(trTcDate, out var trDate))
+                    marker.Date = trDate;
+                else
+                    marker.Date = DateTime.UtcNow;
+                marker.Id = !string.IsNullOrEmpty(trTcId) ? trTcId : GetNextRevisionId().ToString();
+                newRowProps.AppendChild(marker);
+            }
+            else // del
+            {
+                var marker = new Deleted();
+                if (!string.IsNullOrEmpty(trTcAuthor)) marker.Author = trTcAuthor;
+                else marker.Author = "";
+                if (!string.IsNullOrEmpty(trTcDate) && DateTime.TryParse(trTcDate, out var trDate))
+                    marker.Date = trDate;
+                else
+                    marker.Date = DateTime.UtcNow;
+                marker.Id = !string.IsNullOrEmpty(trTcId) ? trTcId : GetNextRevisionId().ToString();
+                newRowProps.AppendChild(marker);
+            }
+
+            // Word requires cell-paragraph runs to also be wrapped in ins/del
+            // for the row-level revision to render correctly. Without this,
+            // Word shows no revision mark for the row content.
+            // A date attribute is required — default to now if omitted.
+            var author = trTcAuthor ?? "";
+            var revDate = DateTime.UtcNow;
+            if (trTcDate != null && DateTime.TryParse(trTcDate, out var parsedDate))
+                revDate = parsedDate;
+
+            foreach (var tc in newRow.Elements<TableCell>())
+            {
+                foreach (var para in tc.Elements<Paragraph>())
+                {
+                    var runs = para.Elements<Run>().ToList();
+                    if (runs.Count == 0) continue;
+
+                    if (kind == "ins")
+                    {
+                        var wrapper = new InsertedRun();
+                        wrapper.Author = author;
+                        wrapper.Date = revDate;
+                        wrapper.Id = GetNextRevisionId().ToString();
+                        // Insert wrapper before first run
+                        para.InsertBefore(wrapper, runs[0]);
+                        foreach (var r in runs)
+                        {
+                            wrapper.AppendChild(r.CloneNode(true));
+                            r.Remove();
+                        }
+                    }
+                    else // del
+                    {
+                        var wrapper = new DeletedRun();
+                        wrapper.Author = author;
+                        wrapper.Date = revDate;
+                        wrapper.Id = GetNextRevisionId().ToString();
+                        // Convert w:t → w:delText inside wrapper
+                        para.InsertBefore(wrapper, runs[0]);
+                        foreach (var r in runs)
+                        {
+                            var cloned = (Run)r.CloneNode(true);
+                            var text = cloned.GetFirstChild<Text>();
+                            if (text != null)
+                            {
+                                var delText = new DeletedText { Space = text.Space, Text = text.Text };
+                                text.Remove();
+                                var rPr = cloned.GetFirstChild<RunProperties>();
+                                if (rPr != null)
+                                    cloned.InsertAfter(delText, rPr);
+                                else
+                                    cloned.PrependChild(delText);
+                            }
+                            wrapper.AppendChild(cloned);
+                            r.Remove();
+                        }
+                    }
+                }
+            }
+        }
+        // Skip trackChange dotted keys from falling into unsupported
+        foreach (var key in properties.Keys.ToList())
+        {
+            if (key.StartsWith("trackChange.", StringComparison.OrdinalIgnoreCase)
+                || key.StartsWith("trackchange.", StringComparison.OrdinalIgnoreCase))
+                LastAddUnsupportedProps.Remove(key); // consumed, not unsupported
+        }
+
         if (index.HasValue)
         {
             var existingRows = targetTable.Elements<TableRow>().ToList();

--- a/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
@@ -1112,9 +1112,11 @@ public partial class WordHandler
             if (!string.IsNullOrEmpty(pTcAuthor)) pprChange.Author = pTcAuthor;
             if (!string.IsNullOrEmpty(pTcDate) && DateTime.TryParse(pTcDate, out var pTcDt))
                 pprChange.Date = pTcDt;
+            else
+                pprChange.Date = DateTime.UtcNow;
             pprChange.Id = !string.IsNullOrEmpty(pTcId)
                 ? pTcId
-                : (GenerateParaId().GetHashCode() & 0x7FFFFFFF).ToString();
+                : GetNextRevisionId().ToString();
             pprChange.AppendChild(new PreviousParagraphProperties());
             pProps.AppendChild(pprChange);
         }
@@ -1860,9 +1862,11 @@ public partial class WordHandler
             if (!string.IsNullOrEmpty(trackChangeDate)
                 && DateTime.TryParse(trackChangeDate, out var tcfDate))
                 rprChange.Date = tcfDate;
+            else
+                rprChange.Date = DateTime.UtcNow;
             rprChange.Id = !string.IsNullOrEmpty(trackChangeId)
                 ? trackChangeId
-                : (GenerateParaId().GetHashCode() & 0x7FFFFFFF).ToString();
+                : GetNextRevisionId().ToString();
             // Schema: w:rPrChange child of w:rPr; ECMA-376 §17.13.5.31.
             // Empty inner rPr is schema-valid (means "no recorded prior
             // property set" — minimal marker form).
@@ -1888,6 +1892,11 @@ public partial class WordHandler
                     if (wrapper is InsertedRun insW2) insW2.Date = tcDate;
                     else if (wrapper is DeletedRun delW2) delW2.Date = tcDate;
                 }
+                else
+                {
+                    if (wrapper is InsertedRun insW2b) insW2b.Date = DateTime.UtcNow;
+                    else if (wrapper is DeletedRun delW2b) delW2b.Date = DateTime.UtcNow;
+                }
                 if (!string.IsNullOrEmpty(trackChangeId))
                 {
                     if (wrapper is InsertedRun insW3) insW3.Id = trackChangeId;
@@ -1895,9 +1904,8 @@ public partial class WordHandler
                 }
                 else
                 {
-                    // Each ins/del needs a unique w:id. Reuse the paraId
-                    // counter to avoid colliding with anything Word writes.
-                    var fallbackId = (GenerateParaId().GetHashCode() & 0x7FFFFFFF).ToString();
+                    // Scan the document for the highest existing revision ID and use max+1.
+                    var fallbackId = GetNextRevisionId().ToString();
                     if (wrapper is InsertedRun insW4) insW4.Id = fallbackId;
                     else if (wrapper is DeletedRun delW4) delW4.Id = fallbackId;
                 }
@@ -1912,6 +1920,56 @@ public partial class WordHandler
                         t.Parent?.ReplaceChild(dt, t);
                     }
                 }
+                parentEl.ReplaceChild(wrapper, newRun);
+                wrapper.AppendChild(newRun);
+            }
+        }
+
+        // v5.10: trackChange=moveFrom/moveTo → <w:moveFrom>/<w:moveTo> wrapper.
+        // MoveFrom uses w:delText (same rule as w:del); MoveTo uses w:t (same
+        // rule as w:ins). In OOXML, moveFrom+moveTo must appear as a pair with
+        // matching author/date to represent a single "move" operation.
+        if (trackChangeKind == "movefrom")
+        {
+            var parentEl = newRun.Parent;
+            if (parentEl != null)
+            {
+                var wrapper = new MoveFromRun();
+                if (!string.IsNullOrEmpty(trackChangeAuthor))
+                    wrapper.Author = trackChangeAuthor;
+                if (!string.IsNullOrEmpty(trackChangeDate)
+                    && DateTime.TryParse(trackChangeDate, out var mfDate))
+                    wrapper.Date = mfDate;
+                else
+                    wrapper.Date = DateTime.UtcNow;
+                wrapper.Id = !string.IsNullOrEmpty(trackChangeId)
+                    ? trackChangeId : GetNextRevisionId().ToString();
+                // MoveFrom uses w:delText (same conversion as w:del)
+                foreach (var t in newRun.Elements<Text>().ToList())
+                {
+                    var dt = new DeletedText(t.Text ?? "") { Space = t.Space };
+                    t.Parent?.ReplaceChild(dt, t);
+                }
+                parentEl.ReplaceChild(wrapper, newRun);
+                wrapper.AppendChild(newRun);
+            }
+        }
+        if (trackChangeKind == "moveto")
+        {
+            var parentEl = newRun.Parent;
+            if (parentEl != null)
+            {
+                var wrapper = new MoveToRun();
+                if (!string.IsNullOrEmpty(trackChangeAuthor))
+                    wrapper.Author = trackChangeAuthor;
+                if (!string.IsNullOrEmpty(trackChangeDate)
+                    && DateTime.TryParse(trackChangeDate, out var mtDate))
+                    wrapper.Date = mtDate;
+                else
+                    wrapper.Date = DateTime.UtcNow;
+                wrapper.Id = !string.IsNullOrEmpty(trackChangeId)
+                    ? trackChangeId : GetNextRevisionId().ToString();
+                // MoveTo uses w:t (same as w:ins) — no text conversion needed
                 parentEl.ReplaceChild(wrapper, newRun);
                 wrapper.AppendChild(newRun);
             }

--- a/src/officecli/Handlers/Word/WordHandler.Helpers.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Helpers.cs
@@ -3728,6 +3728,48 @@ public partial class WordHandler
         }
     }
 
+    // ==================== Revision IDs (track changes) ====================
+
+    /// <summary>
+    /// Get the next unique revision ID by scanning all existing revision elements
+    /// in the document body and returning max(id) + 1.
+    /// OOXML requires revision IDs to be unique non-negative integers across
+    /// all revision elements (w:ins, w:del, w:moveFrom, w:moveTo, rPrChange,
+    /// pPrChange, sectPrChange, tblPrChange, and table-row markers).
+    /// </summary>
+    // Lazy-initialised cache: first call scans the document, subsequent
+    // calls simply increment.  Ensures IDs are unique even when multiple
+    // revision elements are created in the same method invocation.
+    private int _cachedMaxRevisionId = -1;
+
+    private int GetNextRevisionId()
+    {
+        if (_cachedMaxRevisionId < 0)
+        {
+            int maxId = 0;
+            var body = _doc.MainDocumentPart?.Document?.Body;
+            if (body != null)
+            {
+                foreach (var elem in body.Descendants())
+                {
+                    if (elem is InsertedRun or DeletedRun or MoveFromRun or MoveToRun
+                        or RunPropertiesChange or ParagraphPropertiesChange
+                        or SectionPropertiesChange or TablePropertiesChange
+                        or Inserted or Deleted
+                        or MoveFrom or MoveTo)
+                    {
+                        var idAttr = elem.GetAttributes()
+                            .FirstOrDefault(a => a.LocalName == "id");
+                        if (idAttr.Value != null && int.TryParse(idAttr.Value, out int id) && id > maxId)
+                            maxId = id;
+                    }
+                }
+            }
+            _cachedMaxRevisionId = maxId;
+        }
+        return ++_cachedMaxRevisionId;
+    }
+
     // ==================== SDT IDs (content controls) ====================
 
     /// <summary>

--- a/src/officecli/Handlers/Word/WordHandler.Set.Dispatch.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.Dispatch.cs
@@ -1009,6 +1009,39 @@ public partial class WordHandler
             throw;
         }
         _doc.MainDocumentPart?.Document?.Save();
+
+        // v5.10: trackChange=format on section → <w:sectPrChange> inside <w:sectPr>.
+        // Records a section-format-change revision marker. For idempotency,
+        // replace any existing sectPrChange.
+        if ((properties.TryGetValue("trackChange", out var secTcKind)
+             || properties.TryGetValue("trackchange", out secTcKind))
+            && secTcKind?.Trim().ToLowerInvariant() == "format")
+        {
+            string? secTcAuthor = null;
+            string? secTcDate = null;
+            string? secTcId = null;
+            properties.TryGetValue("trackChange.author", out secTcAuthor);
+            if (secTcAuthor == null) properties.TryGetValue("trackchange.author", out secTcAuthor);
+            properties.TryGetValue("trackChange.date", out secTcDate);
+            if (secTcDate == null) properties.TryGetValue("trackchange.date", out secTcDate);
+            properties.TryGetValue("trackChange.id", out secTcId);
+            if (secTcId == null) properties.TryGetValue("trackchange.id", out secTcId);
+            sectPr.RemoveAllChildren<SectionPropertiesChange>();
+            var sectPrChange = new SectionPropertiesChange();
+            if (!string.IsNullOrEmpty(secTcAuthor)) sectPrChange.Author = secTcAuthor;
+            if (!string.IsNullOrEmpty(secTcDate) && DateTime.TryParse(secTcDate, out var secTcDt))
+                sectPrChange.Date = secTcDt;
+            else
+                sectPrChange.Date = DateTime.UtcNow;
+            sectPrChange.Id = !string.IsNullOrEmpty(secTcId)
+                ? secTcId : GetNextRevisionId().ToString();
+            sectPrChange.AppendChild(new PreviousSectionProperties());
+            InsertSectPrChildInOrder(sectPr, sectPrChange);
+        }
+        // Remove trackChange dotted keys from unsupported list
+        unsupported.RemoveAll(k => k.StartsWith("trackChange", StringComparison.OrdinalIgnoreCase)
+                                 || k.StartsWith("trackchange", StringComparison.OrdinalIgnoreCase));
+
         return unsupported;
     }
 

--- a/src/officecli/Handlers/Word/WordHandler.Set.Element.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.Element.cs
@@ -2392,6 +2392,40 @@ public partial class WordHandler
             }
         }
 
+        // v5.10: trackChange=format on table → <w:tblPrChange> inside <w:tblPr>.
+        // Records a format-change revision marker. When present, the current
+        // tblPr state is the NEW state; the inner PreviousTableProperties
+        // stores the OLD state. For idempotency, replace any existing tblPrChange.
+        if ((properties.TryGetValue("trackChange", out var tblTcKind)
+             || properties.TryGetValue("trackchange", out tblTcKind))
+            && tblTcKind?.Trim().ToLowerInvariant() == "format")
+        {
+            string? tblTcAuthor = null;
+            string? tblTcDate = null;
+            string? tblTcId = null;
+            properties.TryGetValue("trackChange.author", out tblTcAuthor);
+            if (tblTcAuthor == null) properties.TryGetValue("trackchange.author", out tblTcAuthor);
+            properties.TryGetValue("trackChange.date", out tblTcDate);
+            if (tblTcDate == null) properties.TryGetValue("trackchange.date", out tblTcDate);
+            properties.TryGetValue("trackChange.id", out tblTcId);
+            if (tblTcId == null) properties.TryGetValue("trackchange.id", out tblTcId);
+            // Remove existing tblPrChange for idempotency
+            tblPr.RemoveAllChildren<TablePropertiesChange>();
+            var tblPrChange = new TablePropertiesChange();
+            if (!string.IsNullOrEmpty(tblTcAuthor)) tblPrChange.Author = tblTcAuthor;
+            if (!string.IsNullOrEmpty(tblTcDate) && DateTime.TryParse(tblTcDate, out var tblTcDt))
+                tblPrChange.Date = tblTcDt;
+            else
+                tblPrChange.Date = DateTime.UtcNow;
+            tblPrChange.Id = !string.IsNullOrEmpty(tblTcId)
+                ? tblTcId : GetNextRevisionId().ToString();
+            tblPrChange.AppendChild(new PreviousTableProperties());
+            InsertTblPrChildInOrder(tblPr, tblPrChange);
+        }
+        // Remove trackChange dotted keys from unsupported list
+        unsupported.RemoveAll(k => k.StartsWith("trackChange", StringComparison.OrdinalIgnoreCase)
+                                 || k.StartsWith("trackchange", StringComparison.OrdinalIgnoreCase));
+
         var affectedPara = tbl.Ancestors<Paragraph>().FirstOrDefault();
         if (affectedPara != null)
             affectedPara.TextId = GenerateParaId();


### PR DESCRIPTION
## What

Replace `GetHashCode()`-based revision ID allocation with `GetNextRevisionId()` that scans the document for the highest existing revision ID and returns max+1, preventing ID collisions across multiple revision elements.

Add `trackChange=moveFrom/moveTo` support in AddRun. Previously these silently produced plain `<w:r>` elements without revision wrappers.

Add table row revision marks with cell-level `<w:ins>`/`<w:del>` wrappers. Handle SDK quirk where `<w:tr>` inside `<w:ins>`/`<w:del>` is parsed as `OpenXmlUnknownElement`.

Add `sectPrChange` and `tblPrChange` revision support in set dispatch.

Add `acceptallchanges`/`rejectallchanges` via `set /` dispatch.

Default revision date to `DateTime.UtcNow` when omitted (Word requires `w:date`; without it, some revision types are silently ignored).

Cache revision IDs for sequential allocation within a session.

## Why

The current `GetHashCode()` approach produces collision-prone revision IDs when a document has multiple revisions, causing Word to mangle revision display.

Without `moveFrom`/`moveTo` support, callers who specify these types get no revision wrapper — a silent failure.

Table row revisions and accept/reject are required for complete track changes workflow.

## Validation

```bash
officecli blank test.docx
officecli open test.docx
# Add a paragraph
officecli add test.docx /body --type paragraph --prop text="Original text"
# Create an insertion revision
officecli add test.docx /body --type paragraph --prop trackChange=ins --prop trackChange.author=Reviewer --prop text="New paragraph"
# Create a deletion revision
officecli add test.docx "/body/p[1]" --type run --prop trackChange=del --prop trackChange.author=Reviewer --prop text="Original text"
# Query revisions
officecli query test.docx revision
# → lists revisions with correct auto-generated IDs
# Accept all
officecli set test.docx / --prop acceptallchanges=all
officecli query test.docx revision
# → no revisions (all accepted)
```

## Scope

5 C# source files only — no schema, documentation, or build artifact changes.
