### PR TITLE
fix(excel-html): chart overlays match Excel position and size

### DIFF
--- a/src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.Charts.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.Charts.cs
@@ -22,7 +22,7 @@ public partial class ExcelHandler
     private void RenderSheetCharts(StringBuilder sb, WorksheetPart worksheetPart)
     {
         var charts = CollectSheetCharts(worksheetPart);
-        foreach (var (_, _, _, _, html) in charts)
+        foreach (var (_, _, _, _, _, html) in charts)
             sb.Append(html);
     }
 
@@ -30,9 +30,9 @@ public partial class ExcelHandler
     /// Pre-render all charts and return them with their anchor row/col positions.
     /// Charts with overlapping row ranges are grouped into flex rows.
     /// </summary>
-    private List<(int fromRow, int toRow, int fromCol, int toCol, string html)> CollectSheetCharts(WorksheetPart worksheetPart, string sheetName = "")
+    private List<(int fromRow, int toRow, int fromCol, int toCol, int widthPtHint, string html)> CollectSheetCharts(WorksheetPart worksheetPart, string sheetName = "")
     {
-        var result = new List<(int fromRow, int toRow, int fromCol, int toCol, string html)>();
+        var result = new List<(int fromRow, int toRow, int fromCol, int toCol, int widthPtHint, string html)>();
         var drawingsPart = worksheetPart.DrawingsPart;
         if (drawingsPart?.WorksheetDrawing == null) return result;
 
@@ -62,11 +62,17 @@ public partial class ExcelHandler
         }).OrderBy(x => x.fromRow).ThenBy(x => x.fromCol).ToList();
 
         // Each chart gets its own overlay (no flex grouping) so drag-to-move works independently
+        var anchorColWidths = GetColumnWidths(GetSheet(worksheetPart));
         foreach (var (gf, fromRow, toRow, fromCol, toCol) in chartAnchors)
         {
             var chartSb = new StringBuilder();
             RenderExcelChart(chartSb, gf, drawingsPart, worksheetPart, sheetName, gfIndexMap.GetValueOrDefault(gf));
-            result.Add((fromRow, toRow, fromCol, toCol, chartSb.ToString()));
+            // The overlay box width must match the chart's own EstimateChartSize (the
+            // value behind the chart-container's max-width) — the column-sum used in
+            // the anchor loop drops the partial-column EMU offset, leaving the card
+            // clamped narrower than Excel. Pass the estimate as the box-width hint.
+            var (estWidthPt, _) = EstimateChartSize(gf, anchorColWidths);
+            result.Add((fromRow, toRow, fromCol, toCol, estWidthPt, chartSb.ToString()));
         }
 
         return result;
@@ -180,38 +186,55 @@ public partial class ExcelHandler
         var legendFontPt = 8.0;
         if (!string.IsNullOrEmpty(info.LegendFontSize) && double.TryParse(info.LegendFontSize.Replace("pt", ""), out var lfp))
             legendFontPt = lfp;
-        var legendH = info.HasLegend ? (int)(legendFontPt * 1.6 + 12) : 0;
+        // Legend position drives layout. A left/right legend sits BESIDE the plot
+        // (flex row) — it takes width, not height; top/bottom legends take height.
+        var legendSide = info.HasLegend && info.LegendPos is "r" or "l";
+        var legendTop  = info.HasLegend && info.LegendPos is "t" or "tr";
+        var legendH = (info.HasLegend && !legendSide) ? (int)(legendFontPt * 1.6 + 12) : 0;
         var chartSvgH = svgH - titleH - legendH;
         if (chartSvgH < 80) return;
 
+        // For a side legend, shrink the plot's viewBox to the actual plot area
+        // (full width minus an estimated legend width) so the meet-fit fills the
+        // box without letterboxing.
+        var plotW = svgW;
+        if (legendSide)
+        {
+            var labels = info.ChartType.Contains("pie") || info.ChartType.Contains("doughnut")
+                ? info.Categories : info.Series.Select(s => s.name).ToArray();
+            var maxChars = labels.Length > 0 ? labels.Max(l => (l ?? "").Length) : 6;
+            var legendWpt = (int)((28 + maxChars * 0.5 * legendFontPt * 1.333) * 0.75);
+            plotW = Math.Max(svgW - legendWpt, 160);
+        }
+
         var bgStyle = info.ChartFillColor != null ? $"background:#{info.ChartFillColor};" : "";
