### PR TITLE
fix: add macOS JIT entitlement for CoreCLR hardened runtime

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,9 +71,12 @@ build_config() {
         fi
 
         # Ad-hoc codesign on macOS (required by AppleSystemPolicy).
+        # The JIT entitlement is required for CoreCLR to allocate executable
+        # memory under hardened runtime; without it the process fails with
+        # "Failed to create CoreCLR, HRESULT: 0x80070008".
         # Done on the staged .new copy so the live binary is never mutated in place.
         if [ "$(uname -s)" = "Darwin" ] && [[ "$RID" == osx-* ]]; then
-            codesign -s - -f "$OUTPUT/$NAME.new" 2>/dev/null || true
+            codesign -s - -f --entitlements officecli.entitlements "$OUTPUT/$NAME.new" 2>/dev/null || true
         fi
 
         mv -f "$OUTPUT/$NAME.new" "$OUTPUT/$NAME"

--- a/install.sh
+++ b/install.sh
@@ -159,7 +159,17 @@ chmod +x "$INSTALL_DIR/$BINARY_NAME.new"
 if [ "$(uname -s)" = "Darwin" ]; then
     xattr -d com.apple.quarantine "$INSTALL_DIR/$BINARY_NAME.new" 2>/dev/null || true
     if ! codesign -v --strict "$INSTALL_DIR/$BINARY_NAME.new" 2>/dev/null; then
-        codesign -s - -f "$INSTALL_DIR/$BINARY_NAME.new" 2>/dev/null || true
+        # The JIT entitlement is required for CoreCLR to allocate executable
+        # memory under hardened runtime; without it the process fails with
+        # "Failed to create CoreCLR, HRESULT: 0x80070008".
+        ENTITLEMENTS_URL="https://raw.githubusercontent.com/$REPO/main/officecli.entitlements"
+        ENTITLEMENTS_FILE="/tmp/officecli.entitlements"
+        if curl -fsSL --max-time 10 "$ENTITLEMENTS_URL" -o "$ENTITLEMENTS_FILE" 2>/dev/null; then
+            codesign -s - -f --entitlements "$ENTITLEMENTS_FILE" "$INSTALL_DIR/$BINARY_NAME.new" 2>/dev/null || true
+            rm -f "$ENTITLEMENTS_FILE"
+        else
+            codesign -s - -f "$INSTALL_DIR/$BINARY_NAME.new" 2>/dev/null || true
+        fi
     fi
 fi
 

--- a/officecli.entitlements
+++ b/officecli.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Add `officecli.entitlements` with `com.apple.security.cs.allow-jit`, `allow-unsigned-executable-memory`, and `disable-library-validation`
- Update `build.sh` to pass `--entitlements` during ad-hoc codesign for macOS targets
- Update `install.sh` to download and apply the entitlements file when ad-hoc re-signing

Without the JIT entitlement, CoreCLR cannot allocate executable memory under macOS hardened runtime, causing `Failed to create CoreCLR, HRESULT: 0x80070008` on launch.

Fixes #141