### PR TITLE
fix(xlsx): shift embedded formulas in dataValidation/conditionalFormatting/table on row insert/delete

### DIFF
--- a/src/officecli/Handlers/Excel/ExcelHandler.SheetShift.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.SheetShift.cs
@@ -8,11 +8,12 @@
 // every sheet-level structure that anchors on an A1 ref/sqref/range:
 //
 //   - mergeCells
-//   - conditionalFormatting (sqref list)
-//   - dataValidations (sqref list)
+//   - conditionalFormatting (sqref list + rule <formula> text)
+//   - dataValidations (sqref list + formula1/formula2 text)
 //   - autoFilter (single ref)
 //   - hyperlinks (per-cell anchor)
-//   - table ref + autoFilter ref (in TableDefinitionPart)
+//   - table ref + autoFilter ref + calc-column/totals-row formula text
+//     (in TableDefinitionPart)
 //   - cell formulas (CellFormula.Text and the shared/array CellFormula.Reference)
 //   - workbook-level definedNames text (for refs that target this sheet)
 //
@@ -75,9 +76,15 @@ public partial class ExcelHandler
             if (!mergeCells.HasChildren) mergeCells.Remove();
         }
 
-        // 2. conditionalFormatting sqref
+        // 2. conditionalFormatting sqref + rule formulas
         foreach (var cf in ws.Elements<ConditionalFormatting>().ToList())
         {
+            // cellIs/formula rules carry cell refs inside <formula> (e.g. $C2>5)
+            // that must follow the displacement, same as cell formulas.
+            if (formulaTextMapper != null)
+                foreach (var rule in cf.Elements<ConditionalFormattingRule>())
+                    foreach (var f in rule.Elements<Formula>())
+                        if (!string.IsNullOrEmpty(f.Text)) f.Text = formulaTextMapper(f.Text);
             if (cf.SequenceOfReferences?.HasValue != true) continue;
             var newRefs = cf.SequenceOfReferences.Items
                 .Where(r => r.Value != null)
@@ -93,6 +100,14 @@ public partial class ExcelHandler
         {
             foreach (var dv in dvs.Elements<DataValidation>().ToList())
             {
+                // Relative refs inside the validation formula (e.g. INDIRECT(B2))
+                // must follow the displacement too. Literal lists ("Yes,No") carry
+                // no refs and pass through the shifter unchanged.
+                if (formulaTextMapper != null)
+                {
+                    if (!string.IsNullOrEmpty(dv.Formula1?.Text)) dv.Formula1.Text = formulaTextMapper(dv.Formula1.Text);
+                    if (!string.IsNullOrEmpty(dv.Formula2?.Text)) dv.Formula2.Text = formulaTextMapper(dv.Formula2.Text);
+                }
                 if (dv.SequenceOfReferences?.HasValue != true) continue;
                 var newRefs = dv.SequenceOfReferences.Items
                     .Where(r => r.Value != null)
@@ -149,6 +164,25 @@ public partial class ExcelHandler
                 {
                     tbl.AutoFilter.Reference = shifted;
                     tblDirty = true;
+                }
+            }
+            // Calculated-column and totals-row formulas carry cell refs (e.g.
+            // SUM(B3:B5)) that must follow the displacement. Structured refs
+            // (Table1[Col]) are name-based and pass through the shifter unchanged.
+            if (formulaTextMapper != null && tbl.TableColumns != null)
+            {
+                foreach (var tc in tbl.TableColumns.Elements<TableColumn>())
+                {
+                    if (!string.IsNullOrEmpty(tc.CalculatedColumnFormula?.Text))
+                    {
+                        tc.CalculatedColumnFormula.Text = formulaTextMapper(tc.CalculatedColumnFormula.Text);
+                        tblDirty = true;
+                    }
+                    if (!string.IsNullOrEmpty(tc.TotalsRowFormula?.Text))
+                    {
+                        tc.TotalsRowFormula.Text = formulaTextMapper(tc.TotalsRowFormula.Text);
+                        tblDirty = true;
+                    }
                 }
             }
             if (tblDirty) tbl.Save();


### PR DESCRIPTION
## What

The sheet-shift walker remaps each structure's range/sqref on a row insert/delete, but leaves cell refs inside the structure's *own* formula pointing at the old row. After a row delete this silently breaks three structures (the sqref/ref itself already shifts correctly in all three — only the embedded formula is missed):

- **dataValidation** `formula1`/`formula2` — e.g. `INDIRECT(B2)` cascading dropdowns
- **conditionalFormatting** rule `<formula>` — e.g. `$C2>5` formula/cellIs rules
- **table** `calculatedColumnFormula` / `totalsRowFormula` — e.g. `SUM(B3:B5)` totals

## Fix

Route all three through `formulaTextMapper` in `ExcelHandler.SheetShift.cs` — the same path cell formulas (§7) and defined names (§8) already use. Literal validation lists (`"Yes,No"`) and structured table refs (`Table1[Col]`) carry no A1 refs and pass through the shifter unchanged.

## Validation (before / after)

**(1) dataValidation**
```bash
officecli create t.xlsx
officecli add t.xlsx /Sheet1 --type validation --prop type=list --prop ref=C2:C4 --prop formula1="INDIRECT(B2)"
officecli remove t.xlsx "/Sheet1/row[1]"
officecli get t.xlsx "/Sheet1/dataValidation[1]"
#   before: ref=C1:C3  formula1=INDIRECT(B2)   (wrong)
#   after:  ref=C1:C3  formula1=INDIRECT(B1)   (correct)
```

**(2) conditionalFormatting rule**
```bash
officecli create t.xlsx
officecli add t.xlsx /Sheet1 --type conditionalformatting --prop type=formula --prop formula='$A2>5' --prop ref=A2:A4 --prop fill=FFFF00
officecli remove t.xlsx "/Sheet1/row[1]"
officecli get t.xlsx "/Sheet1/conditionalFormatting[1]/cfRule[1]"
#   before: $A2>5   after: $A1>5
```

**(3) table totals-row formula** (authored with openpyxl — table A2:B6 with `totalsRowFormula=SUM(B3:B5)`, plus a dummy row 1 above it):
```python
from openpyxl import Workbook
from openpyxl.worksheet.table import Table, TableColumn, TableFormula
wb=Workbook(); ws=wb.active
ws['A1']='dummy'; ws['A2']='H1'; ws['B2']='H2'
for i,r in enumerate(range(3,6)): ws[f'A{r}']=i+1; ws[f'B{r}']=(i+1)*10
ws['A6']='Total'; ws['B6']='=SUM(B3:B5)'
ws.add_table(Table(displayName='T1', ref='A2:B6', totalsRowCount=1,
    tableColumns=[TableColumn(id=1,name='H1'),
                  TableColumn(id=2,name='H2',totalsRowFunction='custom',
                              totalsRowFormula=TableFormula(attr_text='SUM(B3:B5)'))]))
wb.save('t.xlsx')
```
```bash
officecli remove t.xlsx "/Sheet/row[1]"
#   table ref A2:B6 -> A1:B5;  totalsRowFormula  before: SUM(B3:B5)  after: SUM(B2:B4)
```

Fixes #143 (also closes the conditionalFormatting-rule and table instances noted in that issue's comments).