-        // Use estimated width as max-width, but allow stretching to fill parent (e.g. colspan td)
         var chartDataPath = chartIdx > 0 && !string.IsNullOrEmpty(sheetName) ? $" data-path=\"/{HtmlEncode(sheetName)}/chart[{chartIdx}]\"" : "";
-        sb.AppendLine($"<div class=\"chart-container\"{chartDataPath} style=\"max-width:max({svgW}pt,100%);flex:1;min-width:200pt;{bgStyle}\">");
+        // height:100% + flex column makes the chart FILL its anchor box: the plot
+        // grows into the height left after the title/legend instead of being sized
+        // from its width alone (which left a gap below the chart).
+        sb.AppendLine($"<div class=\"chart-container\"{chartDataPath} style=\"max-width:max({svgW}pt,100%);flex:1;min-width:200pt;height:100%;display:flex;flex-direction:column;{bgStyle}\">");
 
         var titleColor = info.TitleFontColor != null ? ChartSvgRenderer.CssHexColor(info.TitleFontColor) : "#333";
         if (!string.IsNullOrEmpty(info.Title))
-            sb.AppendLine($"  <div style=\"text-align:center;font-size:{info.TitleFontSize};font-weight:bold;padding:6px 0;color:{titleColor}\">{HtmlEncode(info.Title)}</div>");
+            sb.AppendLine($"  <div style=\"flex-shrink:0;text-align:center;font-size:{info.TitleFontSize};font-weight:bold;padding:6px 0;color:{titleColor}\">{HtmlEncode(info.Title)}</div>");
 
         var legendColor = info.LegendFontColor != null ? ChartSvgRenderer.CssHexColor(info.LegendFontColor) : "#555";
-        // Legend position drives the plot+legend container layout, mirroring the
-        // Word path. right="r" → row, legend after plot; left="l" → row, legend
-        // before; top="t"/"tr" → column, legend before; bottom (default) → below.
-        var legendSide = info.HasLegend && info.LegendPos is "r" or "l";
-        var legendTop  = info.HasLegend && info.LegendPos is "t" or "tr";
 
         if (legendTop)
             renderer.RenderLegendHtml(sb, info, legendColor);
 
+        // The plot area takes the remaining height (flex:1). Side legends wrap it
+        // in a row [plot | legend]; otherwise the plot fills directly.
         if (legendSide)
         {
             var flexDir = info.LegendPos == "l" ? "row-reverse" : "row";
-            sb.AppendLine($"  <div style=\"display:flex;flex-direction:{flexDir};align-items:center;gap:8px\">");
+            sb.AppendLine($"  <div style=\"flex:1;min-height:0;display:flex;flex-direction:{flexDir};align-items:center;gap:8px\">");
         }
 
-        sb.AppendLine($"  <svg viewBox=\"0 0 {svgW} {chartSvgH}\" style=\"width:100%;height:auto\" preserveAspectRatio=\"xMidYMin meet\">");
+        var svgFill = legendSide ? "flex:1;min-width:0;height:100%" : "flex:1;min-height:0;width:100%";
+        sb.AppendLine($"  <svg viewBox=\"0 0 {plotW} {chartSvgH}\" style=\"{svgFill}\" preserveAspectRatio=\"xMidYMid meet\">");
 
-        renderer.RenderChartSvgContent(sb, info, svgW, chartSvgH);
+        renderer.RenderChartSvgContent(sb, info, plotW, chartSvgH);
 
         sb.AppendLine("  </svg>");
 
@@ -253,10 +276,13 @@ public partial class ExcelHandler
         var fromRowOff = long.TryParse(from.RowOffset?.Text, out var fro) ? fro : 0;
         var toRowOff = long.TryParse(to.RowOffset?.Text, out var tro) ? tro : 0;
 
