### PR TITLE
fix(pptx/xlsx/docx): notify watch SSE after resident batch edits

### DIFF
--- a/src/officecli/ResidentServer.cs
+++ b/src/officecli/ResidentServer.cs
@@ -1044,6 +1044,18 @@ public class ResidentServer : IDisposable
     // (and batch failure rows are written to stdout).
     private bool _lastBatchHadFailure;
 
+    // Batch verbs that never mutate the DOM. ExecuteBatch notifies any live
+    // watch session after applying the items — parity with the per-verb
+    // NotifyWatch* calls in ExecuteCommand (issue #169). A batch made up
+    // entirely of these read-only verbs skips the full-refresh to avoid a
+    // needless re-render + SSE push. Any verb NOT listed here (including
+    // unknown / future ones) fails open to "notify", so a new mutating verb
+    // is never silently dropped from the preview.
+    private static readonly HashSet<string> ReadOnlyBatchVerbs = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "get", "query", "view", "validate", "dump", "raw"
+    };
+
     private void ExecuteBatch(ResidentRequest request)
     {
         _lastBatchHadFailure = false;
@@ -1143,6 +1155,18 @@ public class ResidentServer : IDisposable
         // as the single-shot resident add/set path (EmitUnrecognizedLatex) does.
         foreach (var tok in batchUnrecognizedLatex)
             Console.Error.WriteLine($"  WARNING: {UnrecognizedLatexMarker} {tok}");
+
+        // Notify any live watch session so the preview reflects the batch.
+        // Single add/set/move/remove/etc. each call a NotifyWatch* helper in
+        // ExecuteCommand; batch applied its items directly above and must do
+        // the same, otherwise the watched DOM stays stale until the watch is
+        // manually restarted (issue #169). A batch can span many
+        // slides/sheets/pages with mixed verbs, so a targeted per-slide patch
+        // isn't derivable — a full refresh mirrors swap / refresh / raw-set /
+        // add-part. Skip only provably read-only batches to avoid a needless
+        // re-render; unknown verbs fail open to notify.
+        if (items.Any(it => !ReadOnlyBatchVerbs.Contains(it.Command ?? "")))
+            NotifyWatchFullRefresh();
     }
 
     // ==================== Watch notification helpers ====================


### PR DESCRIPTION
Fixes #169.

## Problem

When `officecli watch <file>` is running, single-command edits (`add`/`set`/`move`/`remove`) live-update the preview via SSE content patches, but **`batch` edits emit no content patch** — the preview stays stale until the watch is restarted.

## Root cause

`ResidentServer.ExecuteBatch` applied its items via `CommandBuilder.ApplyBatchItems(...)` and returned **without calling any `NotifyWatch*` helper**. Every other mutating verb calls a `NotifyWatch*` helper in `ExecuteCommand` after mutating (`add`/`set`/`move`/`remove`/`swap`/`refresh`/`raw-set`/`add-part`); `batch` was the lone exception.

The standalone (non-resident) batch path already notifies (`CommandBuilder.Batch.cs`), so the resident path simply lacked parity.

## Fix

Call `NotifyWatchFullRefresh()` at the end of `ResidentServer.ExecuteBatch`, mirroring `swap`/`refresh`/`raw-set`/`add-part` — those verbs likewise can't derive a single per-slide patch from a broad edit, so a full re-render is the established shape. A batch can span mixed verbs across many slides/sheets/pages, so a targeted patch isn't derivable.

Gated to skip provably **read-only** batches (`get`/`query`/`view`/`validate`/`dump`/`raw`) so a pure-read batch doesn't trigger a needless re-render + SSE push. Any verb not in that set (including unknown / future ones) **fails open to notify**, so a new mutating verb is never silently dropped from the preview.

## Verification (issue #169 repro, `osx-arm64`, v1.0.128)

| batch | before | after |
|---|---|---|
| write (`add`) | no content action | emits `full` ✓ |
| read-only (`get` + `query`) | — | no content action (no needless refresh) ✓ |

SSE event order confirmed: `selection-update → mark-update → replace (single add) → full (batch)`.

Patch is +24 lines, single file, additive only (a notify call + the read-only-verb set); no existing behavior changed.