-        // Sum actual column widths; fall back to 48pt for columns without explicit width
+        // Sum actual column widths; fall back to the grid's default column width
+        // (8.43 chars * 7.0017 px/char * 0.75 px→pt ≈ 44.27pt / 59px) for columns
+        // without an explicit width — matching how the grid renders them and how
+        // Excel positions the chart. (A 48pt fallback over-widened it ~half a column.)
         double totalWidth = 0;
         for (int c = fromCol + 1; c <= toCol; c++)
-            totalWidth += (colWidths != null && colWidths.TryGetValue(c, out var w)) ? w : 48.0;
+            totalWidth += (colWidths != null && colWidths.TryGetValue(c, out var w)) ? w : 8.43 * 7.0017 * 0.75;
         totalWidth += (toColOff - fromColOff) / EmuConverter.EmuPerPointF;
 
         // Default row height ~15pt; offsets in EMU (1pt = 12700 EMU)

--- a/src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.Pictures.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.Pictures.cs
@@ -21,9 +21,9 @@ public partial class ExcelHandler
     /// existing overlay positioning code can consume the result). The image
     /// part is inlined as a data: URI.
     /// </summary>
-    private List<(int fromRow, int toRow, int fromCol, int toCol, string html)> CollectSheetPictures(WorksheetPart worksheetPart)
+    private List<(int fromRow, int toRow, int fromCol, int toCol, int widthPtHint, string html)> CollectSheetPictures(WorksheetPart worksheetPart)
     {
-        var result = new List<(int fromRow, int toRow, int fromCol, int toCol, string html)>();
+        var result = new List<(int fromRow, int toRow, int fromCol, int toCol, int widthPtHint, string html)>();
         var drawingsPart = worksheetPart.DrawingsPart;
         if (drawingsPart?.WorksheetDrawing == null) return result;
 
@@ -59,7 +59,8 @@ public partial class ExcelHandler
 
             var sb = new StringBuilder();
             sb.Append($"<img class=\"xlsx-picture\" src=\"{dataUri}\" style=\"position:absolute;inset:0;width:100%;height:100%;object-fit:contain;pointer-events:none\"/>");
-            result.Add((fromRow, toRow, fromCol, toCol, sb.ToString()));
+            // 0 = no width hint; the overlay loop falls back to its column-sum.
+            result.Add((fromRow, toRow, fromCol, toCol, 0, sb.ToString()));
         }
 
         return result;

--- a/src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.Shapes.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.Shapes.cs
@@ -22,9 +22,9 @@ public partial class ExcelHandler
     /// anchor row/col positions (same tuple shape as CollectSheetCharts so the
     /// existing overlay positioning code can consume the result).
     /// </summary>
-    private List<(int fromRow, int toRow, int fromCol, int toCol, string html)> CollectSheetShapes(WorksheetPart worksheetPart)
+    private List<(int fromRow, int toRow, int fromCol, int toCol, int widthPtHint, string html)> CollectSheetShapes(WorksheetPart worksheetPart)
     {
-        var result = new List<(int fromRow, int toRow, int fromCol, int toCol, string html)>();
+        var result = new List<(int fromRow, int toRow, int fromCol, int toCol, int widthPtHint, string html)>();
         var drawingsPart = worksheetPart.DrawingsPart;
         if (drawingsPart?.WorksheetDrawing == null) return result;
 
@@ -60,7 +60,8 @@ public partial class ExcelHandler
 
             var sb = new StringBuilder();
             RenderShape(sb, shape);
-            result.Add((fromRow, toRow, fromCol, toCol, sb.ToString()));
+            // 0 = no width hint; the overlay loop falls back to its column-sum.
+            result.Add((fromRow, toRow, fromCol, toCol, 0, sb.ToString()));
         }
 
         return result;

--- a/src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.cs
@@ -728,7 +728,11 @@ public partial class ExcelHandler
             if (ctx.HiddenRows.Contains(r)) { sb.AppendLine($"<tr data-row=\"{ctx.SheetIdx}-{r}\" style=\"display:none\"></tr>"); continue; }
             bool isRowFrozen = ctx.FrozenRows > 0 && r <= ctx.FrozenRows;
             var rowStyles = new List<string>();
-            if (ctx.RowHeights.TryGetValue(r, out var rh)) rowStyles.Add($"height:{rh:0.##}pt");
+            // Every row gets a height (explicit, else the sheet default ~15pt) so
+            // empty rows don't collapse — matching Excel and keeping the grid's row
+            // positions consistent with the chart anchor math (which uses the same).
+            var rh = ctx.RowHeights.TryGetValue(r, out var explicitRh) ? explicitRh : ctx.DefaultRowHeightPt;
+            rowStyles.Add($"height:{rh:0.##}pt");
             if (isRowFrozen) rowStyles.Add("background:#fff");
             var rowStyle = rowStyles.Count > 0 ? $" style=\"{string.Join(";", rowStyles)}\"" : "";
             var frozenAttr = isRowFrozen ? " data-frozen=\"1\"" : "";
@@ -3924,7 +3928,7 @@ public partial class ExcelHandler
                via the :first-child rules below. Scoped to table:not(.no-grid) so
                sheets with showGridLines=false suppress the default gridlines while
                still honouring explicit OOXML cell borders (inline styles). */
-            padding: 2px 4px;
+            padding: 1px 4px;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;

--- a/src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.cs
@@ -3971,7 +3971,10 @@ public partial class ExcelHandler
         }
         /* Chart containers */
         .chart-container {
-            margin: 16px auto;
+            /* No margin: charts are absolutely positioned inside their anchor box,
+               so any margin offsets the visible card off its cell anchor (it landed
+               a row low) and overflows the box bottom. */
+            margin: 0;
             background: #fff;
             border: 1px solid #e0e0e0;
             border-radius: 6px;

--- a/src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.cs
@@ -270,7 +270,7 @@ public partial class ExcelHandler
     // ==================== Sheet Rendering ====================
 
     private void RenderSheetTable(StringBuilder sb, string sheetName, WorksheetPart worksheetPart, Stylesheet? stylesheet,
-        List<(int fromRow, int toRow, int fromCol, int toCol, string html)>? charts = null, int sheetIdx = 0,
+        List<(int fromRow, int toRow, int fromCol, int toCol, int widthPtHint, string html)>? charts = null, int sheetIdx = 0,
         bool showGridLines = true)
     {
         var ws = GetSheet(worksheetPart);
@@ -369,7 +369,7 @@ public partial class ExcelHandler
         // Extend maxRow/maxCol from chart anchors even when no cell data
         if (charts != null)
         {
-            foreach (var (fromRow, toRow, fromCol, toCol, _) in charts)
+            foreach (var (fromRow, toRow, fromCol, toCol, _, _) in charts)
             {
                 if (toRow > maxRow) maxRow = toRow;
                 if (toCol > maxCol) maxCol = toCol;
@@ -414,7 +414,7 @@ public partial class ExcelHandler
 
         // Extend maxRow/maxCol to include chart anchor ranges
         if (charts != null)
-            foreach (var (_, toRow, fromCol, toCol, _) in charts)
+            foreach (var (_, toRow, fromCol, toCol, _, _) in charts)
             {
                 if (toCol > maxCol) maxCol = toCol;
                 if (toRow > maxRow) maxRow = toRow;
@@ -529,7 +529,7 @@ public partial class ExcelHandler
         // Build chart lookup: fromRow → chart info for inline insertion
         var chartAtRow = new Dictionary<int, (int toRow, int fromCol, int toCol, string html)>();
         if (charts != null)
-            foreach (var (fromRow, toRow, fromCol, toCol, html) in charts)
+            foreach (var (fromRow, toRow, fromCol, toCol, _, html) in charts)
                 chartAtRow[fromRow] = (toRow, fromCol, toCol, html);
 
         // Compute total table width so the table sizes to its content (not the wrapper).
@@ -607,7 +607,7 @@ public partial class ExcelHandler
         if (charts != null)
         {
             var rowHeaderWidthPt = 30.0; // matches .row-header-col CSS
-            foreach (var (fromRow, toRow, fromCol, toCol, html) in charts)
+            foreach (var (fromRow, toRow, fromCol, toCol, widthPtHint, html) in charts)
             {
                 // Compute left position: sum of column widths from col 1 to fromCol + row header
                 double leftPt = rowHeaderWidthPt;
@@ -651,8 +651,13 @@ public partial class ExcelHandler
                     if (widthPt < 1) widthPt = defaultColWidthPt;
                     if (heightPt < 1) heightPt = defaultRowHeightPt;
                 }
+                // Charts supply their EstimateChartSize width (which includes the
+                // partial-column EMU offset this column-sum drops); honour it so the
+                // card matches Excel's width instead of being clamped a column short.
+                // Pictures/shapes pass 0, so this only affects charts.
+                if (widthPtHint > 0) widthPt = widthPtHint;
 
-                sb.AppendLine($"<div style=\"position:absolute;left:{leftPt:0.##}pt;top:{topPt:0.##}pt;width:{widthPt:0.##}pt;height:{heightPt:0.##}pt;z-index:10;pointer-events:auto\" data-from-col=\"{fromCol}\" data-from-row=\"{fromRow}\">");
+                sb.AppendLine($"<div style=\"position:absolute;left:{leftPt:0.##}pt;top:{topPt:0.##}pt;width:{widthPt:0.##}pt;height:{heightPt:0.##}pt;z-index:10;pointer-events:auto;display:flex\" data-from-col=\"{fromCol}\" data-from-row=\"{fromRow}\">");
                 sb.Append(html);
                 sb.AppendLine("</div>");
             }


### PR DESCRIPTION
Fixes #160

The HTML preview (`view <file> html`) renders charts/shapes/pictures as absolutely-positioned overlays on the sheet grid. Comparing the output to Excel surfaced three position/size issues, fixed here as three atomic commits:

**1. Chart overlays don't fill their anchor box, and render ~a column too narrow.**
The card was sized from its width alone (the inner SVG used `height:auto`), so the plot never grew into the height left below the title — leaving an empty gap under the chart. And the overlay box width summed whole spanned columns but dropped the partial-column EMU offset, while `EstimateChartSize` fell back to 48pt (64px) for default columns instead of the grid's ~44.27pt (59px) — together clamping the card ~one column narrower than Excel. The card is now a flex column (`height:100%`) that fills the box, and the box is sized from the chart's own `EstimateChartSize` (offset included, grid-aligned column metric).

**2. Default/empty rows collapse below Excel's 15pt height.**
Rows without an explicit height got no height attribute, so the grid let them shrink to content — empty rows ~17px and 11pt data rows ~22px, vs Excel's 15pt (~20px). That distorts the grid and drifts it out of step with the overlay anchor math. Every row now gets the explicit-or-default height; cell padding is trimmed (2px→1px) so default 11pt rows land on 15pt. Rows with an explicit/auto-fit height (rotated text, large fonts) keep their value.

**3. Stale `.chart-container` margin offsets the overlay a row low.**
`.chart-container` carried `margin: 16px auto` from an older in-flow layout. With charts now absolutely positioned, that top margin pushed each visible card down ~16px (to the bottom of its anchor row) and overflowed the box bottom. Set to `margin: 0`.

**Validation.** Rendered a multi-sheet workbook (charts, conditional formatting, sparklines, rich formatting, formulas, pivot) and compared to Excel. A 480px chart now renders ~444px ending mid-column-N (was clamped a column short); every gallery chart sits exactly on its anchor row (top + bottom); default grid rows are 20px (were 17/22px). No regressions across CF (color scales, data bars, icon sets), sparklines, rotation/number-formats/merges, formulas, or the pivot cross-tab.

The three commits are independent and can be split into separate PRs if you prefer one atomic fix per PR — happy to do that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

