### PR TITLE
docs: add CodeAlmanac wiki

### DIFF
--- a/almanac/README.md
+++ b/almanac/README.md
@@ -1,0 +1,35 @@
+---
+title: CodeAlmanac Wiki
+topics: [concepts]
+sources: []
+---
+
+# CodeAlmanac Wiki
+
+This is the living wiki for this repository. It records the durable knowledge
+the code cannot say: decisions, flows, invariants, incidents, gotchas, and
+project context that future agents should not rediscover from scratch.
+
+## Notability Bar
+
+Write a page when it preserves non-obvious knowledge that will help a future
+agent work safely in this codebase.
+
+Good pages explain:
+
+- a decision that took research or trial-and-error
+- a cross-file flow
+- an invariant or gotcha not visible from one file
+- an external dependency as this repo uses it
+- a product or operational constraint that shapes future work
+
+Do not write pages that restate nearby code.
+
+## Topic Taxonomy
+
+Topics live in `topics.yaml`. Pages are Markdown files directly under
+`almanac/`, including nested folders.
+
+## Links
+
+Use normal Markdown links between pages. Put file evidence in `sources:`.

--- a/almanac/architecture/agent/mcp-and-skills.md
+++ b/almanac/architecture/agent/mcp-and-skills.md
@@ -1,0 +1,53 @@
+---
+title: "MCP And Skills"
+summary: "OfficeCLI's agent integration combines a single-command MCP server with lazy skill loading so agents use the same CLI grammar and load detailed workflow guidance only when needed."
+topics: [architecture, mcp, skills, agent]
+sources:
+  - id: mcp-server
+    type: file
+    path: src/officecli/McpServer.cs
+  - id: mcp-installer
+    type: file
+    path: src/officecli/McpInstaller.cs
+  - id: skill-installer
+    type: file
+    path: src/officecli/Core/SkillInstaller.cs
+  - id: root-skill
+    type: file
+    path: SKILL.md
+  - id: program
+    type: file
+    path: src/officecli/Program.cs
+---
+
+OfficeCLI's agent layer exposes the CLI to AI tools through MCP and skills. The MCP server advertises one `officecli` tool whose input is a command string or argv array, and skills provide lazy, task-specific guidance for agents before they create or edit Office files. This keeps MCP, terminal usage, and skill examples aligned around the same command grammar [@mcp-server] [@root-skill].
+
+## MCP Server
+
+`officecli mcp` starts a stdio JSON-RPC server. The server implements `initialize`, `tools/list`, `tools/call`, and `ping`, and advertises protocol version `2024-11-05` [@mcp-server]. `Program.cs` handles `mcp` as an early-dispatch command before building the normal CLI root [@program].
+
+The server exposes exactly one tool named `officecli`. A `tools/call` with any other name is rejected, so a misrouted request cannot silently mutate files under a bogus tool name [@mcp-server].
+
+The tool is a thin shell over the CLI. It accepts `command` as either a string or a pre-split argv array, removes an optional leading `officecli`, tokenizes strings without invoking a shell, and invokes the same `System.CommandLine` root as the terminal CLI [@mcp-server]. This is the same design described by [MCP shared CLI root](../runtime/mcp-shared-cli-root): argument validation and command behavior come from the shared root, not from a second MCP-specific command model [@mcp-server].
+
+MCP sets two environment defaults for its process. It defaults `OFFICECLI_NO_AUTO_RESIDENT=1` so a lone MCP command does not auto-spawn a lingering resident, while still routing through an existing resident if one already owns the file. It also defaults `OFFICECLI_BATCH_ALLOW_STDIN_REDIRECT=1` because MCP uses stdin as the JSON-RPC transport and should not warn about redirected stdin on every batch call [@mcp-server].
+
+## Skill Loading
+
+Skills are served through both the CLI and MCP. `Program.cs` treats `load_skill` as a read-only early-dispatch command that prints a catalog, a full skill, or one bundled reference file without installing anything [@program]. The MCP server mirrors that path by intercepting `load_skill`, `skill`, and `skills` before invoking the CLI root, then serving content through `SkillInstaller` [@mcp-server].
+
+`SkillInstaller` owns the available skill map. It maps names such as `pptx`, `word`, `excel`, `morph-ppt`, `pitch-deck`, and `financial-model` to embedded skill folders, builds a catalog with routing descriptions, and appends a reference-file manifest to loaded skill content [@skill-installer].
+
+The root skill is the always-on guide. It tells agents to use OfficeCLI for `.docx`, `.xlsx`, and `.pptx`, to prefer read, DOM edit, and raw XML layers in that order, and to run `load_skill` for specialized document tasks before proceeding [@root-skill].
+
+The MCP tool description includes a compact skill-trigger summary from `SkillInstaller.BuildSkillTriggerSummary`. Full skill text stays lazy behind `load_skill`, which keeps the tool description small while still prompting agents to load the right guide before mutating documents [@mcp-server] [@skill-installer]. The conceptual role is covered by [OfficeCLI skills](../../concepts/officecli-skills) and the bundled skills reference.
+
+## Installation Into Agents
+
+`officecli mcp <target>` registers the MCP server in supported clients. The installer supports LM Studio, Claude Code, Cursor, and VS Code/Copilot targets, and writes each config to launch the stable OfficeCLI path with the `mcp` argument [@mcp-installer].
+
+The MCP installer chooses a stable command path before falling back to the running binary. It prefers the canonical self-install path, then a `PATH` wrapper or symlink, and only then `Environment.ProcessPath`, because versioned binary paths can rot after upgrades [@mcp-installer].
+
+Skill installation is separate. `officecli skills install` installs the base skill to detected agents, while `officecli skills install <name>` installs a named sub-skill to detected agents. Supported agent directories include Claude Code, GitHub Copilot, Codex CLI, Cursor, Pi, Windsurf, MiniMax CLI, OpenCode, Hermes, OpenClaw, NanoBot, and ZeroClaw [@skill-installer].
+
+The result is a two-part agent contract. MCP provides a narrow execution bridge into the same CLI commands humans use; skills provide the workflow knowledge that tells an agent which commands, schemas, checks, and delivery gates matter for a particular document task [@mcp-server] [@root-skill].

--- a/almanac/architecture/agent/sdk-resident-clients.md
+++ b/almanac/architecture/agent/sdk-resident-clients.md
@@ -1,0 +1,61 @@
+---
+title: "SDK Resident Clients"
+summary: "The Node and Python SDKs are thin resident-pipe clients that forward batch-shaped OfficeCLI commands without inventing a second document vocabulary."
+topics: [architecture, sdk, resident, agent]
+sources:
+  - id: node-sdk
+    type: file
+    path: sdk/node/index.js
+  - id: node-types
+    type: file
+    path: sdk/node/index.d.ts
+  - id: python-sdk
+    type: file
+    path: sdk/python/officecli.py
+  - id: python-package
+    type: file
+    path: sdk/python/pyproject.toml
+  - id: node-package
+    type: file
+    path: sdk/node/package.json
+---
+
+The Node and Python SDKs are resident clients, not independent Office document libraries. They create or open a document by starting or reusing an OfficeCLI resident, then send batch-item-shaped commands over the resident pipe. This keeps SDK usage aligned with the [batch item protocol](../../concepts/batch-item-protocol) and the [resident process and pipes](../runtime/resident-process-and-pipes) architecture [@node-sdk] [@python-sdk].
+
+## Shared Model
+
+Both SDKs state the same rule in code comments: there is no second vocabulary. A command passed to `send` is the same object a user would put into an OfficeCLI batch list, with `command` or `op` selecting the verb, `props` carrying property values, and the remaining keys forwarded as command arguments [@node-sdk] [@python-sdk].
+
+The SDKs expose two surfaces. `create` and `open` are bootstrap operations that may spawn one CLI process because no resident may exist yet. `send` and `batch` are the hot path and use pipe round trips instead of per-command process spawns [@node-sdk] [@python-sdk].
+
+The Node type definitions make that contract public. `BatchItem` has common fields such as `command`, `op`, `path`, `parent`, `type`, `selector`, and `props`, while also allowing additional keys so new OfficeCLI batch fields can pass through without SDK type changes [@node-types]. The Python package description says the distribution is a thin SDK for the resident pipe and has no runtime dependencies beyond the standard library [@python-package].
+
+## Pipe Addressing And Framing
+
+Both SDKs reproduce the resident pipe address convention. They hash the canonical full path with SHA-256, uppercase the first 16 hex characters, and build an `officecli-<hash>` pipe name, with a `-ping` companion pipe. macOS and Windows uppercase the full path before hashing; Linux leaves the path case-sensitive [@node-sdk] [@python-sdk].
+
+Requests are one JSON line per connection. The request uses PascalCase fields such as `Command`, `Args`, `Props`, and `Json`, and the response contains `ExitCode`, `Stdout`, and `Stderr` [@node-sdk] [@python-sdk].
+
+The SDKs parse response `Stdout` as JSON only when it is an object or array. Bare JSON scalars stay text, so a content reply like `42` is not confused with a numeric API value [@node-sdk] [@python-sdk].
+
+## Command Delivery
+
+Command delivery mirrors the resident client's busy policy. Connect is bounded by a generous timeout and a small retry loop with backoff. Once connected, the reply read blocks until the resident answers, which avoids cutting off slow but valid operations [@node-sdk] [@python-sdk].
+
+Retries happen only before a command is delivered. If a resident accepts a connection and then closes without a complete reply, the SDKs raise instead of resending, because the command may already have been applied [@node-sdk] [@python-sdk].
+
+On delivery failure, both SDKs probe the ping pipe to distinguish a dead resident from a live but unresponsive one. A dead resident can be restarted with `officecli open` and retried once. A live but busy resident is not bypassed, because touching the file directly would race the resident's eventual save [@node-sdk] [@python-sdk].
+
+## Lifecycle
+
+`open` is idempotent. It reuses a resident that is already serving the file or starts one if needed, then upgrades the resident idle timeout to the interactive window used by OfficeCLI open sessions [@node-sdk] [@python-sdk].
+
+`create` runs `officecli create`, then binds a document handle to the resident that create auto-started. The returned handle is the same kind of handle returned by `open` [@node-sdk] [@python-sdk].
+
+`close` sends the resident close command over the ping pipe. The SDKs treat a missing acknowledgement as acceptable only if a follow-up liveness check says the resident is gone; otherwise they surface the error so the caller does not falsely believe the file was released [@node-sdk] [@python-sdk].
+
+## Packaging Boundary
+
+The Node package depends on `@officecli/officecli`, so it can prefer a bundled installer-package binary before checking `PATH` or the official install location [@node-package] [@node-sdk]. The Python package is named `officecli-sdk` but installs a single `officecli` module; its metadata notes that pip cannot install the OfficeCLI binary and that the CLI must be installed separately [@python-package].
+
+This packaging difference does not change the architecture. In both languages, the SDK is a thin transport shell over the resident process. It forwards OfficeCLI commands, returns parsed envelopes or raw text, and leaves document semantics to the CLI and its handlers [@node-sdk] [@python-sdk].

--- a/almanac/architecture/build/self-contained-binary-and-embedded-resources.md
+++ b/almanac/architecture/build/self-contained-binary-and-embedded-resources.md
@@ -1,0 +1,36 @@
+---
+title: "Self Contained Binary And Embedded Resources"
+summary: "OfficeCLI is published as a self-contained single-file .NET binary that carries its help schemas, skills, and preview resources inside the executable."
+topics: [architecture, build]
+sources:
+  - id: csproj
+    type: file
+    path: src/officecli/officecli.csproj
+  - id: build-script
+    type: file
+    path: build.sh
+  - id: npm-installer
+    type: file
+    path: npm/lib/install-binary.js
+  - id: skill-installer
+    type: file
+    path: src/officecli/Core/SkillInstaller.cs
+---
+
+OfficeCLI's release artifact is meant to behave like a complete product, not a thin launcher. The project file publishes an executable named `officecli` as a self-contained, single-file, trimmed .NET application, then embeds help schemas, agent skills, preview assets, chart resources, and PowerPoint effect templates into the assembly [@csproj]. That choice lets installers and npm downloads place one platform binary and still expose the command help, [help schemas](../../concepts/help-schemas), and [officecli skills](../../concepts/officecli-skills) needed by users and agents.
+
+## Binary Boundary
+
+The build boundary is the .NET publish output for `src/officecli/officecli.csproj`. The project sets `PublishSingleFile`, `SelfContained`, and `PublishTrimmed`, so each runtime identifier produces a native executable that includes the .NET runtime instead of requiring a machine-wide runtime install [@csproj]. The local build script maps runtime identifiers to release asset names such as `officecli-mac-arm64`, `officecli-linux-x64`, `officecli-linux-alpine-arm64`, and `officecli-win-x64.exe` [@build-script].
+
+The same script builds into a temporary publish directory, copies the result to a staged `.new` file, optionally ad-hoc signs macOS outputs, and then renames the staged file into place [@build-script]. This keeps the live binary from being mutated in place while another `officecli` process may still be mapped into memory [@build-script].
+
+## Embedded Contract
+
+The embedded resources are part of the runtime contract. `preview.css`, `preview.js`, watch scripts, chart style XML, chart gallery XML, and PowerPoint effect templates are declared as embedded resources in the project file [@csproj]. The help schema tree under `schemas/help/**/*.json` is also embedded with logical names under `schemas/help/`, so schema help can be loaded from the assembly without extracting files beside the executable [@csproj].
+
+Skills use the same packaging model. The project embeds `../../skills/**/*` under `skills/...` logical names and normalizes recursive directory separators so resource prefix lookups work across platforms [@csproj]. `SkillInstaller` then reads embedded skill files, builds the skill catalog, serves `load_skill` content, lists bundled reference files, and rejects binary skill assets on text-only channels [@skill-installer].
+
+## Installer Consequence
+
+Because the binary is self-contained, the npm package does not ship native code in the package tarball. Its postinstall logic detects the current platform, downloads the matching release asset into `vendor/`, verifies `SHA256SUMS` when available, and exposes the binary path to callers [@npm-installer]. This is why the [release build and checksum flow](../../guides/release-build-and-checksum-flow) treats asset names, checksums, and platform detection as one system: the downloaded file must already contain the resources needed after installation.

--- a/almanac/architecture/cli/batch-execution.md
+++ b/almanac/architecture/cli/batch-execution.md
@@ -1,0 +1,63 @@
+---
+title: "Batch Execution"
+summary: "Batch execution normalizes a JSON array of command items, replays them through one shared item dispatcher, and formats per-item results consistently across CLI, resident, MCP, SDK, and in-process callers."
+topics: [architecture, cli, batch]
+sources:
+  - id: batch-types
+    type: file
+    path: src/officecli/BatchTypes.cs
+  - id: batch-command
+    type: file
+    path: src/officecli/CommandBuilder.Batch.cs
+  - id: batch-executor
+    type: file
+    path: src/officecli/Core/BatchExecutor.cs
+  - id: command-builder
+    type: file
+    path: src/officecli/CommandBuilder.cs
+  - id: resident-server
+    type: file
+    path: src/officecli/ResidentServer.cs
+---
+
+Batch execution is the shared replay path for many OfficeCLI operations packed into one JSON array. The CLI accepts batch input from `--commands`, `--input`, or stdin, validates the item shape, opens or routes to the target document once, then calls the same item dispatcher used by resident mode and in-process embedding. This keeps command semantics, result formatting, and continue-on-error behavior aligned across transports while avoiding repeated open/save cycles [@batch-command] [@batch-executor] [@resident-server].
+
+## Batch Item Shape
+
+A batch item is an object whose `command` is a bare verb such as `add`, `set`, `remove`, `move`, `swap`, `get`, or `query`. Arguments are sibling fields like `path`, `parent`, `type`, `props`, `selector`, `to`, and `path2`, not a whole CLI command line stuffed into `command` [@batch-command] [@batch-types].
+
+`BatchItemConverter` accepts both `command` and `op`, accepts `props` either as an object or as an array of `key=value` strings, and ignores unknown JSON properties during normal deserialization [@batch-types]. The CLI batch command adds a stronger pre-validation layer before deserialization: each object is scanned for unknown fields and rejected with a list of valid fields, so mistakes are caught before replay begins [@batch-command].
+
+The item model also converts directly to `ResidentRequest`. This is the bridge that lets the same batch-shaped object travel through the CLI, resident pipe, MCP command surface, SDKs, and in-process callers without inventing a second command vocabulary [@batch-types] [@batch-executor].
+
+## Input Normalization
+
+The CLI enforces one primary input source. `--commands` and `--input` are mutually exclusive, and redirected stdin produces a warning when it would otherwise be ignored; `--input -` explicitly means stdin [@batch-command]. Stdin input has a UTF-8 BOM stripped so piped input behaves like `File.ReadAllText()` on an input file [@batch-command].
+
+The command also unwraps the normal JSON output envelope from `dump --json` when the root object has a `data` array. That lets a dump result feed back into batch without requiring an extra transformation step [@batch-command]. Non-array roots are rejected with a clear error that tells the caller to wrap a single item in an array, and explicit `null` items are rejected before replay [@batch-command].
+
+## Replay Semantics
+
+`ApplyBatchItems()` is the central loop. It iterates items, calls `ExecuteBatchItem()`, records a `BatchResult` for each item, and either stops at the first failure or continues according to `stopOnError` [@batch-command]. The default CLI behavior is continue-on-error; `--stop-on-error` opts back into strict abort-on-first-failure mode [@batch-command].
+
+Each result records the item index, success flag, output, and error. Failed rows also include the original item so an agent can inspect and retry the failed command [@batch-types]. JSON output writes valid object or array output as raw JSON rather than double-encoding it as a string [@batch-types].
+
+`ExecuteBatchItem()` applies the same command verbs that single-command surfaces expose, but it first rejects NUL bytes in caller-controlled strings and props. That boundary check prevents invalid XML characters from reaching the OOXML save path after earlier batch items have already mutated the document [@command-builder].
+
+## File Lifetime
+
+Non-resident batch opens the file once, checks document protection once against the live in-memory DOM, runs the shared replay loop with save deferral, and relies on handler disposal to finalize and save once [@batch-command]. For Word handlers, this avoids serializing the document after every item and keeps large replays from becoming dominated by repeated whole-document saves [@batch-command].
+
+If a resident already owns the file, the CLI sends the whole batch as a single `batch` request on the resident pipe. The resident applies the items in memory and defers the disk flush to `save`, `close`, idle autosave, or the configured per-command flush policy [@batch-command] [@resident-server]. In resident mode, embedded `open` and `close` items are skipped because the resident already holds the document [@batch-command].
+
+The public `BatchExecutor` gives in-process hosts the same behavior without spawning a CLI process. It deserializes the same item array, calls the same non-resident replay helper, and returns the same text or JSON envelope that the CLI would write to stdout [@batch-executor].
+
+## Output And Exit Contract
+
+Batch is treated as a judgment command. In JSON mode, the outer envelope succeeds only when every item succeeds; per-item success remains available under the result list [@batch-command]. Text mode prints each item result and a batch summary, while JSON mode wraps the formatted result body in the standard `{success, data, warnings}` envelope [@batch-command].
+
+Warnings for unrecognized LaTeX commands are collected per item and surfaced after the replay, matching the single-command add/set behavior. If any item fails, exit code `1` takes precedence; if the only issue is an unrecognized-LaTeX warning, the command exits `2` [@batch-command]. Resident batch mirrors this by tracking whether the most recent batch had any failed row and mapping that verdict back into the response exit code and JSON envelope [@resident-server].
+
+## Consequences
+
+The batch architecture makes batch a protocol, not just a convenience flag. A caller can use the same item fields through the standalone CLI, a live resident, MCP, SDK-style send/batch calls, or direct embedding, and the replay rules stay tied to one implementation [@batch-types] [@batch-command] [@batch-executor]. The resident-specific flush behavior is explained in [Resident Process And Pipes](../runtime/resident-process-and-pipes).

--- a/almanac/architecture/cli/command-dispatch.md
+++ b/almanac/architecture/cli/command-dispatch.md
@@ -1,0 +1,52 @@
+---
+title: "Command Dispatch"
+summary: "OfficeCLI dispatches a small set of process-level commands before handing normal document commands to a shared System.CommandLine root."
+topics: [architecture, cli]
+sources:
+  - id: program
+    type: file
+    path: src/officecli/Program.cs
+  - id: command-builder
+    type: file
+    path: src/officecli/CommandBuilder.cs
+  - id: integration-stubs
+    type: file
+    path: src/officecli/CommandBuilder.IntegrationStubs.cs
+  - id: help-command
+    type: file
+    path: src/officecli/CommandBuilder.Help.cs
+---
+
+Command dispatch in OfficeCLI is split between a process bootstrapper and a reusable command tree. `Program.cs` owns startup policy, help rewriting, update and install side effects, and commands that must run before System.CommandLine. `CommandBuilder.BuildRootCommand()` owns the normal CLI surface for document operations, shared `--json` behavior, resident commands, batch, help, and registered integration stubs. This shape matters because the terminal CLI and MCP bridge can share the same root command while still keeping setup commands and stdio server startup out of the document-command parser [@program] [@command-builder].
+
+## Startup Boundary
+
+The process first sets UTF-8 output and pins the default culture to invariant, while preserving the original OS locale for document creation. That makes numeric and machine-readable output stable across regional settings before any command handler runs [@program].
+
+Before the root command is built, `Program.cs` handles process-level routes. It returns a schema CRC for `--output-schema-crc`, rewrites `--help`, `-h`, and `-?` into the schema-aware `help` command, starts or installs MCP targets under `mcp`, runs the installer under `install`, accepts the legacy `mcp-serve` alias, handles `skill` and `skills`, serves `load_skill`, and handles update-check configuration [@program]. These routes either start a different long-lived process, mutate user installation state, or need help behavior that would be risky or awkward if they were treated as ordinary document subcommands [@program] [@help-command].
+
+After early dispatch, the program logs the command, runs auto-install and background update checks, builds the root command, and invokes it through System.CommandLine. If no arguments are provided, it parses `help`; otherwise it parses the original argument vector with response-file expansion disabled so literal `@...` values can reach document handlers unchanged [@program].
+
+## Root Command
+
+`BuildRootCommand()` constructs the reusable command surface. It creates a shared `--json` option, adds `open`, `close`, and the hidden internal `__resident-serve__` command, then registers document and utility command families from partial `CommandBuilder` files: watch, view, get, query, set, add, remove, move, swap, refresh, raw access, validate, save, batch, dump, import, create, merge, plugins, and help [@command-builder].
+
+The root command is also where resident-process dispatch enters the normal command tree. `open` starts or reuses a resident and can upgrade an auto-started resident's idle timeout. `close` asks a resident to flush and shut down, but treats the absence of a resident as an idempotent success because non-resident mutations already write to disk [@command-builder]. The hidden `__resident-serve__` command is only for child processes; it takes a per-file singleton lock before opening the document and exits quietly if another resident already owns the file [@command-builder].
+
+The command tree is deliberately reusable. [MCP Shared CLI Root](../runtime/mcp-shared-cli-root) invokes this same root command in-process, so parsing and validation behavior stays aligned between terminal users and MCP clients [@command-builder].
+
+## Help As Dispatch
+
+Help is normalized before normal dispatch. `officecli --help`, `officecli <cmd> --help`, and related aliases are rewritten to `officecli help ...`, with trailing tokens preserved so schema help can drill into formats, verbs, and elements [@program]. The `help` command then decides whether the request is for the root command, an early-dispatch command, a registered System.CommandLine command, a flat schema dump, or an element schema [@help-command].
+
+Early-dispatch commands still appear in root help through stubs. `BuildIntegrationStubCommands()` registers visible `mcp`, `skills`, and `install` commands, but their actions only print the same usage text used by `officecli help <cmd>` and early-dispatch error paths [@integration-stubs] [@help-command]. This keeps the command list complete without letting setup commands accidentally run through the document-command parser [@integration-stubs].
+
+## Error And Output Contract
+
+Most root-command actions run through `SafeRun`. In text mode it writes a concise `Error:` message to stderr; in JSON mode it writes a structured error envelope to stdout, matching the rest of the AI-facing output contract [@command-builder]. The same helper also captures command output when CLI logging is enabled, so logging does not change command behavior [@command-builder].
+
+Resident delivery has a stricter rule. `TryResident()` first probes the fast ping pipe. If no resident owns the file, it may auto-start a short-lived resident unless disabled by environment. If a resident is alive but the main command cannot be delivered after retries, it returns a distinct busy failure instead of falling back to direct file access, because direct access could race the resident's in-memory copy [@command-builder]. That same resident path is one of the major collaborators of [Resident Process And Pipes](../runtime/resident-process-and-pipes).
+
+## Consequences
+
+The dispatch boundary gives OfficeCLI three useful properties. Process-level commands can remain simple and side-effectful, normal document commands can share one System.CommandLine grammar, and help can act as a schema-aware reference instead of a generic usage banner [@program] [@command-builder] [@help-command]. Batch execution builds on the same root-command and handler conventions; see [Batch Execution](batch-execution) for the multi-command path.

--- a/almanac/architecture/cli/help-schema-loader.md
+++ b/almanac/architecture/cli/help-schema-loader.md
@@ -1,0 +1,64 @@
+---
+title: "Help Schema Loader"
+summary: "The help schema loader turns embedded schema JSON files into the CLI's schema-aware help, validation, flat search dumps, and schema CRC fingerprint."
+topics: [architecture, cli, schemas]
+sources:
+  - id: schema-loader
+    type: file
+    path: src/officecli/Help/SchemaHelpLoader.cs
+  - id: schema-renderer
+    type: file
+    path: src/officecli/Help/SchemaHelpRenderer.cs
+  - id: flat-renderer
+    type: file
+    path: src/officecli/Help/SchemaHelpFlatRenderer.cs
+  - id: schema-crc
+    type: file
+    path: src/officecli/Help/SchemaCrc.cs
+  - id: help-command
+    type: file
+    path: src/officecli/CommandBuilder.Help.cs
+  - id: project-file
+    type: file
+    path: src/officecli/officecli.csproj
+---
+
+The help schema loader is the boundary between embedded schema files and the user-facing command reference. It indexes `schemas/help/**` resources from the assembly, normalizes format and element aliases, composes schemas that extend shared bases, and feeds renderers used by `officecli help`. It also supports property validation and the schema CRC fingerprint, so the same embedded schema corpus drives discovery, agent-facing references, and compatibility checks [@schema-loader] [@help-command] [@schema-crc].
+
+## Embedded Resource Index
+
+The project embeds every `schemas/help/**/*.json` file with logical names under `schemas/help/` so a single-file OfficeCLI binary can read schemas from the assembly without extracting files to disk [@project-file]. `SchemaHelpLoader` builds a lazy manifest index from assembly resource names, normalizing backslashes to forward slashes so Windows and Unix builds resolve the same canonical keys [@schema-loader].
+
+Only the canonical formats `docx`, `xlsx`, and `pptx` are listed. User-facing aliases map `word` to `docx`, `excel` to `xlsx`, and `ppt` or `powerpoint` to `pptx` [@schema-loader]. Unknown formats raise an error with a closest-match suggestion when possible [@schema-loader].
+
+## Element Resolution
+
+Element lookup starts with a case-insensitive filename match. If that fails, the loader scans the format's schemas for `elementAliases` and builds a per-format alias cache, allowing path-style names such as `p` or `col` to resolve to schema filenames such as `paragraph` or `column` [@schema-loader].
+
+The loader also treats `/` as the root element alias for each format: workbook for `xlsx`, document for `docx`, and presentation for `pptx`. This mirrors the document path vocabulary used by get, set, and query commands [@schema-loader].
+
+When an element is unknown, the loader suggests the closest element name and truncates caller-provided strings in error messages so a bad request cannot amplify arbitrary input into a large response [@schema-loader].
+
+## Schema Composition
+
+Schemas may declare `extends` as a string or an array of shared base references. The loader reads bases from `schemas/help/<base>.json`, layers multiple bases in declaration order, and applies the concrete schema last [@schema-loader]. Merge behavior is shallow for top-level fields except for `properties`: override-declared properties come first, base-only properties are appended, and a same-name property in the override replaces the base entry atomically [@schema-loader].
+
+The loader strips the synthetic `extends` and `shared_base` markers from the composed output. That means renderers and JSON callers see the resolved schema, not the inheritance mechanics used to author it [@schema-loader].
+
+## Help Rendering
+
+`officecli help` uses the loader to decide whether a request is root help, command help, a format listing, a verb-filtered element listing, a specific element schema, or a flat corpus dump [@help-command]. For element pages, `SchemaHelpRenderer` can print resolved raw JSON or a human-readable view with operations, usage examples, properties, parts, children, notes, and examples [@schema-renderer].
+
+Verb-filtered help uses the operations block. If an element does not support the requested verb, the renderer says so instead of showing an empty property list [@schema-renderer]. When properties are shown under a verb filter, only properties that declare that verb are rendered [@schema-renderer].
+
+For broad search, `SchemaHelpFlatRenderer` emits one record per element and property. It supports human-readable flat text, JSONL, and a JSON-array form for `help all` and `help <format> all` [@flat-renderer] [@help-command]. The flat rows include operation flags, paths, property names, types, aliases, enum values, descriptions, and examples where available [@flat-renderer].
+
+## Validation And Fingerprint
+
+The loader also validates property keys for a given format, element, and verb. It accepts declared property names, property aliases, generic add/set keys such as `from` and `text`, known dotted namespaces such as `font.` and `border.`, and selected indexed prefixes such as `series1.` [@schema-loader]. Unknown format or element resolution is treated leniently so new handlers are not blocked by a missing schema entry [@schema-loader].
+
+`SchemaCrc.Compute()` calculates a CRC32 over every embedded `schemas/help/` resource, ordered by normalized resource name and including both canonical names and raw bytes [@schema-crc]. `Program.cs` exposes that value through `--output-schema-crc`, giving downstream automation a cheap way to detect schema-surface drift across binary upgrades [@schema-crc].
+
+## Consequences
+
+Because the schema loader is embedded and deterministic, the help surface does not depend on files beside the executable. The same schema corpus drives detailed help, grep-friendly discovery, validation leniency, and upgrade fingerprinting [@project-file] [@schema-loader] [@flat-renderer] [@schema-crc]. It is part of the same CLI dispatch surface described in [Command Dispatch](command-dispatch).

--- a/almanac/architecture/handlers/document-handler-lifecycle.md
+++ b/almanac/architecture/handlers/document-handler-lifecycle.md
@@ -1,0 +1,45 @@
+---
+title: "Document Handler Lifecycle"
+summary: "How OfficeCLI opens Office files, chooses native or plugin handlers, and exposes one document contract to commands."
+topics: [architecture, handlers]
+sources:
+  - id: factory
+    type: file
+    path: src/officecli/Handlers/DocumentHandlerFactory.cs
+  - id: contract
+    type: file
+    path: src/officecli/Core/IDocumentHandler.cs
+  - id: word-handler
+    type: file
+    path: src/officecli/Handlers/WordHandler.cs
+  - id: excel-handler
+    type: file
+    path: src/officecli/Handlers/ExcelHandler.cs
+  - id: ppt-handler
+    type: file
+    path: src/officecli/Handlers/PowerPointHandler.cs
+---
+
+The document handler lifecycle is the path from a file name to a live object that commands can query, mutate, render, save, and dispose. `DocumentHandlerFactory.Open` is the shared entry point: it validates the path, rejects unsafe packages, repairs a few known producer defects, then returns either a native Word, Excel, or PowerPoint handler, or a plugin-backed handler for non-native formats [@factory]. The returned object implements `IDocumentHandler`, which is the common command contract for semantic views, structured document nodes, raw XML access, validation, binary extraction, and save [@contract]. This shape matters because higher layers can talk in [command layers](../../concepts/command-layers) without owning Word, Excel, or PowerPoint package details.
+
+## Opening boundary
+
+The factory treats an empty path, a missing file, and a zero-byte file as separate user-facing failures before any Open XML package is opened [@factory]. For native `.docx`, `.xlsx`, and `.pptx` files, it also inspects the zip directory for entry count, uncompressed size, and compression ratio, rejecting packages that look like decompression bombs [@factory]. These checks happen before handler construction, so every command path inherits the same safety behavior.
+
+The factory also performs two repair steps before and during open. It scans native packages for dangling internal relationships and strips relationships whose target part is missing, because some Office producers leave broken relationships that Microsoft Office tolerates but the SDK can reject or crash on later traversal [@factory]. It also catches unsupported XML encoding declarations, rewrites them to UTF-8, and retries the open [@factory]. These repairs are intentionally centralized so individual handlers do not each carry their own open-time compatibility policy.
+
+## Handler dispatch
+
+After validation, extension dispatch is simple: `.docx` creates `WordHandler`, `.xlsx` creates `ExcelHandler`, and `.pptx` creates `PowerPointHandler` [@factory]. Unknown extensions are not immediately fatal. The factory first asks the plugin registry for a dump-reader plugin, which can convert a foreign source into a native sibling file, or for a format-handler plugin, which is wrapped in a proxy session [@factory]. If no plugin handles the extension, the factory returns an unsupported-type error that names the native extensions and points users toward plugins [@factory]. That is the bridge from native handler lifecycle to the [plugin system](../plugins/plugin-system).
+
+## Shared contract
+
+`IDocumentHandler` divides handler behavior into three layers. The semantic layer returns text, annotated text, outline, stats, issues, and JSON view variants [@contract]. The structured layer exposes `Get`, `Query`, `Set`, `Add`, `Remove`, `Move`, and `CopyFrom` over `DocumentNode` paths and selectors [@contract]. The raw layer exposes package parts through `Raw`, `RawSet`, and `AddPart`, with validation, binary extraction, and `Save` alongside them [@contract]. This is the same conceptual split described by [raw XML access](../../concepts/raw-xml-access) and [document nodes and paths](../../concepts/document-node-and-paths).
+
+The native handlers all implement this contract and also expose their parsed SDK package to the rendering layer through a narrow render-model interface [@word-handler] [@excel-handler] [@ppt-handler]. Word wraps a `WordprocessingDocument`, Excel wraps a `SpreadsheetDocument`, and PowerPoint wraps a `PresentationDocument` [@word-handler] [@excel-handler] [@ppt-handler]. The command layer therefore sees one handler interface, while each handler keeps format-specific package state private.
+
+## Save and disposal
+
+Editable handlers open package streams with sharing choices that let external readers observe saved snapshots while a session is alive [@word-handler] [@excel-handler] [@ppt-handler]. Mutating paths mark the handler as modified, and `Save` or `Dispose` flushes package changes and stamps the OfficeCLI audit metadata only when a document was actually changed [@word-handler] [@excel-handler] [@ppt-handler]. Word also has a deferred-save mode used by batch replay so many mutations serialize once rather than after every operation [@word-handler].
+
+The lifecycle consequence is that command code should open through the factory, perform work through `IDocumentHandler`, call `Save` only when it needs an explicit mid-session flush, and otherwise rely on disposal for final cleanup. Format-specific details belong inside the handler, while the factory owns file admission, repair, and handler selection.

--- a/almanac/architecture/handlers/rendering-and-preview-stack.md
+++ b/almanac/architecture/handlers/rendering-and-preview-stack.md
@@ -1,0 +1,41 @@
+---
+title: "Rendering And Preview Stack"
+summary: "How OfficeCLI turns live handlers into HTML, SVG, screenshots, and preview assets through a renderer registry."
+topics: [architecture, handlers, rendering, preview]
+sources:
+  - id: rendering-core
+    type: file
+    path: src/officecli/Core/Rendering/
+  - id: handler-rendering
+    type: file
+    path: src/officecli/Handlers/Rendering/
+  - id: view-command
+    type: file
+    path: src/officecli/CommandBuilder.View.cs
+  - id: preview-css
+    type: file
+    path: src/officecli/Resources/preview.css
+  - id: preview-js
+    type: file
+    path: src/officecli/Resources/preview.js
+---
+
+The rendering and preview stack converts an already-open document handler into visual artifacts. Its center is a renderer registry: renderers advertise supported formats, output kinds, watch support, and priority, and the registry selects the highest-priority available renderer that covers a request [@rendering-core]. The built-in adapters forward to the existing Word, Excel, and PowerPoint preview methods, but they receive the parsed handler model through `HandlerRenderInput` rather than reopening files [@handler-rendering]. That decision keeps rendering inside the [document handler lifecycle](document-handler-lifecycle) while leaving room for alternate renderers.
+
+## Registry contract
+
+Rendering is artifact-oriented. `RenderOutputKind` names HTML, SVG, PNG, and PDF outputs, while `RenderOptions` carries page ranges, Word page filters, grid settings, viewport size, and raster dimensions [@rendering-core]. `IRenderInput` exposes the format id, the parsed model, and read-only `Get` and `Query` access to the document tree [@rendering-core]. A renderer can therefore work from the live in-memory document instead of re-parsing a file path.
+
+The built-in renderer bootstrap registers three low-priority renderers: Word HTML, Excel HTML, and PowerPoint HTML/SVG [@handler-rendering]. Those adapters are intentionally thin. Word calls `ViewAsHtml` with page and grid options, Excel calls `ViewAsHtml`, and PowerPoint calls either `ViewAsHtml` or `ViewAsSvg` depending on the requested output [@handler-rendering]. Higher-priority renderers can register during registry composition and replace the built-in behavior without changing command dispatch [@handler-rendering].
+
+## View command flow
+
+`view html` opens a handler through the handler factory, determines the format, and calls `RenderViaRegistry` for Word, Excel, or PowerPoint [@view-command]. If the caller asks for a browser or output file, the command writes HTML to either the requested path or an unpredictable temporary path before opening it [@view-command]. `view svg` uses the same registry path for PowerPoint SVG and falls back to plugin SVG when a format-handler plugin can provide it [@view-command].
+
+`view screenshot` builds on the same preview stack. It first tries native Word or PowerPoint raster backends on Windows when allowed by `--render`, then asks the renderer registry for PNG bytes, and finally falls back to HTML captured by a headless browser [@view-command]. Screenshot mode can crop to rendered `data-path` targets, tile PowerPoint or Word pages into a grid, and size single-slide or single-page captures to their native 96 DPI pixel dimensions [@view-command].
+
+## Preview assets
+
+The preview HTML is supported by embedded static resources. `preview.css` defines the shared slide viewer layout, sidebar thumbnails, main scrolling area, fullscreen state, headless capture behavior, and responsive sidebar behavior [@preview-css]. `preview.js` implements slide scaling, thumbnail construction, fullscreen navigation, keyboard navigation, and sidebar toggling [@preview-js]. These assets are not the renderer API, but they are part of the default visual contract because built-in PowerPoint previews rely on their classes and browser behavior.
+
+The stack is also the input to the [watch preview contract](watch-preview-contract). Watch uses rendered HTML snapshots and patches, not a second renderer, so the same renderer output supports one-shot `view`, screenshots, and live browser refresh [@rendering-core].

--- a/almanac/architecture/handlers/rich-object-helpers.md
+++ b/almanac/architecture/handlers/rich-object-helpers.md
@@ -1,0 +1,46 @@
+---
+title: "Rich Object Helpers"
+summary: "Shared helper subsystems that keep charts, diagrams, OLE objects, and formulas consistent across OfficeCLI handlers."
+topics: [architecture, handlers, charts]
+sources:
+  - id: chart-core
+    type: file
+    path: src/officecli/Core/Chart/
+  - id: diagram-core
+    type: file
+    path: src/officecli/Core/Diagram/
+  - id: ole-helper
+    type: file
+    path: src/officecli/Core/OleHelper.cs
+  - id: formula-core
+    type: file
+    path: src/officecli/Core/Formula/
+---
+
+Rich object helpers are the shared subsystems that stop each handler from inventing its own chart, diagram, OLE, and formula behavior. They live under `Core`, operate on Open XML parts or neutral intermediate models, and are called by Word, Excel, and PowerPoint handlers when a document contains objects more complex than text, cells, slides, or paragraphs [@chart-core] [@diagram-core] [@ole-helper] [@formula-core]. This makes rich objects part of the normal [document handler lifecycle](document-handler-lifecycle) instead of isolated per-format features.
+
+## Charts
+
+The chart helpers own chart parsing, construction, mutation, and preview rendering. `ChartHelper` is documented as shared chart build, read, and set logic for PowerPoint, Excel, and Word handlers, and its methods operate on `ChartPart`, `C.Chart`, and `C.PlotArea` rather than on a host document type [@chart-core]. It parses chart types, series data, cell references, categories, colors, axes, and chart properties before building or updating chart XML [@chart-core].
+
+Extended chart support is split into `ChartExBuilder`, `ChartExResources`, and related style builders for newer chart families such as histogram, funnel, treemap, sunburst, box-and-whisker, and waterfall [@chart-core]. `ChartSvgRenderer` reads regular and extended chart information and renders chart previews as SVG/HTML-friendly output, using theme-derived colors when available and fallback Office palette colors otherwise [@chart-core]. The result is one chart vocabulary across add, set, query, dump, and preview flows.
+
+## Diagrams
+
+Diagram helpers translate Mermaid input into either editable Office shapes or raster images. `DiagramCompiler` is the native entry point for `add --type diagram`; it recognizes flowchart and sequence diagram headers, dispatches to the corresponding layout engine, and rejects unsupported diagram types with a clear error [@diagram-core]. `MermaidParser` parses a practical Mermaid flowchart subset into a semantic graph, including common node shapes, chained edges, labels, grouped endpoints, Unicode identifiers, and ignored style directives [@diagram-core].
+
+When native editable shapes are not enough, `MermaidImageRenderer` can render Mermaid through `mmdc` or a Chrome-family browser and return a PNG [@diagram-core]. It caches Mermaid JavaScript under the user's OfficeCLI cache, stamps source text into image alt text with a sentinel tag, and falls back to the native compiler when no image backend is available [@diagram-core]. That gives handlers a choice between editable shape synthesis and higher-fidelity raster output.
+
+## OLE objects
+
+`OleHelper` is the shared OLE boundary for embedded objects. It detects default ProgIDs from source extensions, maps embedded package part types, classifies Office files versus generic object payloads, creates embedded parts on Word, Excel, or PowerPoint host parts, and populates canonical `DocumentNode` fields from an embedded part [@ole-helper]. It also validates ProgIDs, normalizes display modes, creates placeholder icon images, supports data URI payloads, and warns about unknown OLE properties [@ole-helper].
+
+The helper also handles failure-sensitive embedding details. It permits self-embedding by writing a placeholder payload when the host package lock would otherwise prevent reading the source file, wraps generic object payloads in an Ole10Native compound-file container, and deletes newly-created parts if feeding bytes fails [@ole-helper]. Those behaviors keep OLE semantics consistent across handlers and reduce the chance of orphan parts.
+
+## Formulas
+
+Formula helpers cover two different domains. `FormulaParser` converts a LaTeX subset to Office Math Markup Language and can convert OMML back to readable or LaTeX text [@formula-core]. It records unrecognized LaTeX commands for user-facing warnings, guards recursion depth, flattens nested Office Math, and has a lenient parse mode that writes a valid placeholder instead of failing an entire batch [@formula-core].
+
+Excel formulas use `FormulaEvaluator` and related partial files. The evaluator represents numeric, string, boolean, error, array, range, blank, and lambda results; it shares evaluation session state for cross-sheet references, memoized formula-cell results, range materialization, row and column extents, and circular-reference tracking [@formula-core]. `ModernFunctionQualifier` prefixes modern Excel functions with `_xlfn.` or `_xlfn._xlws.` when emitting OOXML, and identifies formulas that need dynamic-array spill metadata [@formula-core].
+
+Together, these helpers form the rich-object map for maintainers. Handler code should delegate shared object rules here, then keep host-specific placement, anchoring, and path resolution inside the handler. The intended lookup companion is the rich object helper map reference.

--- a/almanac/architecture/handlers/watch-preview-contract.md
+++ b/almanac/architecture/handlers/watch-preview-contract.md
@@ -1,0 +1,48 @@
+---
+title: "Watch Preview Contract"
+summary: "How OfficeCLI live preview uses pre-rendered HTML, named pipes, SSE updates, marks, and goto without making watch own document parsing."
+topics: [architecture, handlers, watch, preview]
+sources:
+  - id: watch-command
+    type: file
+    path: src/officecli/CommandBuilder.Watch.cs
+  - id: mark-command
+    type: file
+    path: src/officecli/CommandBuilder.Mark.cs
+  - id: goto-command
+    type: file
+    path: src/officecli/CommandBuilder.Goto.cs
+  - id: watch-server
+    type: file
+    path: src/officecli/Core/Watch/WatchServer.cs
+  - id: watch-notifier
+    type: file
+    path: src/officecli/Core/Watch/WatchNotifier.cs
+  - id: command-builder
+    type: file
+    path: src/officecli/CommandBuilder.cs
+---
+
+The watch preview contract is a live-browser layer over rendered HTML, not a document parser. `officecli watch` starts a loopback HTTP server for one file, seeds it with initial HTML from a resident session or direct handler open, and then serves that HTML with watch scripts injected [@watch-command] [@watch-server]. Later document commands render fresh HTML or slide fragments while the handler is still open and send those artifacts to the watch process over a named pipe [@command-builder] [@watch-notifier]. This keeps watch aligned with the [rendering and preview stack](rendering-and-preview-stack) while preserving a hard boundary: watch does not open Office files or reference handlers [@watch-server] [@watch-notifier].
+
+## Process ownership
+
+One watched file maps to one hashed pipe name and one marker file in the temp directory [@watch-server]. The marker stores process id and port so callers can check whether a watch is already running without probing the pipe [@watch-server]. `WatchServer.RunAsync` refuses duplicate watch processes for the same file, starts a loopback `TcpListener`, writes the marker, starts the pipe listener, and starts an idle watchdog [@watch-server]. Shutdown is centralized through `StopAsync`, which cancels loops, stops the TCP listener, closes SSE streams, kicks the named pipe listener, deletes the marker, and removes stale Unix pipe sockets [@watch-server].
+
+The HTTP server is local-only by default. It rejects requests whose `Host` header is not a loopback host, with an environment-variable allowlist for reverse-proxy cases [@watch-server]. State-changing HTTP endpoints also check `Origin`, allowing absent or loopback origins and rejecting cross-origin requests [@watch-server].
+
+## Refresh protocol
+
+The pipe protocol carries `WatchMessage` objects with an action, optional slide number, optional full HTML, optional slide HTML, optional scroll target, version, base version, and optional Word patches [@watch-notifier]. `WatchNotifier.NotifyIfWatching` serializes the message, writes it to the named pipe, waits for an acknowledgement, and gives up silently if no watch process answers [@watch-notifier].
+
+Mutation commands call `NotifyWatch` or `NotifyWatchRoot` after a change. Excel and Word send full HTML snapshots plus an optional scroll selector; PowerPoint sends a slide-level `replace` when a changed slide can be rendered in isolation, otherwise it sends a full deck snapshot [@command-builder]. Root changes such as adding or removing slides may send `add`, `remove`, or full messages with the new full HTML cache [@command-builder].
+
+Inside the watch server, a full HTML message updates the cached snapshot, increments the version, reconciles marks, and then broadcasts either a full SSE update or a smaller patch [@watch-server]. Word can use block-level patches when hidden block markers make the diff safe; Excel can use row-level patches when table chrome and chart overlay signatures are unchanged [@watch-server]. PowerPoint slide updates patch cached HTML by `data-slide` [@watch-server]. If a patch is unsafe or too broad, the server falls back to a full refresh [@watch-server].
+
+## Marks, selection, and goto
+
+Marks are in-memory annotations owned by the watch process. The `watch mark`, `watch unmark`, and `watch marks` commands talk to the pipe through `WatchNotifier`, and the server stores marks with ids, paths, colors, notes, matched text, stale state, and a monotonic version [@mark-command] [@watch-server] [@watch-notifier]. Mark paths must start with `/`, colors are validated server-side, and mark resolution uses the current cached HTML snapshot rather than reopening the document [@watch-server].
+
+Browser selection is reported to the server through `POST /api/selection`, and commands can query that selection through the pipe [@watch-server] [@watch-notifier]. `watch goto` resolves supported Word paths to either an anchor id or a `data-path` selector, asks the server to validate the selector against cached HTML, and then broadcasts a scroll-only SSE event without changing cached HTML or version [@goto-command] [@watch-server] [@watch-notifier]. The public command list is tracked by the command surface reference.
+
+The invariant is simple: commands and handlers render documents; watch relays, patches, scrolls, and annotates the rendered result.

--- a/almanac/architecture/plugins/dump-reader-and-exporter-plugins.md
+++ b/almanac/architecture/plugins/dump-reader-and-exporter-plugins.md
@@ -1,0 +1,51 @@
+---
+title: "Dump Reader And Exporter Plugins"
+summary: "Dump-reader and exporter plugins are one-shot sidecar flows for converting foreign inputs into native OfficeCLI files or rendering native files to foreign outputs."
+topics: [architecture, plugins]
+sources:
+  - id: plugin-protocol
+    type: file
+    path: plugins/plugin-protocol.md
+  - id: dump-invoker
+    type: file
+    path: src/officecli/Core/Plugins/DumpReaderInvoker.cs
+  - id: exporter-invoker
+    type: file
+    path: src/officecli/Core/Plugins/ExporterInvoker.cs
+  - id: handler-factory
+    type: file
+    path: src/officecli/Handlers/DocumentHandlerFactory.cs
+  - id: plugin-process
+    type: file
+    path: src/officecli/Core/Plugins/PluginProcess.cs
+---
+
+Dump-reader and exporter plugins are OfficeCLI's short-lived plugin paths. A dump-reader converts a foreign source into a native OfficeCLI document by emitting batch items; an exporter converts a native document into a foreign output file. They share discovery and timeout rules with the [plugin system](plugin-system), but they do not keep an editing session open [@plugin-protocol].
+
+## Dump Readers
+
+A dump-reader is used when a non-native file should be migrated into `.docx`, `.xlsx`, or `.pptx`. The protocol requires the plugin to run as `<plugin> dump <source>` and write one JSON object per line to stdout, where each line is a batch item in the target format's vocabulary [@plugin-protocol].
+
+`DumpReaderInvoker.Run` resolves a dump-reader for the source extension, creates a minimal blank native temp file based on the plugin manifest target, runs the plugin, and replays the emitted batch into that temp file [@dump-invoker]. The emitted target is native, so after replay the normal document-handler machinery can open it [@handler-factory].
+
+The protocol says dump-reader output must stream. The current invoker still requires JSONL from the plugin, rejects top-level JSON arrays, and uses stdout activity for the idle watchdog, but it buffers all non-empty JSONL lines until the plugin exits before replaying them [@dump-invoker] [@plugin-process]. The code comment records why: replaying OpenXML mutations from the stdout reader thread hit non-thread-safe package behavior, so replay now happens synchronously on the caller thread [@dump-invoker]. That implementation detail is the core reason behind the dump reader buffered replay decision.
+
+The document handler factory adds a sibling-file cache around dump-readers. When a foreign source such as `.doc` is opened, OfficeCLI checks for a sibling native file with the plugin target extension. If the sibling exists and is newer than the source, OfficeCLI opens it directly. Otherwise it runs the dump-reader, writes or reuses the sibling, and reports that the sibling will be reused later [@handler-factory].
+
+Edits belong to the sibling native file, not to the original foreign source. The protocol states this ownership rule, and the factory implements it by opening the generated or cached native sibling after conversion [@plugin-protocol] [@handler-factory].
+
+## Exporters
+
+An exporter is used when a native Office document should be rendered to a foreign target such as PDF. The protocol runs it as `<plugin> export <source-file> --out <target-file>` and requires the plugin not to modify the source file [@plugin-protocol].
+
+`ExporterInvoker.Run` resolves an exporter by target extension, filters it by source support when the manifest advertises `supports`, closes an active resident for the source if one exists, runs the plugin, and verifies that the output path was written [@exporter-invoker]. If no exporter matches, the error is `exporter_not_found`; non-zero plugin exits map to plugin error codes such as corrupt input, unsupported feature, license expiry, protocol mismatch, or generic plugin failure [@exporter-invoker].
+
+The exporter path passes the source directly to the plugin. That is why the source-read-only rule is important: OfficeCLI does not snapshot the native file before export [@plugin-protocol] [@exporter-invoker].
+
+## Shared Failure Model
+
+Both flows use the shared short-lived process runner. The runner starts the executable with redirected stdout and stderr, sets `OFFICECLI_BIN` for plugins that need to call back into the current binary, and kills the process tree if no activity arrives within the resolved idle timeout [@plugin-process].
+
+For dump-readers, any stdout line counts as activity. For exporters, long rendering work should use stderr heartbeat lines because exporter output is normally the target file, not stdout JSONL [@plugin-protocol] [@plugin-process].
+
+These one-shot plugin types keep ownership clear. Dump-readers hand control back to native handlers after conversion. Exporters never enter the document-handler interface at all; they only consume a native file and produce an external artifact [@plugin-protocol] [@exporter-invoker].

--- a/almanac/architecture/plugins/format-handler-plugins.md
+++ b/almanac/architecture/plugins/format-handler-plugins.md
@@ -1,0 +1,55 @@
+---
+title: "Format Handler Plugins"
+summary: "Format-handler plugins are long-lived sidecar sessions that let a non-native file behave like an OfficeCLI document handler."
+topics: [architecture, plugins]
+sources:
+  - id: plugin-protocol
+    type: file
+    path: plugins/plugin-protocol.md
+  - id: format-session
+    type: file
+    path: src/officecli/Core/Plugins/FormatHandlerSession.cs
+  - id: format-proxy
+    type: file
+    path: src/officecli/Core/Plugins/FormatHandlerProxy.cs
+  - id: handler-factory
+    type: file
+    path: src/officecli/Handlers/DocumentHandlerFactory.cs
+  - id: plugin-manifest
+    type: file
+    path: src/officecli/Core/Plugins/PluginManifest.cs
+---
+
+Format-handler plugins make a foreign file act like a first-class OfficeCLI document. The main process starts a plugin with `open <file>`, completes an open handshake, caches the plugin's capabilities and vocabulary, and wraps the session in an `IDocumentHandler` proxy. That lets the rest of OfficeCLI use the same read, query, mutation, validation, and raw-access paths it uses for native handlers [@plugin-protocol] [@format-session] [@format-proxy].
+
+## Session Boundary
+
+A format-handler plugin owns the foreign file for the lifetime of the session. The protocol says the plugin keeps the file open, uses stdin for requests, stdout for JSONL replies, and stderr for diagnostics or heartbeat lines [@plugin-protocol]. `FormatHandlerSession` implements that boundary with a child process, UTF-8 no-BOM streams, an internal I/O lock, and a start-time open handshake [@format-session].
+
+The session begins by sending an `open` envelope with protocol version, file path, and editability. The plugin must reply with `ok` and may include runtime capabilities and vocabulary [@plugin-protocol]. OfficeCLI deserializes that reply into `PluginSessionCapabilities`, which contains supported commands, optional features, and a vocabulary snapshot [@plugin-manifest] [@format-session].
+
+The manifest vocabulary is useful for discovery and help, but the runtime snapshot is the session's live contract. The protocol allows the snapshot to differ from the manifest, and the session caches the open-handshake result for the session lifetime [@plugin-protocol] [@format-session].
+
+## Proxy Behavior
+
+`FormatHandlerProxy` is the adapter that makes the plugin look like an `IDocumentHandler`. It forwards text views, annotated views, outlines, stats, issues, get, query, validate, set, add, remove, move, copy, raw, raw-set, add-part, binary extraction, and save through the session [@format-proxy].
+
+Most proxy methods build a JSON object of command arguments, convert user properties into a string map, and call `FormatHandlerSession.Send`. Reply shapes are strict where the protocol requires them. For example, `set` reads `unsupported_properties`, and `add` reads the created `path` plus unsupported properties [@format-proxy].
+
+The proxy also provides plugin-side fallbacks for view modes that built-in handlers historically owned directly. SVG, HTML, and forms JSON are sent as `view` commands with plugin-specific modes, and `unsupported_command` is treated as absence of that optional feature [@format-proxy].
+
+## Failure And Concurrency
+
+The protocol permits only one request in flight per session, and the session enforces that with an internal lock [@plugin-protocol] [@format-session]. Before a command is sent, the session checks the cached capability list. If the plugin declared supported commands and the requested command is missing, OfficeCLI fails fast with `unsupported_command` without a round trip [@format-session].
+
+Malformed stdout poisons the session. If a plugin writes non-JSON, returns a non-object reply, uses an unknown `msg_type`, closes stdout unexpectedly, or hits an I/O failure, the session enters a broken state and later sends fail with `plugin_stream_closed` [@format-session].
+
+Long commands use the same idle-timeout model as the wider [plugin system](plugin-system). The session waits for a reply while polling activity. Stderr heartbeats reset the timer; if no activity arrives within the verb's timeout, OfficeCLI kills the process tree and raises `plugin_idle_timeout` [@format-session].
+
+## Opening Flow
+
+When a file extension is not native, the document handler factory tries plugins. Dump-readers are tried first. If no dump-reader resolves, the factory looks for a `format-handler`, starts a `FormatHandlerSession`, and returns a `FormatHandlerProxy` [@handler-factory].
+
+This ordering gives migrations a chance to produce native sibling files before handing full ownership to a foreign-format process. When a format-handler is used, the rest of the system sees a handler object, not a special-case plugin branch [@handler-factory]. The plugin still defines its own document vocabulary through the protocol and manifest, which keeps format-specific semantics outside the main binary [@plugin-protocol].
+
+The result is a controlled foreign-format integration. The main process owns command routing and handler boundaries; the plugin owns parsing, mutation, save durability, and any format-specific vocabulary [@plugin-protocol] [@format-proxy].

--- a/almanac/architecture/plugins/plugin-system.md
+++ b/almanac/architecture/plugins/plugin-system.md
@@ -1,0 +1,58 @@
+---
+title: "Plugin System"
+summary: "OfficeCLI's plugin system discovers sidecar executables that add foreign-format reading, exporting, or full handler ownership without moving those implementations into the native handler code."
+topics: [architecture, plugins]
+sources:
+  - id: plugin-protocol
+    type: file
+    path: plugins/plugin-protocol.md
+  - id: plugin-manifest
+    type: file
+    path: src/officecli/Core/Plugins/PluginManifest.cs
+  - id: plugin-registry
+    type: file
+    path: src/officecli/Core/Plugins/PluginRegistry.cs
+  - id: plugin-process
+    type: file
+    path: src/officecli/Core/Plugins/PluginProcess.cs
+  - id: plugin-command
+    type: file
+    path: src/officecli/CommandBuilder.Plugins.cs
+  - id: handler-factory
+    type: file
+    path: src/officecli/Handlers/DocumentHandlerFactory.cs
+---
+
+OfficeCLI's plugin system extends the three native Office formats with sidecar executables. A plugin can migrate a foreign file into a native sibling, export a native file to a foreign target, or own a foreign file through the normal document-handler interface. The boundary matters because the main binary keeps native `.docx`, `.xlsx`, and `.pptx` support in-tree while heavier, licensed, regional, or proprietary implementations live outside the repository [@plugin-protocol].
+
+## Shape
+
+The protocol defines three plugin kinds: `dump-reader`, `exporter`, and `format-handler` [@plugin-protocol]. The same enum and wire strings are represented in `PluginKind`, so runtime selection uses the same names as manifests and the protocol document [@plugin-manifest].
+
+A `dump-reader` reads a foreign source and emits OfficeCLI batch items for a native target. An `exporter` reads a native file and writes a foreign output file. A `format-handler` keeps a foreign file open and answers document operations over stdin and stdout [@plugin-protocol].
+
+This design keeps the plugin boundary at process level. The main program discovers an executable, probes its manifest with `--info`, and then invokes the executable through the flow for its kind [@plugin-registry]. Short-lived plugin calls share the `PluginProcess` runner, which starts the process, reads stdout and stderr, applies an idle watchdog, and maps timeout behavior back to OfficeCLI errors [@plugin-process].
+
+## Discovery And Manifests
+
+Discovery is ordered. OfficeCLI first checks an environment variable, then the user plugin directory, then a bundled plugin directory beside the main executable, and then `PATH` names such as `officecli-dump-reader-doc` or `officecli-doc` [@plugin-protocol]. `PluginRegistry.CandidatePaths` implements that order and caches both positive and negative lookups for the current process [@plugin-registry].
+
+Each candidate must answer `--info` with JSON. The registry parses that JSON as a `PluginManifest` and rejects a plugin whose protocol major version is not `1` [@plugin-registry]. The manifest model stores the name, version, protocol, kinds, extensions, target format, runtime tag, idle-timeout block, optional metadata, and format-handler vocabulary [@plugin-manifest].
+
+The registry also hardens `PATH` lookup. It ignores relative `PATH` entries and Unix directories that are world-writable, which reduces accidental or malicious executable hijacking during plugin resolution [@plugin-registry].
+
+## Runtime Integration
+
+The document open path is where plugins enter normal OfficeCLI behavior. Native extensions still open built-in handlers. Other extensions first try a dump-reader and then a format-handler [@handler-factory]. If neither plugin kind resolves, OfficeCLI reports the file type as unsupported and points the user toward installed plugins and the protocol document [@handler-factory].
+
+The plugin system therefore collaborates with the [document handler lifecycle](../handlers/document-handler-lifecycle) instead of replacing it. Dump-readers convert into a native file that built-in handlers can open. Format-handlers are wrapped as handlers through [format handler plugins](format-handler-plugins), so commands such as get, query, set, add, and validate still flow through the `IDocumentHandler` boundary [@handler-factory].
+
+The command surface includes `plugins list`, `plugins info`, and `plugins lint`. Listing enumerates discoverable plugins and surfaces manifest warnings. Info re-runs `--info` and prints the raw manifest. Lint currently targets dump-readers: it runs `dump`, parses the JSONL batch stream, and checks emitted `add` and `set` properties against the target-format help schemas [@plugin-command].
+
+## Constraints
+
+The manifest is both a compatibility gate and a diagnostic surface. Protocol mismatch is fatal during probing, while softer problems such as missing idle-timeout defaults, unknown kind names, unsupported dump-reader targets, or missing format-handler vocabulary are surfaced as warnings [@plugin-manifest].
+
+The idle watchdog is activity-based, not wall-clock based. Any stdout byte or heartbeat line can reset it, and a user can override the manifest budget with `OFFICECLI_PLUGIN_IDLE_TIMEOUT_SECONDS`, including `0` to disable the watchdog for debugging [@plugin-protocol]. This behavior is implemented in the shared process runner and is the basis for the plugin idle watchdog decision [@plugin-process].
+
+The system's consequence is a narrow but useful extension point. Plugins can add format support without changing native handlers, but they must obey the manifest, discovery, stream, timeout, and ownership rules described by the plugin manifest and plugin discovery references [@plugin-protocol].

--- a/almanac/architecture/runtime/mcp-shared-cli-root.md
+++ b/almanac/architecture/runtime/mcp-shared-cli-root.md
@@ -1,0 +1,60 @@
+---
+title: "MCP Shared CLI Root"
+summary: "The MCP server exposes one officecli tool that parses command strings or argv arrays and invokes the same root command used by the terminal CLI."
+topics: [architecture, runtime, mcp, cli]
+sources:
+  - id: mcp-server
+    type: file
+    path: src/officecli/McpServer.cs
+  - id: mcp-installer
+    type: file
+    path: src/officecli/McpInstaller.cs
+  - id: program
+    type: file
+    path: src/officecli/Program.cs
+  - id: command-builder
+    type: file
+    path: src/officecli/CommandBuilder.cs
+---
+
+The MCP runtime is a stdio JSON-RPC server that exposes a single tool named `officecli`. Instead of defining one MCP tool per document operation, it accepts an OfficeCLI command line as a string or pre-split argv array, strips an optional leading binary name, and invokes the same `CommandBuilder.BuildRootCommand()` tree used by the terminal CLI. This keeps MCP parsing, validation, envelopes, and document behavior aligned with normal command dispatch [@mcp-server] [@command-builder].
+
+## Server Entry Point
+
+`Program.cs` handles `officecli mcp` before normal root-command dispatch. With no target, it starts `McpServer.RunAsync()`; with supported target arguments, it registers or unregisters the server with an MCP client through `McpInstaller` [@program] [@mcp-installer]. The legacy `mcp-serve` alias also starts the MCP server [@program].
+
+The server reads newline-delimited JSON-RPC requests from stdin and writes JSON-RPC responses to stdout. It implements `initialize`, `notifications/initialized`, `tools/list`, `tools/call`, and `ping`, and it rejects unsupported JSON-RPC batch requests with an invalid-request error [@mcp-server].
+
+At startup, the MCP process sets `OFFICECLI_NO_AUTO_RESIDENT=1` unless the environment already defines it. That prevents a lone MCP command from auto-spawning a resident whose deferred flush might surprise the caller, while still allowing commands to route through an already-running resident for the file [@mcp-server]. It also defaults `OFFICECLI_BATCH_ALLOW_STDIN_REDIRECT=1` because stdin is the JSON-RPC transport for MCP, not a user-supplied batch payload [@mcp-server].
+
+## One Tool Surface
+
+`tools/list` advertises exactly one tool, `officecli`. Its input schema has one required property, `command`, whose type may be a string or an array of strings [@mcp-server]. The tool description tells agents to use the same CLI verbs, paths, props, help, validation, screenshot, and save flow that terminal examples use [@mcp-server].
+
+`tools/call` rejects any tool name other than `officecli`. For the accepted tool, `ExecuteCommandLine()` extracts argv, handles special command families that live outside the shared root, handles screenshot output, or invokes the shared CLI root [@mcp-server].
+
+The string form is tokenized without invoking a shell. It honors single and double quotes, preserves most backslashes inside double quotes, and never creates a command-injection surface because tokens go directly to the in-process System.CommandLine parser [@mcp-server]. The array form preserves empty string arguments, which is necessary for values such as `--prop text=` [@mcp-server].
+
+## Shared Root Invocation
+
+The MCP server keeps a cached `RootCommand` from `CommandBuilder.BuildRootCommand()` and calls `RootCommand.Parse(argv).Invoke()` while capturing stdout, stderr, and the exit code [@mcp-server] [@command-builder]. Parse and validation failures are allowed to render through System.CommandLine so MCP users receive the same usage blocks that terminal users see [@mcp-server].
+
+This root-command path means most document commands need no MCP-specific marshalling. New CLI flags and command validation become available to MCP through the shared grammar as soon as they are added to the root command [@mcp-server] [@command-builder].
+
+Some commands are not in the root tree because `Program.cs` early-dispatches them. MCP mirrors the read-only skill path by serving `load_skill`, `skill`, and `skills` from `SkillInstaller` directly [@mcp-server] [@program]. MCP also special-cases screenshots: it runs the CLI screenshot command, injects a temporary output path when needed, reads the PNG, returns an MCP image content block, and removes the auto-created temp file [@mcp-server].
+
+## Result Mapping
+
+CLI stdout and stderr are surfaced together when both exist, so a caller does not lose success text or advisory warnings [@mcp-server]. A non-zero CLI exit normally sets MCP `isError=true`, but exit code `2` with stdout is treated as "applied with caveats" rather than a hard MCP error, because the underlying add or set operation may already have landed while reporting unsupported properties [@mcp-server].
+
+The server returns business verdicts verbatim. For example, a batch or validate command may write a structured envelope with `success:false` to stdout; MCP preserves that text and uses `isError` as the transport-level signal rather than rewriting the payload [@mcp-server].
+
+## Registration
+
+`McpInstaller` registers the command as `officecli mcp` for supported clients. It prefers a stable binary path: the canonical self-install path, then an `officecli` executable found on `PATH`, then the current process path as a fallback [@mcp-installer].
+
+Supported installation targets include LM Studio, Claude Code, Cursor, and VS Code Copilot. LM Studio gets a plugin directory with a manifest and bridge config; Cursor and VS Code use JSON config files; Claude Code prefers the `claude mcp` CLI and falls back to editing `~/.claude.json` if the CLI is unavailable [@mcp-installer].
+
+## Consequences
+
+The MCP architecture chooses one command-string tool over a large generated MCP surface. The benefit is low drift: the CLI root remains the authoritative grammar, help remains the discovery path, and MCP behavior follows [Command Dispatch](../cli/command-dispatch) instead of a parallel tool schema [@mcp-server] [@command-builder]. Resident routing still applies when another OfficeCLI process already owns a file, as described in [Resident Process And Pipes](resident-process-and-pipes) [@mcp-server].

--- a/almanac/architecture/runtime/resident-process-and-pipes.md
+++ b/almanac/architecture/runtime/resident-process-and-pipes.md
@@ -1,0 +1,64 @@
+---
+title: "Resident Process And Pipes"
+summary: "The resident runtime keeps one document open behind per-file named pipes, serializes commands, and controls when in-memory changes are flushed to disk."
+topics: [architecture, runtime, resident]
+sources:
+  - id: command-builder
+    type: file
+    path: src/officecli/CommandBuilder.cs
+  - id: resident-server
+    type: file
+    path: src/officecli/ResidentServer.cs
+  - id: resident-client
+    type: file
+    path: src/officecli/ResidentClient.cs
+  - id: flush-policy
+    type: file
+    path: src/officecli/Core/ResidentFlushPolicy.cs
+---
+
+The resident runtime is OfficeCLI's long-lived document session. A resident process owns one file, keeps its handler in memory, exposes a main named pipe for commands, and exposes a separate ping pipe for liveness, close, and idle-timeout control. This avoids repeated file open/save cost while preserving one-writer ownership: clients must route through the resident when it is alive, and direct file access is used only when no resident owns the file [@command-builder] [@resident-server] [@resident-client].
+
+## Process Ownership
+
+`open` starts a resident by spawning the current executable with the hidden `__resident-serve__` command. The child is given the target file path through `ProcessStartInfo.ArgumentList`, and the parent waits up to five seconds for the ping pipe to respond before reporting success [@command-builder].
+
+The server command takes a per-file singleton lock in the temp directory before opening the document. The lock name is derived from the same pipe name as the resident, and a competing process exits quietly if another resident already starts serving the file [@command-builder]. This prevents multiple resident processes from holding separate in-memory copies and overwriting each other on flush [@command-builder].
+
+Pipe names are based on a SHA-256 hash of the full path, with path casing normalized on Windows and macOS. The main pipe is named `officecli-<hash>` and the ping pipe adds `-ping` [@resident-server] [@resident-client].
+
+## Two-Pipe Protocol
+
+The ping pipe is intentionally separate from the main command pipe. `ResidentClient.TryConnect()` talks to `officecli-<hash>-ping`, sends `__ping__`, and verifies that the returned full path matches the requested file [@resident-client]. The ping pipe also serves `__set-idle-timeout__` and `__close__`, so these control operations remain responsive even when the main command queue is busy [@resident-server] [@resident-client].
+
+The main pipe carries business commands as one JSON request per connection. The server pre-creates the next pipe instance before handing an accepted connection to a worker, which reduces connection gaps during bursts of clients [@resident-server]. Actual command execution is serialized by `_commandLock`, so only one handler operation mutates or reads the in-memory document at a time [@resident-server].
+
+The client retries only during the connect phase. Once a request has been written, it does not resend on broken replies or bad JSON, because the resident may already have applied a non-idempotent mutation such as add, remove, move, swap, or batch [@resident-client]. That gives the pipe protocol at-most-once delivery after write, with visible failure preferred over silent double-application [@resident-client].
+
+## Dispatch And Mutation State
+
+The resident opens handlers read-only by default. The first mutating command promotes the handler to editable mode, enables Word save deferral where applicable, and marks the session dirty [@resident-server]. Mutating commands include set, add, remove, move, swap, refresh, raw-set, add-part, and batch; read-only commands such as get, query, view, raw, validate, and dump can run without promoting the handler [@resident-server].
+
+`CommandBuilder.TryResident()` is the normal front door for single commands. It probes the ping pipe first. If no resident is found, it may auto-start a short-lived resident unless `OFFICECLI_NO_AUTO_RESIDENT` disables that behavior. If a resident is alive but the main pipe cannot accept the command after longer retries, it returns a busy error instead of falling back to direct file access [@command-builder].
+
+Batch uses the same ownership rule. When a resident is alive, the CLI sends the whole batch as one `batch` request, and the resident applies the items against the in-memory handler [@command-builder] [@resident-server]. That path is described from the CLI side in [Batch Execution](../cli/batch-execution).
+
+## Flush And Shutdown
+
+A resident separates in-memory visibility from on-disk visibility. OfficeCLI commands routed through the resident read the live in-memory handler immediately, but external programs only see changes after a save, close, idle autosave, shutdown, or `each` flush [@resident-server] [@flush-policy].
+
+The flush policy is controlled by `OFFICECLI_RESIDENT_FLUSH`, with a legacy fallback environment variable. Supported modes are `each`, `auto`, fixed seconds, and `off` or `0` [@resident-server] [@flush-policy]. `auto` is the default. It uses an idle-debounced interval based on an exponential moving average of measured save duration, clamped between two and ten seconds [@resident-server] [@flush-policy].
+
+Shutdown ordering is part of the correctness contract. The server uses separate cancellation tokens for the main command loop and the ping responder. During shutdown, the main loop stops accepting new commands first, the in-flight command is drained, the handler is disposed, and only then is the ping responder cancelled [@resident-server]. This preserves the invariant that a successful ping implies the resident still owns the handler and file [@resident-server].
+
+`close` sends `__close__` over the ping pipe and waits for the resident's acknowledgement. If shutdown detects that the backing file disappeared before saving, the close response can report a non-zero exit; if the file vanishes after a successful dispose, it reports a warning without flipping the exit code [@resident-server] [@resident-client].
+
+## Failure Behavior
+
+The server captures stdout and stderr around each request, then maps warnings, batch verdicts, validation failures, and JSON envelopes into a `ResidentResponse` with an exit code [@resident-server]. JSON-mode responses avoid double-wrapping already wrapped envelopes and merge resident-level warnings when needed [@resident-server].
+
+Malformed or unreadable pipe input gets an explicit error response instead of a silent close. Pipe reads also have a large message-size ceiling so runaway messages fail visibly instead of being truncated and misreported as undelivered [@resident-server] [@resident-client].
+
+## Consequences
+
+The resident runtime makes OfficeCLI fast for repeated operations without giving up a single-writer model. The cost is that callers must understand the flush boundary: OfficeCLI sees live changes immediately, while non-OfficeCLI readers may need `save`, `close`, or an idle flush first [@resident-server] [@flush-policy]. Normal CLI dispatch is the entry point for this behavior; see [Command Dispatch](../cli/command-dispatch).

--- a/almanac/concepts/batch-item-protocol.md
+++ b/almanac/concepts/batch-item-protocol.md
@@ -1,0 +1,37 @@
+---
+title: "Batch Item Protocol"
+summary: "The batch item protocol is OfficeCLI's shared JSON command object for multi-step CLI batches, resident RPC, MCP execution, SDKs, and in-process embedding."
+topics: [concepts, batch, cli, resident, sdk]
+sources:
+  - id: batch-types
+    type: file
+    path: src/officecli/BatchTypes.cs
+  - id: batch-command
+    type: file
+    path: src/officecli/CommandBuilder.Batch.cs
+  - id: batch-executor
+    type: file
+    path: src/officecli/Core/BatchExecutor.cs
+---
+
+The batch item protocol is the JSON shape OfficeCLI uses when a command must be represented as data instead of argv. A batch item has a bare verb in `command` or `op`, and the verb arguments live beside it as fields such as `path`, `parent`, `type`, `props`, `selector`, `text`, `mode`, `part`, `xpath`, `action`, and `xml` [@batch-types]. This is the shared object behind CLI batch files, resident batch delivery, MCP and SDK-style command objects, and in-process embedding.
+
+The protocol exists to prevent every transport from inventing its own command vocabulary. `BatchItem` can convert itself into a `ResidentRequest`, carrying scalar arguments through `Args` and property dictionaries through `Props` [@batch-types]. The in-process `BatchExecutor` also accepts the same JSON array and returns the same output shape as the CLI batch command [@batch-executor].
+
+## Item Shape
+
+A batch item is not a shell command string. The batch command help explicitly calls out that `command` must be the bare verb, while arguments are sibling fields such as `parent`, `path`, `selector`, `type`, `props`, `to`, `after`, `before`, and `path2` [@batch-command].
+
+The JSON reader is intentionally lenient where that helps agents. It accepts `op` as an alias for `command`, accepts `path` as a query selector alias in the executor path, accepts `path2` or legacy `to` for swap, and accepts `props` either as an object or as an array of `key=value` strings [@batch-types].
+
+## Shared Replay
+
+The central replay loop is `ApplyBatchItems`. It walks the item list, executes each item, captures per-item success or error, and stops early only when `stopOnError` is true [@batch-command]. The CLI non-resident path, MCP-style batch surface, and resident server all reuse this loop so failure handling does not drift between transports [@batch-command].
+
+That shared replay model is why [batch execution](../architecture/cli/batch-execution), [using batch safely](../guides/using-batch-safely), and [batch item fields](../reference/batch-item-fields) all describe the same protocol from different angles. The concept is the object model; the architecture page explains runtime flow; the reference page names every field.
+
+## Save Boundaries
+
+A batch groups mutations so the document can be opened once and saved once in the non-resident path [@batch-command]. When a resident process already owns the file, the CLI sends the whole batch to the resident as one `batch` request, and the resident applies the items in memory while disk flushing is deferred to resident save, close, idle autosave, or an explicit flush policy [@batch-command].
+
+This is the main behavioral difference between a batch item and an argv command. The item describes the same operation, but the surrounding batch controls replay, error collection, and save timing.

--- a/almanac/concepts/command-layers.md
+++ b/almanac/concepts/command-layers.md
@@ -1,0 +1,36 @@
+---
+title: "Command Layers"
+summary: "OfficeCLI commands sit on semantic, document-node, and raw XML layers so agents can start with stable document operations and drop lower only when needed."
+topics: [concepts, cli, handlers]
+sources:
+  - id: readme-purpose
+    type: file
+    path: README.md
+  - id: handler-contract
+    type: file
+    path: src/officecli/Core/IDocumentHandler.cs
+---
+
+Command layers are the three levels at which OfficeCLI exposes an Office document: a semantic view layer for readable summaries, a document-node layer for structured operations, and a raw layer for direct OOXML access. The layers matter because OfficeCLI is built for agents that need to read, change, validate, and render Word, Excel, and PowerPoint files without Office installed, while still having an escape hatch when a curated operation is not enough [@readme-purpose].
+
+The [command dispatch](../architecture/cli/command-dispatch) surface is easier to understand through this model. A command is not just a CLI verb. It also chooses how much of the document model the caller wants to handle.
+
+## Semantic Layer
+
+The semantic layer is for looking at a document without committing to its internal tree shape. The shared handler contract exposes text, annotated text, outline, stats, issue, and JSON variants as first-class view operations [@handler-contract]. These operations let callers inspect a document before deciding which node to edit.
+
+This layer is intentionally high-level. It answers questions like "what does the document say?", "what sections or slides exist?", and "what problems are visible?". It is the safest layer for orientation because it does not require a path, selector, or XML part name.
+
+## Document-Node Layer
+
+The document-node layer is the normal editing layer. The same handler contract exposes `get`, `query`, `set`, `add`, `remove`, `move`, and `copyFrom` operations over paths, selectors, element types, insertion positions, and property dictionaries [@handler-contract].
+
+This layer gives OfficeCLI its cross-format command vocabulary. A PowerPoint shape, a Word paragraph, and an Excel cell are different objects internally, but they can all be addressed as document nodes and changed through the same command family. The [document node and paths](document-node-and-paths) concept explains that address model in more detail.
+
+The layer is also where most user-facing safety checks belong. A curated `set` operation can reject an unsupported property, a `remove` can return a warning, and an `add` can resolve an insertion position before anything touches raw XML [@handler-contract]. That keeps common edits inside the handler lifecycle rather than pushing callers into package internals.
+
+## Raw Layer
+
+The raw layer is the fallback below curated document operations. The handler contract includes raw part reads, XPath-based raw writes, part creation, validation, binary extraction, and save operations [@handler-contract].
+
+This layer exists because OOXML is larger than the curated command surface. It lets maintainers and advanced agents reach specific package parts while still using the same file-opening and validation machinery described in the [document handler lifecycle](../architecture/handlers/document-handler-lifecycle). The [command surface](../reference/command-surface) reference should therefore be read as layered: semantic commands first, structured node mutations next, and raw XML only when the stable vocabulary does not cover the case.

--- a/almanac/concepts/document-node-and-paths.md
+++ b/almanac/concepts/document-node-and-paths.md
@@ -1,0 +1,40 @@
+---
+title: "Document Node And Paths"
+summary: "DocumentNode is OfficeCLI's cross-format tree object, and slash paths are the stable addresses used by get, query output, mutations, batches, and agent calls."
+topics: [concepts, handlers, cli]
+sources:
+  - id: document-node
+    type: file
+    path: src/officecli/Core/DocumentNode.cs
+  - id: handler-paths
+    type: file
+    path: src/officecli/Core/IDocumentHandler.cs
+  - id: get-query-command
+    type: file
+    path: src/officecli/CommandBuilder.GetQuery.cs
+  - id: mcp-command-line
+    type: file
+    path: src/officecli/McpServer.cs
+---
+
+`DocumentNode` is the common object OfficeCLI uses to describe Word, Excel, PowerPoint, and plugin-backed document structure. Its `path` is the durable address of a node, while fields such as `type`, `text`, `preview`, `style`, `childCount`, `format`, and `children` carry the visible data returned to callers [@document-node]. Paths matter because most read and mutation commands use them as their exact target language.
+
+The shared handler contract makes paths central. `Get` takes a path and depth, while `Set`, `Remove`, `Move`, `CopyFrom`, and binary extraction all target paths directly [@handler-paths]. `Query` is different: it accepts a selector and returns matching `DocumentNode` values, which then carry paths that can be reused by later commands [@handler-paths].
+
+## Slash Paths
+
+Slash paths name positions in the document tree. The CLI describes `get` as reading a DOM path such as `/body/p[1]`, and it defaults to `/` when no path is supplied [@get-query-command]. Other examples in the agent-facing MCP guidance use the same 1-based bracketed form, such as `/slide[1]`, so agents can pass the same path string through the CLI tool instead of learning a separate transport model [@mcp-command-line].
+
+The path string is exact. A command such as `set` or `remove` is expected to name one target node, not a broad query. This is why [selectors vs slash paths](selectors-vs-slash-paths) is a separate concept: selectors are for finding nodes, while paths are for addressing the chosen node.
+
+## Node Shape
+
+`DocumentNode` is deliberately small. User-facing JSON includes the address, type, text-like summaries, a `format` dictionary, and optional children [@document-node]. The class also has `InternalFormat`, but it is ignored by JSON serialization and is reserved for round-trip metadata such as verbatim OOXML fragments used by internal emitters [@document-node].
+
+That split is important. The public node shape stays stable for CLI, MCP, batch, and SDK consumers, while handlers can still carry internal details needed for faithful document rewrites.
+
+## How Paths Flow
+
+The normal path flow is: use a semantic view or selector to locate content, read the node with `get`, then pass the node path into a mutation. `query` returns node lists, and `get --json` uses the same `{matches, results}` shape as query so consumers can parse both through one path [@get-query-command].
+
+Batch items use the same address fields described in [batch item fields](../reference/batch-item-fields). That is why a path learned from `get`, query output, a watch selection, or MCP text can be carried into a later batch or resident request without translating it into a format-specific object id.

--- a/almanac/concepts/help-schemas.md
+++ b/almanac/concepts/help-schemas.md
@@ -1,0 +1,37 @@
+---
+title: "Help Schemas"
+summary: "Help schemas are embedded JSON capability contracts that tell agents which OfficeCLI elements, verbs, properties, aliases, and examples are supported."
+topics: [concepts, schemas, cli]
+sources:
+  - id: schemas-readme
+    type: file
+    path: schemas/README.md
+  - id: schema-loader
+    type: file
+    path: src/officecli/Help/SchemaHelpLoader.cs
+  - id: project-embedding
+    type: file
+    path: src/officecli/officecli.csproj
+---
+
+Help schemas are OfficeCLI's machine-readable capability contract. They live under `schemas/help/`, are embedded into the binary, and describe what each supported Word, Excel, and PowerPoint element can do through operations, properties, aliases, and examples [@schemas-readme]. They are not narrative documentation; they are the data source agents and tests use to stay aligned with the command surface.
+
+The schema system matters because OfficeCLI has a large cross-format vocabulary. A caller should be able to ask what `docx`, `xlsx`, or `pptx` supports and receive a precise answer from the same binary that will execute the command.
+
+## Embedded Contract
+
+The project file embeds every JSON file under `schemas/help/**` as an assembly resource with a `schemas/help/...` logical name [@project-embedding]. `SchemaHelpLoader` builds an index from manifest resource names and opens schemas from the assembly rather than from the runtime filesystem [@schema-loader].
+
+That design is important for the self-contained binary. The schema reference travels with the executable, so `help` can work without a checked-out source tree, extracted schema directory, or network access.
+
+## Resolution Model
+
+The loader normalizes format aliases: `word` maps to `docx`, `excel` to `xlsx`, and `ppt` or `powerpoint` to `pptx` [@schema-loader]. It also treats `/` as the root element alias for the relevant format, mapping it to workbook, document, or presentation [@schema-loader].
+
+Element lookup first tries the schema filename and then scans `elementAliases` declared in schemas, so path-style names such as short element aliases can still resolve to their canonical schema file [@schema-loader]. A schema may also declare `extends`, and the loader composes shared bases before applying the element-specific override [@schema-loader].
+
+## How They Differ From Wiki Pages
+
+The schemas README draws a sharp boundary: schemas are the single source of truth for supported add, set, get, and readback behavior, while narrative tutorials and best practices belong in the wiki [@schemas-readme]. That is why [help schema loader](../architecture/cli/help-schema-loader), [help schema format](../reference/help-schema-format), and [schema CRC](../reference/schema-crc) are separate pages. The concept is the contract; the architecture explains loading; the references describe file shape and fingerprinting.
+
+When command behavior changes, the matching schema is expected to change with it, and contract tests verify schema claims against real handler behavior [@schemas-readme]. This keeps the agent-facing help surface from becoming aspirational documentation.

--- a/almanac/concepts/officecli-skills.md
+++ b/almanac/concepts/officecli-skills.md
@@ -1,0 +1,44 @@
+---
+title: "OfficeCLI Skills"
+summary: "OfficeCLI skills are lazy, agent-facing guides that teach document workflows while the CLI help schemas remain the command authority."
+topics: [concepts, skills, agent]
+sources:
+  - id: root-skill
+    type: file
+    path: SKILL.md
+  - id: docx-skill
+    type: file
+    path: skills/officecli-docx/SKILL.md
+  - id: skill-installer
+    type: file
+    path: src/officecli/Core/SkillInstaller.cs
+  - id: program
+    type: file
+    path: src/officecli/Program.cs
+---
+
+OfficeCLI skills are the human-readable operating manuals that an AI agent loads when it needs to work on Office files. They explain workflow, safety gates, and format-specific habits, while `officecli help` remains the source for command syntax, element properties, and schema details [@root-skill]. This matters because the repo supports both broad agent entry points and specialized document tasks: the base skill teaches the overall layer model, and sub-skills such as `officecli-docx` teach deeper rules for one format [@docx-skill].
+
+## Why Skills Exist
+
+The CLI already has a schema-driven help system, but schemas are not enough for an agent building a real document. A schema can list valid properties. It cannot reliably teach when to prefer read commands, when to run visual QA, or why a Word footer should use a live `PAGE` field instead of literal text. The base skill therefore tells agents to use the command layers in order: read first, use DOM edits when possible, and fall back to raw XML only when needed [@root-skill].
+
+Specialized skills carry the operational knowledge that would be too large or too situational for every session. The DOCX skill, for example, explains shell quoting, incremental execution, document hierarchy, output quality requirements, the open/save lifecycle, and QA expectations for Word files [@docx-skill]. That makes skills a guidance layer around the command surface rather than a replacement for it.
+
+## Lazy Loading
+
+OfficeCLI keeps skill detail lazy. The `SkillInstaller` maps short names such as `word`, `excel`, `pptx`, `morph-ppt`, `academic-paper`, `data-dashboard`, and `financial-model` to bundled skill folders [@skill-installer]. It also builds a compact trigger summary for MCP tool descriptions, so agents see when to load a skill without receiving every full manual up front [@skill-installer].
+
+The same installer can return a catalog, return one skill's `SKILL.md`, list bundled reference files, or fetch a referenced text file from a skill bundle [@skill-installer]. Binary assets are deliberately excluded from text-channel loading and are only made available through skill installation on disk [@skill-installer]. This split lets the MCP and CLI surfaces expose guidance without corrupting non-text assets.
+
+## Loading Versus Installing
+
+OfficeCLI separates reading a skill from installing a skill. `load_skill` is a read-only command that prints the skill catalog, a named skill, or one bundled reference file; `skills install` writes skill files into detected agent skill directories [@program]. Program dispatch keeps `skill` and `skills` as accepted command tokens, but routes named skill reading through `load_skill` so loading and installation have matching CLI and MCP semantics [@program].
+
+Installation is targeted at AI clients. The installer knows directory conventions for Claude Code, GitHub Copilot, Codex CLI, Cursor, Pi, Windsurf, MiniMax CLI, OpenCode, Hermes Agent, OpenClaw, NanoBot, and ZeroClaw [@skill-installer]. A base install writes the umbrella OfficeCLI skill, while a named install writes a specific sub-skill and any bundled files for that sub-skill [@skill-installer].
+
+## Relationship To Schemas And MCP
+
+Skills are closely related to [MCP and skills](../architecture/agent/mcp-and-skills) and [bundled skills](../reference/bundled-skills), but they solve a different problem from schemas. The base skill explicitly tells agents to run `officecli help` when property names, value formats, or command syntax are uncertain [@root-skill]. The DOCX skill repeats that help-first rule and states that help is authoritative when a skill and help disagree [@docx-skill].
+
+That division is the key mental model: skills teach how to work, and help schemas define what the installed binary accepts. A contributor changing OfficeCLI behavior should update schemas for command truth and update skills when the agent workflow, quality gate, or format-specific discipline changes.

--- a/almanac/concepts/raw-xml-access.md
+++ b/almanac/concepts/raw-xml-access.md
@@ -21,7 +21,7 @@ Raw XML access is the universal fallback under OfficeCLI's curated document comm
 
 ## The Command Layer
 
-`raw` takes a file and a part path, with optional row and column filters for Excel sheets [@raw-command]. `raw-set` takes a file, part path, XPath, action, and optional XML fragment or attribute assignment [@raw-command]. Supported raw-set actions include append, prepend, insert-before, insert-after, replace, remove, and set-attribute operations [@raw-helper].
+`raw` takes a file and a part path, with optional row and column filters for Excel sheets [@raw-command]. `raw-set` takes a file, part path, XPath, action, and optional XML fragment or attribute assignment [@raw-command]. Its accepted action tokens are `append`, `prepend`, `insertbefore`, `insertafter`, `replace`, `remove`, and `setattr` [@raw-helper].
 
 The command builder still uses the normal OfficeCLI safety frame. It tries resident delivery first, opens the handler directly when no resident owns the file, validates before and after mutation, reports new validation problems as warnings, and notifies live watch previews after a raw edit [@raw-command]. That makes raw access a low-level command layer, not a separate toolchain.
 

--- a/almanac/concepts/raw-xml-access.md
+++ b/almanac/concepts/raw-xml-access.md
@@ -1,0 +1,44 @@
+---
+title: "Raw XML Access"
+summary: "Raw XML access is OfficeCLI's lowest command layer, exposing Office package parts for inspection and last-resort mutation when curated operations are not enough."
+topics: [concepts, cli, handlers]
+sources:
+  - id: raw-command
+    type: file
+    path: src/officecli/CommandBuilder.Raw.cs
+  - id: raw-helper
+    type: file
+    path: src/officecli/Core/RawXmlHelper.cs
+  - id: excel-handler
+    type: file
+    path: src/officecli/Handlers/ExcelHandler.cs
+  - id: ppt-handler
+    type: file
+    path: src/officecli/Handlers/PowerPointHandler.cs
+---
+
+Raw XML access is the universal fallback under OfficeCLI's curated document commands. The `raw` command reads XML from a document part, `raw-set` applies an XPath-based mutation to a part, and `add-part` creates a new Office package part for later raw editing [@raw-command]. This layer exists because not every OpenXML feature has a first-class `add`, `set`, or `remove` operation, but the file format is still XML inside an Office package.
+
+## The Command Layer
+
+`raw` takes a file and a part path, with optional row and column filters for Excel sheets [@raw-command]. `raw-set` takes a file, part path, XPath, action, and optional XML fragment or attribute assignment [@raw-command]. Supported raw-set actions include append, prepend, insert-before, insert-after, replace, remove, and set-attribute operations [@raw-helper].
+
+The command builder still uses the normal OfficeCLI safety frame. It tries resident delivery first, opens the handler directly when no resident owns the file, validates before and after mutation, reports new validation problems as warnings, and notifies live watch previews after a raw edit [@raw-command]. That makes raw access a low-level command layer, not a separate toolchain.
+
+## Semantic Parts And Zip URIs
+
+Raw part names can be semantic or literal. Semantic names are handler-defined shortcuts such as `/workbook`, `/styles`, `/Sheet1`, `/presentation`, `/slide[1]`, `/slideMaster[1]`, or `/notesMaster` [@excel-handler] [@ppt-handler]. Literal zip-URI paths are paths ending in `.xml` or `.rels`, such as `/xl/worksheets/sheet1.xml` or `/ppt/slides/slide1.xml`; `RawXmlHelper` treats those as package-internal URIs and resolves them across the package part graph [@raw-helper].
+
+This design replaced incomplete per-handler alias tables. The helper comments state the rule directly: semantic short names still route through handler switches, while `.xml` and `.rels` paths use zip-URI lookup so arbitrary package parts can be reached [@raw-helper].
+
+## XML Mutation Semantics
+
+Raw XML mutation is XPath-based. `RawXmlHelper` parses the target XML, registers common OpenXML namespace prefixes, finds matching elements, applies the requested action, and writes the modified XML back to the OpenXML part [@raw-helper]. If the XPath matches no elements, raw-set raises an error rather than returning a successful no-op, because silent raw mutations are dangerous in batch and resident flows [@raw-helper].
+
+The helper also handles OpenXML details that ordinary XML string replacement would miss. It preserves namespace declarations for SDK round-tripping, copies root attributes that the `InnerXml` setter would otherwise drop, normalizes whitespace-only leaf text so meaningful spaces survive, and reorders known PowerPoint containers into schema order after raw appends [@raw-helper]. It also updates markup-compatibility `mc:Ignorable` data when alternate-content choices require extension prefixes [@raw-helper].
+
+## When To Use It
+
+Raw XML is related to [command layers](command-layers), [document handler lifecycle](../architecture/handlers/document-handler-lifecycle), and the [command surface](../reference/command-surface). It should be understood as the escape hatch below the semantic API. Curated commands are easier to validate and easier for agents to reason about. Raw access is for gaps: unusual OpenXML features, package parts without a curated wrapper, replay of advanced dumps, or precise repairs that the high-level handler cannot express.
+
+The mental model is therefore layered. Use `get`, `query`, `add`, `set`, and `remove` when they cover the task. Use `raw` to inspect the underlying XML when the semantic view is insufficient. Use `raw-set` only when the caller knows the target part, XPath, and XML effect well enough to own the package-level consequences.

--- a/almanac/concepts/resident-sessions.md
+++ b/almanac/concepts/resident-sessions.md
@@ -1,0 +1,37 @@
+---
+title: "Resident Sessions"
+summary: "Resident sessions are per-file in-memory OfficeCLI handlers served over named pipes, with serialized commands and explicit or policy-driven disk flushing."
+topics: [concepts, resident, runtime]
+sources:
+  - id: resident-server
+    type: file
+    path: src/officecli/ResidentServer.cs
+  - id: resident-client
+    type: file
+    path: src/officecli/ResidentClient.cs
+  - id: flush-policy
+    type: file
+    path: src/officecli/Core/ResidentFlushPolicy.cs
+---
+
+A resident session is a long-lived OfficeCLI process that keeps one document handler in memory for one file. Clients find it through a per-file named pipe, send commands over the main pipe, and use a separate ping pipe to check liveness or request close without waiting behind document work [@resident-server]. The model exists so repeated edits can reuse the same parsed document and avoid reopening or resaving the package for every command.
+
+The server derives its pipe name from a normalized full file path hash, so the resident is scoped to the file rather than to a terminal or project directory [@resident-server]. The client verifies that a ping response names the same full path before treating a resident as the owner of a file [@resident-client].
+
+## Serialized Ownership
+
+Resident sessions are single-owner sessions. The server accepts pipe connections concurrently, but command execution is guarded by `_commandLock`, so document operations run one at a time against the in-memory handler [@resident-server]. The client only retries connection establishment; after it writes a command, it does not resend on read failure because the resident may already have applied a non-idempotent mutation [@resident-client].
+
+That at-most-once rule is part of the safety model. A visible delivery failure is better than applying `add`, `remove`, `move`, `swap`, or `batch` twice.
+
+## Dirty State And Flush Policy
+
+Resident mutation commands first promote the handler to editable mode, mark the in-memory document dirty, and defer Word saves inside the resident lifetime [@resident-server]. The dirty flag is cleared by explicit save, close, shutdown, or idle autosave after a successful handler save [@resident-server].
+
+The flush policy is controlled by one parser that recognizes `each`, `auto`, fixed seconds, and `off` or `0` [@flush-policy]. In `auto` mode, the debounce interval is derived from an exponential moving average of measured save duration and clamped between two and ten seconds [@flush-policy]. This lets ordinary resident sessions feel current without forcing every mutation to pay a full package save.
+
+## Ping Liveness
+
+The ping pipe has a specific invariant: a successful ping should mean the handler still owns the file [@resident-server]. During shutdown, the server cancels the main command loop before disposing the handler, and it cancels the ping responder only after dispose finishes [@resident-server]. This ordering supports the [resident ping liveness invariant](../decisions/resident-ping-liveness-invariant) and keeps clients from silently falling back to direct file access while a live resident still holds unsaved state.
+
+Related runtime behavior is covered by [resident process and pipes](../architecture/runtime/resident-process-and-pipes) and the operational guide for [resident save, close, and flush](../guides/resident-save-close-flush).

--- a/almanac/concepts/selectors-vs-slash-paths.md
+++ b/almanac/concepts/selectors-vs-slash-paths.md
@@ -1,0 +1,47 @@
+---
+title: "Selectors Vs Slash Paths"
+summary: "Selectors and slash paths are two addressing models in OfficeCLI: exact node paths identify known elements, while selectors find elements by type, content, or attributes."
+topics: [concepts, handlers, cli]
+sources:
+  - id: word-selector
+    type: file
+    path: src/officecli/Handlers/Word/WordHandler.Selector.cs
+  - id: excel-selector
+    type: file
+    path: src/officecli/Handlers/Excel/ExcelHandler.Selector.cs
+  - id: ppt-selector
+    type: file
+    path: src/officecli/Handlers/Pptx/PowerPointHandler.Selector.cs
+  - id: command-query
+    type: file
+    path: src/officecli/CommandBuilder.GetQuery.cs
+  - id: command-set
+    type: file
+    path: src/officecli/CommandBuilder.Set.cs
+---
+
+Selectors and slash paths are the two ways OfficeCLI names document content. A slash path such as `/body/p[1]`, `/Sheet1/A1`, or `/slide[1]/shape[2]` points at a specific node. A selector such as `paragraph[style=Heading1]`, `cell[bold=true]`, or `shape:Revenue` finds nodes by type, content, or attributes. The distinction matters because `get`, mutation commands, batch items, and handler internals often cross from one model to the other [@command-query] [@command-set].
+
+## Exact Paths
+
+Slash paths are best when the caller already knows the target. They are stable enough to pass between commands, and they match the document-node model used by `get` and many mutation operations. In practice, a path is a concrete address inside one document: a Word paragraph, an Excel cell or sheet element, or a PowerPoint slide element.
+
+The CLI treats query as selector-oriented. Its `query` command accepts a CSS-like selector argument and then asks the current handler to produce matching `DocumentNode` results [@command-query]. That keeps broad searches separate from exact-node reads.
+
+## Selectors
+
+Selectors are intentionally format-specific. Word parses element names, bracket attributes, `:contains(...)`, `:empty`, `:no-alt`, and a `>` child combinator while matching paragraphs and runs against Word-specific properties such as style, numbering, font, and run content [@word-selector]. Excel accepts sheet prefixes, path-style selector normalization, cell value filters, formula and empty pseudo-selectors, type filters, and short format aliases such as `bold` mapping to `font.bold` [@excel-selector]. PowerPoint accepts slide scoping, shape/media/table/chart-oriented element types, `:contains(...)`, `:no-alt`, generic attributes, and rejects unsupported combinators with explicit selector errors [@ppt-selector].
+
+This is why [selector grammar by format](../reference/selector-grammar-by-format) is a separate reference page. The shared idea is CSS-like filtering, not one universal CSS engine.
+
+## Where They Meet
+
+Handlers bridge selectors to paths by returning matching `DocumentNode` values. Once a selector has matched nodes, downstream code can use each node's concrete path for edits or output. The set command has a special selector-set path: if the target is a selector instead of a slash path, matching nodes are edited through the same filtering path used by query, and the handler records how many elements were touched [@command-set].
+
+The bridge has safety rules. The CLI rejects bare unscoped selector-style mutation targets in cases where a short selector could accidentally update too much content [@command-set]. Query, by contrast, is meant for discovery and accepts broad selectors such as type names or attribute filters [@command-query].
+
+## Format-Specific Normalization
+
+Excel shows the most explicit path-selector overlap. Its selector parser normalizes path-style selectors such as `/Sheet1/cell[...]` into sheet-scoped selector form and also accepts Excel-native forms such as `Sheet1!cell[...]` [@excel-selector]. PowerPoint allows selected path-style slide scopes such as `/slide[1]/...`, but rejects other leading-slash selectors in query because a raw path like `/theme` is not a selector subject [@ppt-selector]. Word keeps its selector parser focused on element and attribute matching rather than treating arbitrary slash paths as selectors [@word-selector].
+
+The useful rule is simple: use slash paths when you have an exact node, and use selectors when you need to find nodes. Pages such as [document node and paths](document-node-and-paths), [selector grammar by format](../reference/selector-grammar-by-format), and [adding handler mutations](../guides/adding-handler-mutations) depend on that distinction.

--- a/almanac/coverage-map.md
+++ b/almanac/coverage-map.md
@@ -1,0 +1,291 @@
+---
+title: Coverage Map
+summary: Frozen page inventory for this first wiki build.
+topics: [build, wiki, reference]
+sources: []
+---
+
+## Page Inventory
+
+### Root
+
+- path: `almanac/getting-started.md`
+  - slug: `getting-started`
+  - purpose: Front door that routes contributors to the command, handler, agent integration, plugin, and release clusters.
+  - planned links: `architecture/cli/command-dispatch`, `architecture/handlers/document-handler-lifecycle`, `architecture/runtime/resident-process-and-pipes`, `concepts/command-layers`
+  - key evidence: `README.md`, `src/officecli/Program.cs`, `src/officecli/CommandBuilder.cs`
+
+### `concepts/`
+
+- path: `almanac/concepts/command-layers.md`
+  - slug: `concepts/command-layers`
+  - purpose: Explain the semantic view, document DOM, and raw XML layers that shape the public command model.
+  - planned links: `architecture/cli/command-dispatch`, `architecture/handlers/document-handler-lifecycle`, `reference/command-surface`
+  - key evidence: `README.md`, `src/officecli/Core/IDocumentHandler.cs`
+- path: `almanac/concepts/document-node-and-paths.md`
+  - slug: `concepts/document-node-and-paths`
+  - purpose: Define the cross-format `DocumentNode` abstraction and 1-based path model used by get, query, mutations, and SDK calls.
+  - planned links: `concepts/command-layers`, `concepts/selectors-vs-slash-paths`, `reference/batch-item-fields`
+  - key evidence: `src/officecli/Core/DocumentNode.cs`, `src/officecli/Core/IDocumentHandler.cs`, `src/officecli/McpServer.cs`
+- path: `almanac/concepts/batch-item-protocol.md`
+  - slug: `concepts/batch-item-protocol`
+  - purpose: Explain why batch items are the shared command object across CLI batch, resident RPC, MCP, SDKs, and in-process embedding.
+  - planned links: `architecture/cli/batch-execution`, `reference/batch-item-fields`, `guides/using-batch-safely`
+  - key evidence: `src/officecli/BatchTypes.cs`, `src/officecli/CommandBuilder.Batch.cs`, `src/officecli/Core/BatchExecutor.cs`
+- path: `almanac/concepts/resident-sessions.md`
+  - slug: `concepts/resident-sessions`
+  - purpose: Define resident sessions as per-file in-memory handlers with deferred flush and serialized mutation delivery.
+  - planned links: `architecture/runtime/resident-process-and-pipes`, `guides/resident-save-close-flush`, `decisions/resident-ping-liveness-invariant`
+  - key evidence: `src/officecli/ResidentServer.cs`, `src/officecli/ResidentClient.cs`, `src/officecli/Core/ResidentFlushPolicy.cs`
+- path: `almanac/concepts/help-schemas.md`
+  - slug: `concepts/help-schemas`
+  - purpose: Explain schemas as the embedded agent-facing capability contract, not narrative documentation.
+  - planned links: `architecture/cli/help-schema-loader`, `reference/help-schema-format`, `reference/schema-crc`
+  - key evidence: `schemas/README.md`, `src/officecli/Help/SchemaHelpLoader.cs`, `src/officecli/officecli.csproj`
+- path: `almanac/concepts/officecli-skills.md`
+  - slug: `concepts/officecli-skills`
+  - purpose: Explain the base and specialized skills as lazy agent guidance that complements but does not replace help schemas.
+  - planned links: `architecture/agent/mcp-and-skills`, `reference/bundled-skills`
+  - key evidence: `SKILL.md`, `skills/officecli-docx/SKILL.md`, `src/officecli/Core/SkillInstaller.cs`
+- path: `almanac/concepts/selectors-vs-slash-paths.md`
+  - slug: `concepts/selectors-vs-slash-paths`
+  - purpose: Clarify when OfficeCLI uses exact slash paths versus CSS-like selectors and how handlers bridge the two.
+  - planned links: `concepts/document-node-and-paths`, `reference/selector-grammar-by-format`, `guides/adding-handler-mutations`
+  - key evidence: `src/officecli/Handlers/Word/WordHandler.Selector.cs`, `src/officecli/Handlers/Excel/ExcelHandler.Selector.cs`, `src/officecli/Handlers/Pptx/PowerPointHandler.Selector.cs`
+- path: `almanac/concepts/raw-xml-access.md`
+  - slug: `concepts/raw-xml-access`
+  - purpose: Explain raw XML and zip-URI access as the universal fallback below curated document operations.
+  - planned links: `concepts/command-layers`, `architecture/handlers/document-handler-lifecycle`, `reference/command-surface`
+  - key evidence: `src/officecli/CommandBuilder.Raw.cs`, `src/officecli/Core/RawXmlHelper.cs`, `src/officecli/Handlers/ExcelHandler.cs`, `src/officecli/Handlers/PowerPointHandler.cs`
+
+### `architecture/cli/`
+
+- path: `almanac/architecture/cli/command-dispatch.md`
+  - slug: `architecture/cli/command-dispatch`
+  - purpose: Map early dispatch, help rewriting, root command construction, command families, and shared `--json` behavior.
+  - planned links: `concepts/command-layers`, `architecture/cli/batch-execution`, `architecture/runtime/mcp-shared-cli-root`, `reference/command-surface`
+  - key evidence: `src/officecli/Program.cs`, `src/officecli/CommandBuilder.cs`, `src/officecli/CommandBuilder.IntegrationStubs.cs`
+- path: `almanac/architecture/cli/batch-execution.md`
+  - slug: `architecture/cli/batch-execution`
+  - purpose: Explain input normalization, envelope unwrapping, continue-on-error semantics, shared replay, and output formatting for batches.
+  - planned links: `concepts/batch-item-protocol`, `guides/using-batch-safely`, `reference/batch-item-fields`
+  - key evidence: `src/officecli/BatchTypes.cs`, `src/officecli/CommandBuilder.Batch.cs`, `src/officecli/Core/BatchExecutor.cs`
+- path: `almanac/architecture/cli/help-schema-loader.md`
+  - slug: `architecture/cli/help-schema-loader`
+  - purpose: Explain how embedded help schemas are located, alias-resolved, merged through `extends`, rendered, and fingerprinted.
+  - planned links: `concepts/help-schemas`, `reference/help-schema-format`, `reference/schema-crc`
+  - key evidence: `src/officecli/Help/SchemaHelpLoader.cs`, `src/officecli/Help/SchemaHelpRenderer.cs`, `src/officecli/Help/SchemaHelpFlatRenderer.cs`, `src/officecli/Help/SchemaCrc.cs`
+
+### `architecture/runtime/`
+
+- path: `almanac/architecture/runtime/resident-process-and-pipes.md`
+  - slug: `architecture/runtime/resident-process-and-pipes`
+  - purpose: Explain the resident server/client lifecycle, per-file pipe names, singleton lock, serialized command queue, autosave, and failure behavior.
+  - planned links: `concepts/resident-sessions`, `architecture/agent/sdk-resident-clients`, `guides/resident-save-close-flush`, `decisions/resident-ping-liveness-invariant`
+  - key evidence: `src/officecli/CommandBuilder.cs`, `src/officecli/ResidentServer.cs`, `src/officecli/ResidentClient.cs`, `src/officecli/Core/ResidentFlushPolicy.cs`
+- path: `almanac/architecture/runtime/mcp-shared-cli-root.md`
+  - slug: `architecture/runtime/mcp-shared-cli-root`
+  - purpose: Explain the stdio JSON-RPC MCP server as a single-tool bridge into the same CLI root.
+  - planned links: `architecture/cli/command-dispatch`, `architecture/agent/mcp-and-skills`, `decisions/mcp-single-tool-command-string`
+  - key evidence: `src/officecli/McpServer.cs`, `src/officecli/McpInstaller.cs`, `src/officecli/Program.cs`
+
+### `architecture/handlers/`
+
+- path: `almanac/architecture/handlers/document-handler-lifecycle.md`
+  - slug: `architecture/handlers/document-handler-lifecycle`
+  - purpose: Explain file opening, safety guards, native handler dispatch, plugin fallback, and the shared `IDocumentHandler` contract.
+  - planned links: `concepts/command-layers`, `concepts/document-node-and-paths`, `concepts/raw-xml-access`, `architecture/plugins/plugin-system`
+  - key evidence: `src/officecli/Handlers/DocumentHandlerFactory.cs`, `src/officecli/Core/IDocumentHandler.cs`, `src/officecli/Handlers/WordHandler.cs`, `src/officecli/Handlers/ExcelHandler.cs`, `src/officecli/Handlers/PowerPointHandler.cs`
+- path: `almanac/architecture/handlers/rendering-and-preview-stack.md`
+  - slug: `architecture/handlers/rendering-and-preview-stack`
+  - purpose: Explain the renderer registry, parsed-model render inputs, format-specific preview implementations, screenshots, and resources.
+  - planned links: `architecture/handlers/document-handler-lifecycle`, `architecture/handlers/watch-preview-contract`, `decisions/renderers-receive-parsed-models`
+  - key evidence: `src/officecli/Core/Rendering/`, `src/officecli/Handlers/Rendering/`, `src/officecli/CommandBuilder.View.cs`, `src/officecli/Resources/preview.css`, `src/officecli/Resources/preview.js`
+- path: `almanac/architecture/handlers/watch-preview-contract.md`
+  - slug: `architecture/handlers/watch-preview-contract`
+  - purpose: Explain live preview watch/unwatch, marks and goto, SSE refresh, and why watch does not own document parsing.
+  - planned links: `architecture/handlers/rendering-and-preview-stack`, `reference/command-surface`
+  - key evidence: `src/officecli/CommandBuilder.Watch.cs`, `src/officecli/CommandBuilder.Mark.cs`, `src/officecli/Core/Watch/WatchServer.cs`, `src/officecli/Core/Watch/WatchNotifier.cs`
+- path: `almanac/architecture/handlers/rich-object-helpers.md`
+  - slug: `architecture/handlers/rich-object-helpers`
+  - purpose: Explain shared helper subsystems for charts, diagrams, OLE, formulas, themes, and rich Office objects used across handlers.
+  - planned links: `architecture/handlers/document-handler-lifecycle`, `reference/rich-object-helper-map`
+  - key evidence: `src/officecli/Core/Chart/`, `src/officecli/Core/Diagram/`, `src/officecli/Core/OleHelper.cs`, `src/officecli/Core/Formula/`
+
+### `architecture/plugins/`
+
+- path: `almanac/architecture/plugins/plugin-system.md`
+  - slug: `architecture/plugins/plugin-system`
+  - purpose: Explain plugin kinds, discovery, manifest probing, and how plugins extend format support without entering the native handler code.
+  - planned links: `architecture/handlers/document-handler-lifecycle`, `reference/plugin-discovery`, `reference/plugin-manifest`, `decisions/plugin-idle-watchdog`
+  - key evidence: `plugins/plugin-protocol.md`, `src/officecli/Core/Plugins/PluginRegistry.cs`, `src/officecli/Core/Plugins/PluginManifest.cs`
+- path: `almanac/architecture/plugins/format-handler-plugins.md`
+  - slug: `architecture/plugins/format-handler-plugins`
+  - purpose: Explain long-lived format-handler sessions, vocabulary snapshots, proxying, capabilities, and broken-state handling.
+  - planned links: `architecture/plugins/plugin-system`, `reference/plugin-manifest`
+  - key evidence: `plugins/plugin-protocol.md`, `src/officecli/Core/Plugins/FormatHandlerSession.cs`, `src/officecli/Core/Plugins/FormatHandlerProxy.cs`
+- path: `almanac/architecture/plugins/dump-reader-and-exporter-plugins.md`
+  - slug: `architecture/plugins/dump-reader-and-exporter-plugins`
+  - purpose: Explain one-shot dump-reader and exporter flows, sibling native-file caching, output verification, and source ownership.
+  - planned links: `architecture/plugins/plugin-system`, `decisions/dump-reader-buffered-replay`
+  - key evidence: `plugins/plugin-protocol.md`, `src/officecli/Core/Plugins/DumpReaderInvoker.cs`, `src/officecli/Core/Plugins/ExporterInvoker.cs`
+
+### `architecture/agent/`
+
+- path: `almanac/architecture/agent/mcp-and-skills.md`
+  - slug: `architecture/agent/mcp-and-skills`
+  - purpose: Explain how MCP, `load_skill`, skill installation, and the root skill form the agent-facing workflow.
+  - planned links: `concepts/officecli-skills`, `architecture/runtime/mcp-shared-cli-root`, `reference/bundled-skills`
+  - key evidence: `src/officecli/McpServer.cs`, `src/officecli/Core/SkillInstaller.cs`, `src/officecli/McpInstaller.cs`, `SKILL.md`
+- path: `almanac/architecture/agent/sdk-resident-clients.md`
+  - slug: `architecture/agent/sdk-resident-clients`
+  - purpose: Explain the Node and Python SDKs as thin resident-pipe clients with no second command vocabulary.
+  - planned links: `concepts/batch-item-protocol`, `architecture/runtime/resident-process-and-pipes`, `guides/using-sdks`
+  - key evidence: `sdk/node/index.js`, `sdk/node/index.d.ts`, `sdk/python/officecli.py`, `sdk/python/pyproject.toml`
+
+### `architecture/build/`
+
+- path: `almanac/architecture/build/self-contained-binary-and-embedded-resources.md`
+  - slug: `architecture/build/self-contained-binary-and-embedded-resources`
+  - purpose: Explain the .NET single-file binary, embedded schemas, embedded skills, preview assets, and trimming constraints.
+  - planned links: `concepts/help-schemas`, `concepts/officecli-skills`, `guides/release-build-and-checksum-flow`
+  - key evidence: `src/officecli/officecli.csproj`, `build.sh`, `npm/lib/install-binary.js`
+
+### `guides/`
+
+- path: `almanac/guides/using-batch-safely.md`
+  - slug: `guides/using-batch-safely`
+  - purpose: Show maintainers how to prepare, run, verify, and recover batch operations without command-shape mistakes.
+  - planned links: `concepts/batch-item-protocol`, `architecture/cli/batch-execution`, `reference/batch-item-fields`
+  - key evidence: `src/officecli/CommandBuilder.Batch.cs`, `src/officecli/BatchTypes.cs`, `README.md`
+- path: `almanac/guides/resident-save-close-flush.md`
+  - slug: `guides/resident-save-close-flush`
+  - purpose: Show when to use `open`, `save`, `close`, and flush environment variables so external readers see current bytes.
+  - planned links: `concepts/resident-sessions`, `architecture/runtime/resident-process-and-pipes`, `decisions/resident-ping-liveness-invariant`
+  - key evidence: `src/officecli/CommandBuilder.cs`, `src/officecli/CommandBuilder.Save.cs`, `src/officecli/Core/ResidentFlushPolicy.cs`, `README.md`
+- path: `almanac/guides/adding-handler-mutations.md`
+  - slug: `guides/adding-handler-mutations`
+  - purpose: Guide contributors through adding or changing a curated add/set/remove operation while keeping handlers, schemas, and warnings aligned.
+  - planned links: `architecture/handlers/document-handler-lifecycle`, `concepts/selectors-vs-slash-paths`, `reference/help-schema-format`
+  - key evidence: `src/officecli/Handlers/Word/WordHandler.Set.cs`, `src/officecli/Handlers/Excel/ExcelHandler.Set.cs`, `src/officecli/Handlers/Pptx/PowerPointHandler.Set.cs`, `schemas/README.md`
+- path: `almanac/guides/debugging-preview-rendering.md`
+  - slug: `guides/debugging-preview-rendering`
+  - purpose: Guide maintainers through tracing a preview, screenshot, or watch rendering issue across registry, handler preview, and static resources.
+  - planned links: `architecture/handlers/rendering-and-preview-stack`, `architecture/handlers/watch-preview-contract`
+  - key evidence: `src/officecli/CommandBuilder.View.cs`, `src/officecli/Core/Rendering/`, `src/officecli/Handlers/Word/WordHandler.HtmlPreview.cs`, `src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.cs`, `src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.cs`
+- path: `almanac/guides/installing-and-platform-detection.md`
+  - slug: `guides/installing-and-platform-detection`
+  - purpose: Guide maintainers through installer platform detection, checksum verification, binary placement, PATH updates, and skill/MCP side effects.
+  - planned links: `architecture/build/self-contained-binary-and-embedded-resources`, `reference/platform-assets-and-install-surfaces`, `decisions/immutable-release-downloads`
+  - key evidence: `install.sh`, `install.ps1`, `npm/lib/install-binary.js`, `src/officecli/Core/Installer.cs`
+- path: `almanac/guides/release-build-and-checksum-flow.md`
+  - slug: `guides/release-build-and-checksum-flow`
+  - purpose: Guide maintainers through release build assets, signing/notarization, smoke checks, checksums, and npm publishing.
+  - planned links: `architecture/build/self-contained-binary-and-embedded-resources`, `reference/platform-assets-and-install-surfaces`, `decisions/immutable-release-downloads`
+  - key evidence: `build.sh`, `.github/workflows/build.yml`, `.github/workflows/publish-npm.yml`, `npm/package.json`
+- path: `almanac/guides/using-sdks.md`
+  - slug: `guides/using-sdks`
+  - purpose: Guide maintainers and integrators through using the Node and Python SDKs safely with resident handles.
+  - planned links: `architecture/agent/sdk-resident-clients`, `concepts/batch-item-protocol`, `guides/resident-save-close-flush`
+  - key evidence: `sdk/node/README.md`, `sdk/node/index.js`, `sdk/python/README.md`, `sdk/python/officecli.py`
+- path: `almanac/guides/examples-corpus.md`
+  - slug: `guides/examples-corpus`
+  - purpose: Guide contributors through using the examples directory as executable feature coverage and source material.
+  - planned links: `reference/command-surface`, `reference/bundled-skills`
+  - key evidence: `examples/README.md`, `examples/excel/`, `examples/ppt/`, `examples/word/`
+
+### `decisions/`
+
+- path: `almanac/decisions/mcp-single-tool-command-string.md`
+  - slug: `decisions/mcp-single-tool-command-string`
+  - purpose: Record the choice to expose one MCP tool that accepts CLI command strings or argv arrays instead of per-command MCP tools.
+  - planned links: `architecture/runtime/mcp-shared-cli-root`, `architecture/agent/mcp-and-skills`
+  - key evidence: `src/officecli/McpServer.cs`
+- path: `almanac/decisions/resident-ping-liveness-invariant.md`
+  - slug: `decisions/resident-ping-liveness-invariant`
+  - purpose: Record the invariant that ping availability must imply handler ownership and why shutdown ordering preserves direct-mode safety.
+  - planned links: `architecture/runtime/resident-process-and-pipes`, `guides/resident-save-close-flush`
+  - key evidence: `src/officecli/ResidentServer.cs`, `src/officecli/ResidentClient.cs`
+- path: `almanac/decisions/plugin-idle-watchdog.md`
+  - slug: `decisions/plugin-idle-watchdog`
+  - purpose: Record the activity-based plugin timeout model and user override behavior.
+  - planned links: `architecture/plugins/plugin-system`, `reference/plugin-manifest`
+  - key evidence: `plugins/plugin-protocol.md`, `src/officecli/Core/Plugins/PluginProcess.cs`, `src/officecli/Core/Plugins/PluginManifest.cs`
+- path: `almanac/decisions/dump-reader-buffered-replay.md`
+  - slug: `decisions/dump-reader-buffered-replay`
+  - purpose: Record why dump-reader JSONL output is buffered before replay even though the protocol requires streaming output.
+  - planned links: `architecture/plugins/dump-reader-and-exporter-plugins`, `architecture/plugins/plugin-system`
+  - key evidence: `src/officecli/Core/Plugins/DumpReaderInvoker.cs`, `plugins/plugin-protocol.md`
+- path: `almanac/decisions/immutable-release-downloads.md`
+  - slug: `decisions/immutable-release-downloads`
+  - purpose: Record why installers and npm downloads prefer immutable versioned release URLs over mutable latest URLs.
+  - planned links: `guides/installing-and-platform-detection`, `guides/release-build-and-checksum-flow`
+  - key evidence: `install.sh`, `install.ps1`, `npm/lib/install-binary.js`
+- path: `almanac/decisions/atomic-binary-replacement.md`
+  - slug: `decisions/atomic-binary-replacement`
+  - purpose: Record why local installer and dev install flows use atomic replacement rather than in-place overwrite.
+  - planned links: `guides/installing-and-platform-detection`, `architecture/build/self-contained-binary-and-embedded-resources`
+  - key evidence: `install.sh`, `dev-install.sh`, `build.sh`
+- path: `almanac/decisions/renderers-receive-parsed-models.md`
+  - slug: `decisions/renderers-receive-parsed-models`
+  - purpose: Record the renderer API choice that renderers receive parsed model hosts instead of reopening files by path.
+  - planned links: `architecture/handlers/rendering-and-preview-stack`, `architecture/handlers/document-handler-lifecycle`
+  - key evidence: `src/officecli/Core/Rendering/IRenderer.cs`, `src/officecli/Handlers/Rendering/HandlerRenderInput.cs`, `src/officecli/Handlers/Rendering/BasicRenderers.cs`
+
+### `reference/`
+
+- path: `almanac/reference/command-surface.md`
+  - slug: `reference/command-surface`
+  - purpose: Lookup reference for public command families, early-dispatched commands, hidden compatibility aliases, and command ownership files.
+  - planned links: `architecture/cli/command-dispatch`, `concepts/command-layers`
+  - key evidence: `src/officecli/Program.cs`, `src/officecli/CommandBuilder.cs`, `src/officecli/CommandBuilder.*.cs`
+- path: `almanac/reference/batch-item-fields.md`
+  - slug: `reference/batch-item-fields`
+  - purpose: Exact field reference for `BatchItem`, lenient props, aliases, and resident request conversion.
+  - planned links: `concepts/batch-item-protocol`, `architecture/cli/batch-execution`
+  - key evidence: `src/officecli/BatchTypes.cs`, `src/officecli/CommandBuilder.Batch.cs`
+- path: `almanac/reference/selector-grammar-by-format.md`
+  - slug: `reference/selector-grammar-by-format`
+  - purpose: Lookup reference comparing selector capabilities and limits for Word, Excel, and PowerPoint.
+  - planned links: `concepts/selectors-vs-slash-paths`, `guides/adding-handler-mutations`
+  - key evidence: `src/officecli/Handlers/Word/WordHandler.Selector.cs`, `src/officecli/Handlers/Excel/ExcelHandler.Selector.cs`, `src/officecli/Handlers/Pptx/PowerPointHandler.Selector.cs`
+- path: `almanac/reference/help-schema-format.md`
+  - slug: `reference/help-schema-format`
+  - purpose: Exact reference for help schema files, including operations, paths, aliases, properties, examples, enforcement, and shared bases.
+  - planned links: `concepts/help-schemas`, `architecture/cli/help-schema-loader`, `guides/adding-handler-mutations`
+  - key evidence: `schemas/README.md`, `schemas/help/_schema.json`, `schemas/help/docx/paragraph.json`, `schemas/help/xlsx/cell.json`, `schemas/help/pptx/shape.json`
+- path: `almanac/reference/schema-crc.md`
+  - slug: `reference/schema-crc`
+  - purpose: Lookup reference for the schema CRC command and what it does and does not fingerprint.
+  - planned links: `concepts/help-schemas`, `architecture/cli/help-schema-loader`
+  - key evidence: `src/officecli/Program.cs`, `src/officecli/Help/SchemaCrc.cs`
+- path: `almanac/reference/plugin-discovery.md`
+  - slug: `reference/plugin-discovery`
+  - purpose: Exact plugin discovery order, executable names, cache behavior, and hardening rules.
+  - planned links: `architecture/plugins/plugin-system`, `reference/plugin-manifest`
+  - key evidence: `plugins/plugin-protocol.md`, `src/officecli/Core/Plugins/PluginRegistry.cs`
+- path: `almanac/reference/plugin-manifest.md`
+  - slug: `reference/plugin-manifest`
+  - purpose: Exact plugin manifest fields, supported protocol version, kinds, target, idle timeout, and vocabulary fields.
+  - planned links: `architecture/plugins/plugin-system`, `decisions/plugin-idle-watchdog`
+  - key evidence: `plugins/plugin-protocol.md`, `src/officecli/Core/Plugins/PluginManifest.cs`
+- path: `almanac/reference/platform-assets-and-install-surfaces.md`
+  - slug: `reference/platform-assets-and-install-surfaces`
+  - purpose: Lookup reference for platform binary names, install locations, npm package behavior, package-manager surfaces, and config side effects.
+  - planned links: `guides/installing-and-platform-detection`, `guides/release-build-and-checksum-flow`
+  - key evidence: `README.md`, `install.sh`, `install.ps1`, `npm/package.json`, `npm/lib/install-binary.js`
+- path: `almanac/reference/bundled-skills.md`
+  - slug: `reference/bundled-skills`
+  - purpose: Lookup reference for bundled skill names, aliases, specialized use cases, and installation targets.
+  - planned links: `concepts/officecli-skills`, `architecture/agent/mcp-and-skills`
+  - key evidence: `src/officecli/Core/SkillInstaller.cs`, `SKILL.md`, `skills/`
+- path: `almanac/reference/rich-object-helper-map.md`
+  - slug: `reference/rich-object-helper-map`
+  - purpose: Lookup reference for shared chart, diagram, OLE, formula, theme, and style helper directories and what each supports.
+  - planned links: `architecture/handlers/rich-object-helpers`
+  - key evidence: `src/officecli/Core/Chart/`, `src/officecli/Core/Diagram/`, `src/officecli/Core/OleHelper.cs`, `src/officecli/Core/Formula/`, `src/officecli/Core/TableStyles/`
+- path: `almanac/reference/security-policy.md`
+  - slug: `reference/security-policy`
+  - purpose: Lookup reference for supported security versions, private reporting, and the security-sensitive file-opening guards in this repo.
+  - planned links: `architecture/handlers/document-handler-lifecycle`, `architecture/plugins/plugin-system`
+  - key evidence: `SECURITY.md`, `src/officecli/Handlers/DocumentHandlerFactory.cs`, `src/officecli/Core/SsrfGuard.cs`, `src/officecli/Core/DocumentLimits.cs`

--- a/almanac/decisions/atomic-binary-replacement.md
+++ b/almanac/decisions/atomic-binary-replacement.md
@@ -1,0 +1,39 @@
+---
+title: "Atomic Binary Replacement"
+summary: "Unix install and build flows stage OfficeCLI binaries beside the target and rename them into place instead of overwriting executable files in place."
+topics: [decisions, install, build]
+sources:
+  - id: unix-installer
+    type: file
+    path: install.sh
+  - id: dev-installer
+    type: file
+    path: dev-install.sh
+  - id: build-script
+    type: file
+    path: build.sh
+---
+
+OfficeCLI's Unix installer, development installer, and local build script replace binaries atomically: they copy the new executable to a sibling `.new` file, apply permissions or signing to that staged file, then rename it over the target. The choice protects running `officecli` processes from in-place mutation and future install or build changes must keep live binaries immutable until the final rename [@unix-installer] [@dev-installer] [@build-script].
+
+## Context
+
+The installed CLI is a self-contained executable that may be running while an upgrade or local build writes a replacement. The Unix install script explicitly says that overwriting the binary in place can damage the text segment of a running process on macOS and leave it stuck on a later code-page fault [@unix-installer]. The same warning appears in the development installer and the build script, so the rule applies to local development, install upgrades, and release asset generation [@dev-installer] [@build-script].
+
+This decision constrains both [installing and platform detection](../guides/installing-and-platform-detection) and the [self-contained binary build](../architecture/build/self-contained-binary-and-embedded-resources). The binary may be signed, made executable, or copied from a publish directory, but those operations happen before the target path is swapped into service.
+
+## Decision
+
+Unix replacement flows stage the new executable beside the final path with a `.new` suffix and then call `mv -f` to replace the target. `install.sh` copies the downloaded or local source to `$INSTALL_DIR/officecli.new`, marks it executable, performs macOS quarantine and signing work on the staged copy, and renames it to `$INSTALL_DIR/officecli` [@unix-installer].
+
+`dev-install.sh` follows the same pattern after `dotnet publish`: it copies the published binary to `$INSTALL_DIR/officecli.new`, marks it executable, signs the staged copy on macOS, and only then renames it into place [@dev-installer]. `build.sh` uses the same staging rule for generated release or debug assets under `bin/release` or `bin/debug`; each target asset is copied as `<asset>.new`, optionally signed on macOS, and renamed to the final asset name [@build-script].
+
+## Status
+
+This decision is active for Unix install and build paths. The evidence is repeated in all three scripts, and each one performs the final replacement with a rename after preparation is complete [@unix-installer] [@dev-installer] [@build-script].
+
+## Consequences
+
+The benefit is that the live binary path is not mutated while preparation is still happening. Permissions, quarantine removal, and signing can fail or be retried against the staged file without partially changing the executable that users may currently be running [@unix-installer] [@dev-installer].
+
+The required discipline is simple but important: future install or build code should prepare a sibling file on the same filesystem and rename it into place. Code that writes directly to the final executable path, signs the live binary in place, or streams a download into the installed path violates this decision.

--- a/almanac/decisions/dump-reader-buffered-replay.md
+++ b/almanac/decisions/dump-reader-buffered-replay.md
@@ -1,0 +1,40 @@
+---
+title: "Dump Reader Buffered Replay"
+summary: "Dump-reader plugins must stream JSONL, but OfficeCLI buffers those lines before replay so OpenXML mutations run synchronously on the caller thread."
+topics: [decisions, plugins, batch]
+sources:
+  - id: dump-invoker
+    type: file
+    path: src/officecli/Core/Plugins/DumpReaderInvoker.cs
+  - id: plugin-protocol
+    type: file
+    path: plugins/plugin-protocol.md
+---
+
+OfficeCLI keeps the dump-reader protocol streaming but buffers the received JSONL lines before replaying them into a native document. This preserves the plugin contract and idle-watchdog activity signal while avoiding unsafe OpenXML mutation from the stdout reader thread. Future dump-reader work must keep plugin output line-oriented, but replay should remain on the caller thread unless the document package layer is made safe for concurrent mutation [@dump-invoker] [@plugin-protocol].
+
+## Context
+
+A dump-reader converts a foreign source file into OfficeCLI batch items. The protocol requires one JSON object per line on stdout, with each line matching a `batch --commands` item [@plugin-protocol]. Top-level JSON arrays are rejected with `corrupt_batch` [@plugin-protocol].
+
+The streaming requirement exists for two reasons: it gives the plugin watchdog per-item activity, and it avoids making the plugin protocol depend on one large JSON array [@plugin-protocol]. The broader flow is described in [Dump Reader And Exporter Plugins](../architecture/plugins/dump-reader-and-exporter-plugins).
+
+## Decision
+
+`DumpReaderInvoker.Run` still invokes the plugin as a streaming producer and processes stdout line by line [@dump-invoker]. Each non-empty line is trimmed, a per-line UTF-8 BOM is tolerated, and a line beginning with `[` is rejected as the old JSON-array shape [@dump-invoker].
+
+Instead of replaying each line inside the stdout callback, the invoker appends valid raw lines to an in-memory list. After the plugin exits successfully, the invoker opens the generated native temp file on the caller thread and deserializes and replays each buffered line through `CommandBuilder.ExecuteBatchItem` [@dump-invoker].
+
+The reason is package safety. The previous design replayed from the process stdout reader task. The code records that heavy OpenXML updates from that background thread could trip non-thread-safe package state, especially with many parts being created or reopened in update mode [@dump-invoker].
+
+## Status
+
+This is the current implementation in `DumpReaderInvoker.cs`. The plugin still streams. OfficeCLI still uses the plugin process runner and idle timeout while lines arrive. Replay is deferred until after plugin exit [@dump-invoker].
+
+## Consequences
+
+The decision makes replay behavior closer to normal batch execution, where items are replayed synchronously through one handler [@dump-invoker]. It also keeps item-indexed errors for invalid JSON, null items, and failed commands during replay [@dump-invoker].
+
+The cost is host memory proportional to the number and size of emitted JSONL lines. That weakens one original benefit of full streaming replay, so dump-reader authors should still emit compact batch items and avoid unnecessary payload bloat [@dump-invoker] [@plugin-protocol].
+
+The boundary remains clear: dump-reader plugins own the foreign source and emit commands; OfficeCLI owns the target native file and the replay. Edits after conversion belong to the native output, not to the original foreign file [@plugin-protocol] [@dump-invoker].

--- a/almanac/decisions/immutable-release-downloads.md
+++ b/almanac/decisions/immutable-release-downloads.md
@@ -1,0 +1,43 @@
+---
+title: "Immutable Release Downloads"
+summary: "Installers resolve or derive a concrete release tag and download versioned assets so a cached latest URL cannot install an older binary."
+topics: [decisions, release, install]
+sources:
+  - id: unix-installer
+    type: file
+    path: install.sh
+  - id: windows-installer
+    type: file
+    path: install.ps1
+  - id: npm-installer
+    type: file
+    path: npm/lib/install-binary.js
+---
+
+OfficeCLI installers prefer immutable release downloads: they turn "latest" into a concrete tag, or derive the tag from the npm package version, then fetch assets from `/releases/download/vX.Y.Z/...`. This choice exists because mutable latest URLs can lag behind a just-published release, even when the downloaded checksum manifest is self-consistent; future installer work must preserve tag-pinned downloads before it changes mirrors, checksums, or package publishing [@unix-installer] [@windows-installer] [@npm-installer].
+
+## Context
+
+The shell and PowerShell installers still need to discover the current release for users who run a generic install command. They do that by following the `/releases/latest` redirect on the OfficeCLI mirror first, then GitHub, and extracting the final `vX.Y.Z` tag from the resolved URL [@unix-installer] [@windows-installer]. After that resolution step, both scripts build mirror and GitHub asset bases with `/releases/download/$VERSION` instead of downloading directly from `/releases/latest/download` [@unix-installer] [@windows-installer].
+
+The npm installer has a different source of truth. Because npm publication sets `npm/package.json` to the release version, postinstall derives `TAG` from the package version and strips prerelease or build suffixes before forming versioned mirror and GitHub URLs [@npm-installer]. That makes npm install depend on the package version rather than a mutable latest redirect.
+
+This decision belongs with [installing and platform detection](../guides/installing-and-platform-detection) and the [release build and checksum flow](../guides/release-build-and-checksum-flow), because asset names, release tags, and checksum manifests are one install contract.
+
+## Decision
+
+Installers must download release assets from immutable versioned paths whenever the release tag is known. The Unix and Windows scripts may fall back to latest paths only when tag resolution fails [@unix-installer] [@windows-installer]. The npm installer does not use latest paths; it downloads from the tag derived from the package version [@npm-installer].
+
+The checksum lookup follows the same pinned asset base. The script installers download `SHA256SUMS` beside the selected asset and match the exact filename column before comparing hashes [@unix-installer] [@windows-installer]. The npm installer also fetches `SHA256SUMS` from the versioned tag and matches the exact asset name, allowing an optional leading binary-mode marker in the manifest row [@npm-installer].
+
+## Status
+
+This decision is active. `install.sh`, `install.ps1`, and `npm/lib/install-binary.js` all document the reason in code comments and implement versioned downloads with the OfficeCLI mirror as the first source and GitHub releases as fallback [@unix-installer] [@windows-installer] [@npm-installer].
+
+## Consequences
+
+The main benefit is release freshness. A user who installs immediately after a release should receive the asset for the resolved tag, not a stale object served from a cached latest URL [@unix-installer] [@windows-installer]. It also makes npm reproducible by tying the downloaded binary to the package version that triggered postinstall [@npm-installer].
+
+The cost is that installer code must keep tag resolution healthy. If the generic script installers cannot resolve a tag, they deliberately fall back to latest paths so installation can still proceed, but that is the degraded path and carries the stale-download risk this decision avoids [@unix-installer] [@windows-installer].
+
+Future changes must not reintroduce direct latest downloads as the normal path. Mirror rewrites, checksum changes, and package publishing changes should keep asset and checksum URLs on the same immutable release tag.

--- a/almanac/decisions/mcp-single-tool-command-string.md
+++ b/almanac/decisions/mcp-single-tool-command-string.md
@@ -1,0 +1,37 @@
+---
+title: "MCP Single Tool Command String"
+summary: "OfficeCLI exposes MCP as one command-string tool so agent calls share the terminal CLI grammar instead of a separate per-command MCP schema."
+topics: [decisions, mcp, cli, runtime]
+sources:
+  - id: mcp-server
+    type: file
+    path: src/officecli/McpServer.cs
+---
+
+OfficeCLI chooses a single MCP tool named `officecli` whose required `command` field is either a CLI command string or a pre-split argv array. The choice keeps MCP behavior tied to the same command root, validation, help text, screenshots, skills, stdout, stderr, and exit-code mapping that terminal users get. Future MCP work must preserve this shared grammar instead of adding a parallel set of per-operation MCP tools [@mcp-server].
+
+## Context
+
+The MCP server is a stdio JSON-RPC process that implements `initialize`, `tools/list`, `tools/call`, and `ping` [@mcp-server]. It needs to let agents create, inspect, mutate, validate, and render Office documents without drifting away from the normal CLI surface described in [MCP Shared CLI Root](../architecture/runtime/mcp-shared-cli-root) and [MCP And Skills](../architecture/agent/mcp-and-skills).
+
+The alternative would be a generated MCP tool for each OfficeCLI verb or document operation. That would duplicate argument schemas, parsing rules, and help behavior. It would also require MCP-specific updates whenever a CLI flag or document command changed.
+
+## Decision
+
+`tools/list` advertises exactly one tool, `officecli` [@mcp-server]. Its input schema has one required property, `command`, and that property accepts either a string or an array of strings [@mcp-server].
+
+`tools/call` rejects any name other than `officecli`, so misrouted calls do not mutate files under an unexpected tool name [@mcp-server]. Accepted calls are converted to argv and run through the shared root command, with special handling only for command families that are outside the root dispatch path, such as `load_skill` and screenshot image return [@mcp-server].
+
+The string form is tokenized inside the process and never passed to a shell. The array form preserves empty string arguments, which matters for intentionally empty values such as clearing text with a property value [@mcp-server]. A leading `officecli` binary name is optional and is stripped when present, so examples copied from terminal-oriented skill text still work [@mcp-server].
+
+## Status
+
+This decision is implemented in `McpServer.cs`. The server builds a cached root command, parses argv with that root, invokes it while capturing stdout and stderr, and maps the result into MCP content blocks plus `isError` [@mcp-server].
+
+## Consequences
+
+The main benefit is low drift. New CLI verbs, flags, validation messages, and usage output become available to MCP through the shared root rather than a second schema layer [@mcp-server].
+
+The cost is that agents must learn CLI syntax through `help`, loaded skills, and examples rather than through many narrow MCP tools. The server compensates by putting usage guidance in the single tool description and by surfacing CLI stdout and stderr together when both are present [@mcp-server].
+
+MCP-specific code is allowed only where the transport requires it: JSON-RPC framing, tool validation, argv extraction, skill early dispatch, screenshot image content, and result mapping. Document behavior should remain owned by the CLI command path [@mcp-server].

--- a/almanac/decisions/plugin-idle-watchdog.md
+++ b/almanac/decisions/plugin-idle-watchdog.md
@@ -1,0 +1,45 @@
+---
+title: "Plugin Idle Watchdog"
+summary: "Plugin processes are timed out by lack of activity, not total runtime, with manifest budgets and a user override for debugging."
+topics: [decisions, plugins, runtime]
+sources:
+  - id: plugin-protocol
+    type: file
+    path: plugins/plugin-protocol.md
+  - id: plugin-process
+    type: file
+    path: src/officecli/Core/Plugins/PluginProcess.cs
+  - id: plugin-manifest
+    type: file
+    path: src/officecli/Core/Plugins/PluginManifest.cs
+---
+
+OfficeCLI uses an activity-based watchdog for plugin subprocesses. A plugin may run for a long time, but it must keep producing protocol output, diagnostics, or heartbeat lines within its idle budget. This lets large conversions and exports continue while still killing hung plugins that stop communicating [@plugin-protocol] [@plugin-process].
+
+## Context
+
+Plugins are sidecar processes used by the [Plugin System](../architecture/plugins/plugin-system). Dump-readers and exporters are short-lived, while format-handlers can hold a long-lived editing session [@plugin-protocol].
+
+Those processes can hang in external parsers, renderers, license checks, or file I/O. A wall-clock timeout would be too blunt for large documents, but no timeout would leave OfficeCLI waiting forever.
+
+## Decision
+
+The timeout measures idle time. The protocol says any stdout byte resets the timer, and a stderr line matching `{"heartbeat":true}` resets it without being surfaced as user diagnostics [@plugin-protocol]. The shared `PluginProcess` runner implements that rule by updating an activity timestamp from stdout lines, heartbeat stderr lines, and non-heartbeat stderr output [@plugin-process].
+
+When the gap since last activity exceeds the budget, the runner kills the entire process tree and reports an idle timeout [@plugin-process]. The protocol maps that condition to `plugin_idle_timeout` with exit code 6 [@plugin-protocol].
+
+Budgets come from the plugin manifest. `idle_timeout_seconds.default` is the fallback, and optional per-verb entries override it [@plugin-protocol] [@plugin-manifest]. The manifest model resolves a timeout for each verb and falls back to a safe default when the manifest is silent [@plugin-manifest].
+
+Users can override the manifest with `OFFICECLI_PLUGIN_IDLE_TIMEOUT_SECONDS`. A non-negative value replaces the manifest budget for the invocation, and `0` disables the watchdog for debugging [@plugin-protocol] [@plugin-manifest].
+
+## Status
+
+The decision is implemented in `PluginProcess.Run`, `PluginManifest.ResolveIdleTimeout`, and the protocol document [@plugin-process] [@plugin-manifest] [@plugin-protocol].
+
+## Consequences
+
+Plugin authors must treat stdout and stderr as liveness channels. Dump-readers naturally reset the watchdog by streaming JSONL output, while exporters and long format-handler operations should emit heartbeat lines during opaque work [@plugin-protocol].
+
+The host intentionally does not bound total wall-clock runtime. A large job can run for minutes if it keeps making observable progress [@plugin-process].
+
+The main risk is polluted streams. Heartbeats belong on stderr, and protocol frames belong on stdout. The protocol warns that non-envelope stdout in format-handler sessions is a plugin bug and can break the session [@plugin-protocol].

--- a/almanac/decisions/renderers-receive-parsed-models.md
+++ b/almanac/decisions/renderers-receive-parsed-models.md
@@ -1,0 +1,43 @@
+---
+title: "Renderers Receive Parsed Models"
+summary: "OfficeCLI renderers receive a live render input backed by the open handler instead of reopening documents from file paths."
+topics: [decisions, rendering, handlers]
+sources:
+  - id: renderer-contract
+    type: file
+    path: src/officecli/Core/Rendering/IRenderer.cs
+  - id: handler-input
+    type: file
+    path: src/officecli/Handlers/Rendering/HandlerRenderInput.cs
+  - id: basic-renderers
+    type: file
+    path: src/officecli/Handlers/Rendering/BasicRenderers.cs
+---
+
+OfficeCLI renderers receive parsed models through `IRenderInput`, not document file paths. The renderer boundary exposes the format id, optional in-memory model, and read-only document-tree access, while `HandlerRenderInput` binds that boundary to a live document handler; future renderers should render from this live input instead of reopening files and building a second view of the document [@renderer-contract] [@handler-input].
+
+## Context
+
+Rendering sits downstream of the [document handler lifecycle](../architecture/handlers/document-handler-lifecycle). By the time a view, screenshot, or preview is requested, OfficeCLI already has a handler that owns the parsed document package and the current in-session document state. `IRenderInput` therefore defines `FormatId`, `Model`, `Get`, and `Query` as the renderer-facing input surface [@renderer-contract].
+
+The handler adapter is deliberately narrower than the full mutation surface. `HandlerRenderInput` stores an `IDocumentHandler`, exposes the format id, projects `Model` from handlers that implement `IRenderModelHost`, and forwards `Get` and `Query` to the handler [@handler-input]. Its comment states the intent: renderers see read access and the parsed model, not the file path or mutation API [@handler-input].
+
+This decision is the core constraint behind the [rendering and preview stack](../architecture/handlers/rendering-and-preview-stack).
+
+## Decision
+
+Renderers must accept `IRenderInput` and `RenderOptions`. The renderer contract says the model is the already parsed in-memory document and that `Get` reflects in-session edits, so renderers work from handler-owned state rather than re-reading a file [@renderer-contract].
+
+Built-in renderers remain thin adapters over the existing handler preview methods. The Word renderer casts the input back to `HandlerRenderInput`, obtains the `WordHandler`, and calls `ViewAsHtml`; the Excel renderer does the same for `ExcelHandler`; the PowerPoint renderer calls `ViewAsHtml` or `ViewAsSvg` based on the requested output [@basic-renderers]. The adapters are registered as low-priority built-ins, leaving room for higher-priority renderers without changing the input decision [@basic-renderers].
+
+## Status
+
+This decision is active. `IRenderer.Render` takes `IRenderInput`, `HandlerRenderInput` bridges live handlers into that contract, and the built-in Word, Excel, and PowerPoint renderers all consume handler-backed inputs [@renderer-contract] [@handler-input] [@basic-renderers].
+
+## Consequences
+
+The main benefit is consistency with live document state. A renderer can use `Get` and `Query` against the current handler, and the contract explicitly says that this read access reflects in-session edits [@renderer-contract]. That avoids a second parser observing stale bytes or missing resident-session changes.
+
+The boundary also keeps renderer plugins from depending on the mutation-facing handler API. Renderers receive a model object when one is attached and format-neutral read helpers, but the narrow contract is independent of any one concrete handler [@renderer-contract] [@handler-input].
+
+The tradeoff is that built-in renderers that still need handler-specific preview methods must validate that the input is a `HandlerRenderInput` with the expected native handler type, and they throw if a different input is passed [@basic-renderers]. Future alternate renderers should prefer the `IRenderInput` surface directly when possible, and should treat direct file reopening as a regression unless a separate decision creates that path.

--- a/almanac/decisions/resident-ping-liveness-invariant.md
+++ b/almanac/decisions/resident-ping-liveness-invariant.md
@@ -1,0 +1,40 @@
+---
+title: "Resident Ping Liveness Invariant"
+summary: "Resident shutdown keeps the ping pipe alive until the handler is disposed so a successful ping means the resident still owns the file."
+topics: [decisions, resident, runtime]
+sources:
+  - id: resident-server
+    type: file
+    path: src/officecli/ResidentServer.cs
+  - id: resident-client
+    type: file
+    path: src/officecli/ResidentClient.cs
+---
+
+OfficeCLI defines resident liveness as more than "a process exists": if the ping pipe responds, the resident must still hold the document handler and file. Shutdown therefore cancels the main command loop first, drains in-flight work, disposes the handler, and only then cancels the ping responder. Future resident changes must keep that ordering, because clients use ping availability to decide whether direct file access is safe [@resident-server].
+
+## Context
+
+The resident runtime uses two named pipes for one file: a main pipe for document commands and a `-ping` pipe for liveness, idle-timeout updates, and close [@resident-server] [@resident-client]. `ResidentClient.TryConnect()` connects to the ping pipe, sends `__ping__`, and verifies that the returned path matches the requested file [@resident-client].
+
+That ping result affects ownership. If a client believes no resident is alive, it may open the file directly. If a resident is alive, clients should route through it or report busy rather than racing the resident's in-memory handler.
+
+## Decision
+
+The invariant is: ping responds if and only if the resident handler still owns the file [@resident-server]. `ResidentServer` enforces this with separate cancellation tokens. `_mainCts` gates the main command loop, while `_pingCts` gates the ping responder and idle watchdog [@resident-server].
+
+Shutdown is ordered. The server cancels `_mainCts`, kicks the main pipe, waits for the command lock so the current command can drain, disposes the handler, then cancels `_pingCts` and kicks the ping pipe [@resident-server]. During the slow handler-dispose step, the ping pipe intentionally remains live, so a probing client still sees "resident owns this file" rather than falling back to direct access [@resident-server].
+
+`__close__` also uses this ordering. The close handler calls shutdown before acknowledging the client, so a caller that receives the close acknowledgement can assume the handler has been released or that the response reports the shutdown problem [@resident-server].
+
+## Status
+
+This invariant is documented and implemented in `ResidentServer.cs`. `ResidentClient.cs` is written around it: ping is the liveness probe, close uses the ping pipe, and command retry is limited to the connect phase so a delivered mutation is not resent after a broken response [@resident-client].
+
+## Consequences
+
+The invariant makes direct-mode fallback safer. A live ping means "do not open the file directly"; a dead ping means the resident has released the handler or is no longer a valid owner [@resident-server].
+
+The tradeoff is that ping remains available during part of shutdown. That is intentional. It may make a client wait or report busy while disposal finishes, but it avoids the worse outcome where a client sees no resident and opens a file that is still being flushed [@resident-server].
+
+Future shutdown, idle, close, or pipe changes must not cancel the ping responder before handler disposal. Doing so would break the ownership signal used by [Resident Process And Pipes](../architecture/runtime/resident-process-and-pipes) [@resident-server].

--- a/almanac/getting-started.md
+++ b/almanac/getting-started.md
@@ -1,0 +1,45 @@
+---
+title: "Getting Started"
+summary: "Start here to navigate the OfficeCLI wiki by command dispatch, handlers, resident runtime, command layers, skills, selectors, and raw XML."
+topics: [guides, architecture, cli]
+sources:
+  - id: readme
+    type: file
+    path: README.md
+  - id: program
+    type: file
+    path: src/officecli/Program.cs
+  - id: command-builder
+    type: file
+    path: src/officecli/CommandBuilder.cs
+---
+
+OfficeCLI is a single-binary CLI for creating, reading, rendering, validating, and modifying `.docx`, `.xlsx`, and `.pptx` files without requiring Microsoft Office [@readme]. This wiki starts from the command surface, then routes into handlers, resident runtime behavior, agent integration, and lower-level concepts. Use this page as a map, not as a tutorial.
+
+## Start With Commands
+
+Begin with [command dispatch](architecture/cli/command-dispatch) if you need to understand how a terminal invocation becomes OfficeCLI behavior. Startup code rewrites `--help` into the schema-driven `help` command, handles early-dispatch commands such as `mcp`, `install`, `skills`, and `load_skill`, then builds the root command for normal document operations [@program].
+
+For the public command vocabulary, read [command surface](reference/command-surface). The root command registers the main document verbs: `open`, `close`, `watch`, `view`, `get`, `query`, `set`, `add`, `remove`, `move`, `swap`, `raw`, `raw-set`, `add-part`, `validate`, `save`, `batch`, `dump`, `import`, `create`, `merge`, plugins, and help [@command-builder].
+
+## Understand The Document Model
+
+Read [command layers](concepts/command-layers) before changing command behavior. OfficeCLI exposes high-level document operations for creating, reading, analyzing, modifying, and reorganizing Office content, while still keeping lower-level commands available for exact nodes and raw package parts [@readme] [@command-builder].
+
+Then read [document node and paths](concepts/document-node-and-paths) and [selectors vs slash paths](concepts/selectors-vs-slash-paths). Exact slash paths identify known nodes, while selectors search by type, content, or attributes. That distinction is central to `get`, `query`, `set`, `remove`, handler mutation code, and batch replay.
+
+## Follow Handler And Runtime Flow
+
+Use [document handler lifecycle](architecture/handlers/document-handler-lifecycle) when working on file opening, format dispatch, validation, or handler contracts. The root command delegates document verbs to handler-backed command builders, and those builders decide whether to use a resident process or open a handler directly [@command-builder].
+
+Use [resident process and pipes](architecture/runtime/resident-process-and-pipes) when debugging performance, file locking, save/close behavior, or serialized mutation delivery. The root command has explicit `open` and `close` commands, starts a hidden `__resident-serve__` process, and uses a resident client probe before falling back to direct file handling [@command-builder].
+
+## Use The Agent Cluster
+
+Read [MCP and skills](architecture/agent/mcp-and-skills) to understand the agent-facing workflow. Program dispatch starts the MCP server with `officecli mcp`, registers or unregisters clients through `mcp <target>`, and exposes `load_skill` as the read-only way to fetch bundled skill guidance [@program].
+
+The concept page [OfficeCLI skills](concepts/officecli-skills) explains why skills exist beside schemas. The reference page [bundled skills](reference/bundled-skills) is the planned lookup surface for the skill inventory.
+
+## Use Lower-Level References When Needed
+
+For broad searches and mutation targeting, use [selector grammar by format](reference/selector-grammar-by-format). For last-resort OpenXML work, use [raw XML access](concepts/raw-xml-access). For adding or changing curated mutations, use [adding handler mutations](guides/adding-handler-mutations). These pages sit downstream of the command and handler architecture, so they make the most sense after the routing and lifecycle pages.

--- a/almanac/guides/adding-handler-mutations.md
+++ b/almanac/guides/adding-handler-mutations.md
@@ -1,0 +1,65 @@
+---
+title: "Adding Handler Mutations"
+summary: "How to add or change add, set, and remove behavior while keeping handlers, command warnings, and schemas aligned."
+topics: [guides, handlers]
+sources:
+  - id: command-set
+    type: file
+    path: src/officecli/CommandBuilder.Set.cs
+  - id: command-add
+    type: file
+    path: src/officecli/CommandBuilder.Add.cs
+  - id: word-set
+    type: file
+    path: src/officecli/Handlers/Word/WordHandler.Set.cs
+  - id: excel-set
+    type: file
+    path: src/officecli/Handlers/Excel/ExcelHandler.Set.cs
+  - id: ppt-set
+    type: file
+    path: src/officecli/Handlers/Pptx/PowerPointHandler.Set.cs
+  - id: word-add
+    type: file
+    path: src/officecli/Handlers/Word/WordHandler.Add.cs
+  - id: excel-add
+    type: file
+    path: src/officecli/Handlers/Excel/ExcelHandler.Add.cs
+  - id: excel-remove
+    type: file
+    path: src/officecli/Handlers/Excel/ExcelHandler.Remove.cs
+  - id: schemas-readme
+    type: file
+    path: schemas/README.md
+---
+
+Add or change a handler mutation when OfficeCLI needs a curated operation instead of raw XML editing. The safe path is to put format-specific behavior inside the Word, Excel, or PowerPoint handler, let the command layer keep parsing, guard, and warning behavior, and update the matching help schema in the same change [@command-add] [@command-set] [@schemas-readme]. The successful outcome is that direct CLI, resident, batch, and schema-driven agent help all describe the same mutation.
+
+## Start At The Command Contract
+
+Use the existing command shape unless you are intentionally changing the public CLI. `add` owns parent path, type, copy-from, insert position, properties, protection checks, resident forwarding, unsupported-property warnings, and watch notifications [@command-add]. `remove` shares the same command file and owns path parsing, optional Excel `--shift`, selector guardrails, resident forwarding, handler dispatch, and watch notification [@command-add]. `set` owns path, `--find` and `--replace` sugar, missing-property errors, protection checks, selector guardrails, resident forwarding, unsupported-property correction, and result warnings [@command-set].
+
+The command layer should not learn the OOXML details of the new operation. It should parse user input, pass a property dictionary to the handler, and report what the handler says was unsupported [@command-add] [@command-set]. This keeps behavior aligned with the [document handler lifecycle](../architecture/handlers/document-handler-lifecycle).
+
+## Put Dispatch Near The Format
+
+Add the mutation to the handler that owns the file format. Word `Add` resolves the parent, validates parent-child legality, resolves insert anchors, and dispatches by element type [@word-add]. Excel `Add` normalizes paths, rejects wrong-format element types early, and dispatches by type such as sheet, row, cell, picture, chart, pivot table, or slicer [@excel-add].
+
+For `set`, follow the existing order. Word routes revision selectors, selector-style sets, range formatting, find/replace, and then concrete path dispatch [@word-set]. Excel normalizes sheet paths, handles selector sets, validates find/replace, and then dispatches by workbook, sheet, cell, table, chart, pivot, and related path forms [@excel-set]. PowerPoint normalizes path casing, id paths, and last predicates before selector sets, range formatting, find/replace, presentation-level properties, and slide or shape paths [@ppt-set].
+
+## Preserve Selector And Path Semantics
+
+Do not bypass the selector bridge for broad edits. The handlers route bare selectors or slash-scoped content filters through the same filtering engine used by query, then call `Set` on each matched concrete path [@word-set] [@excel-set] [@ppt-set]. Excel remove follows the same query-to-concrete-path pattern and orders row removals descending so shift-deletes do not retarget later rows [@excel-remove]. This is why selector edits can report a match count or fail clearly on zero matches instead of silently doing nothing [@command-set] [@excel-remove].
+
+Use exact slash paths for deterministic node edits and selectors for discovery or multi-target edits. The distinction is explained in [selectors vs slash paths](../concepts/selectors-vs-slash-paths); new mutation code should preserve it instead of inventing a third addressing model.
+
+## Report Unsupported Properties Honestly
+
+Handlers are the source of truth for supported properties. `add` wraps properties in a tracking dictionary and reports keys the handler never reads; Word can also add handler-internal unsupported properties for helpers that must iterate the dictionary [@command-add]. `set` applies through a shared correction path and returns unsupported properties with scoped suggestions based on handler type [@command-set].
+
+When adding a property, make sure the handler actually consumes it. If the operation must reject a combination, throw a targeted error near the dispatcher, as existing Word and PowerPoint code do for contradictory `find` and `range` requests [@word-set] [@ppt-set]. If a property is accepted only for some paths, return it as unsupported for the other paths so callers see a warning instead of a false success [@command-add] [@command-set].
+
+## Update Schemas And Verify
+
+Update the matching file under `schemas/help/` in the same change. The schema README states that any PR changing `Add`, `Set`, or `Get` behavior for an element must update the matching schema, and contract tests verify schema claims against the real handler implementation [@schemas-readme].
+
+Verify through the command surface, not only a helper method. Exercise the new direct command, the same operation through resident mode, and the same item in a batch when the mutation should be batch-addressable. Then run a readback command such as `get`, `query`, `view`, or `validate` so the saved document and the agent-facing result agree with the handler behavior [@command-add] [@command-set].

--- a/almanac/guides/debugging-preview-rendering.md
+++ b/almanac/guides/debugging-preview-rendering.md
@@ -1,0 +1,64 @@
+---
+title: "Debugging Preview Rendering"
+summary: "How to trace HTML, screenshot, SVG, and watch-preview rendering issues across the view command, renderer registry, handlers, and preview assets."
+topics: [guides, rendering, preview]
+sources:
+  - id: view-command
+    type: file
+    path: src/officecli/CommandBuilder.View.cs
+  - id: rendering-core
+    type: file
+    path: src/officecli/Core/Rendering/
+  - id: handler-rendering
+    type: file
+    path: src/officecli/Handlers/Rendering/
+  - id: word-preview
+    type: file
+    path: src/officecli/Handlers/Word/WordHandler.HtmlPreview.cs
+  - id: excel-preview
+    type: file
+    path: src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.cs
+  - id: ppt-preview
+    type: file
+    path: src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.cs
+  - id: preview-css
+    type: file
+    path: src/officecli/Resources/preview.css
+  - id: preview-js
+    type: file
+    path: src/officecli/Resources/preview.js
+---
+
+Debug preview rendering by following the artifact from `view` into the renderer registry and then into the format-specific HTML generator. `view html`, `view screenshot`, and `view svg` all start in `CommandBuilder.View.cs`; Word, Excel, and PowerPoint HTML normally go through registered basic renderers that forward to the handler preview methods [@view-command] [@handler-rendering]. The successful outcome is knowing whether the failure is command option parsing, renderer selection, handler markup, screenshot capture, or shared preview assets.
+
+## Reproduce The Smallest Artifact
+
+Start with `officecli view <file> html --out preview.html` for HTML problems. The command opens the handler, calls `RenderViaRegistry`, and writes either stdout, the requested output path, or an unpredictable temporary file when `--browser` needs one [@view-command].
+
+For screenshot problems, first decide whether the issue exists in HTML. Screenshot mode renders the same HTML preview unless a native Windows backend or a PNG-capable renderer provides pixels first [@view-command]. If the HTML is correct but the screenshot is wrong, focus on viewport size, page filtering, grid mode, clipping, or headless browser capture [@view-command].
+
+## Check Renderer Selection
+
+The registry chooses the highest-priority available renderer whose capabilities cover the requested format, output kind, and mode [@rendering-core]. The built-in bootstrap registers Word HTML, Excel HTML, and PowerPoint HTML/SVG renderers at priority `0`, then gives out-of-tree renderers a composition hook [@handler-rendering].
+
+If a renderer is not being called, inspect the requested `RenderOptions`. `RenderOutputKind` separates HTML, SVG, PNG, and PDF; `RenderMode` separates static output from watch output; page ranges, Word page filters, grid columns, viewport size, and raster dimensions travel through `RenderOptions` [@rendering-core]. A renderer that does not advertise the requested output or watch support will be skipped [@rendering-core].
+
+## Inspect Handler Markup
+
+Word preview builds a self-contained HTML document from the live Word model, catches malformed XML during preview, emits page and grid behavior, and places `data-path` attributes on rendered paragraphs and tables [@word-preview]. Excel preview renders visible sheets as spreadsheet tables, materializes style arrays for efficient lookup, and emits `data-path` attributes for column headers, row headers, and cells [@excel-preview]. PowerPoint preview renders slides as absolutely positioned HTML, supports page ranges and grid overrides, loads shared CSS and JS resources, and emits slide and shape path data used by interaction and clipping [@ppt-preview].
+
+When a visual element is missing, compare the handler's `get` or `query` output with the HTML. If the node exists but has no `data-path`, clipping and watch selection may fail even though the pixels render [@view-command] [@word-preview] [@excel-preview] [@ppt-preview].
+
+## Debug Screenshot And Clip Failures
+
+Screenshot mode defaults to a bounded visual unit: PowerPoint slide 1, Word page 1, and Excel's active sheet behavior through the HTML preview [@view-command]. Use `--page 1-N` or `--grid` when the bug requires a multi-page or multi-slide capture [@view-command].
+
+For `--range` clipping, use a path that the HTML preview actually emits. The command resolves clip targets to `data-path` selectors and returns a targeted error suggesting queryable paths when no rendered region matches [@view-command]. This makes the preview HTML the authority for clipped screenshots, not just the document tree.
+
+If the error says no screenshot backend is available, install a supported headless browser or Playwright Chromium. The command's fallback path writes temporary HTML and captures it with `HtmlScreenshot`; if that backend is missing, no HTML-based screenshot can be produced [@view-command].
+
+## Check Shared Preview Assets
+
+For PowerPoint sidebar, thumbnail, fullscreen, scaling, or keyboard-navigation issues, inspect the embedded preview assets after confirming the handler emitted valid slide markup. The PowerPoint preview loads `Resources.preview.css` and `Resources.preview.js` through helper methods [@ppt-preview]. The CSS owns shared slide viewer layout and headless hiding rules, while the JavaScript owns scaling, thumbnail construction, navigation, and sidebar behavior [@preview-css] [@preview-js].
+
+For live preview behavior, connect the rendering issue to [rendering and preview stack](../architecture/handlers/rendering-and-preview-stack) and [watch preview contract](../architecture/handlers/watch-preview-contract). Watch depends on the same rendered HTML contract, so a broken one-shot preview usually needs to be fixed before debugging the refresh loop.

--- a/almanac/guides/examples-corpus.md
+++ b/almanac/guides/examples-corpus.md
@@ -1,0 +1,42 @@
+---
+title: "Examples Corpus"
+summary: "The examples directory is a runnable corpus for Word, Excel, and PowerPoint features, pairing CLI scripts, Python SDK scripts, walkthroughs, and generated Office files."
+topics: [guides, examples]
+sources:
+  - id: examples-readme
+    type: file
+    path: examples/README.md
+  - id: word-examples
+    type: file
+    path: examples/word/
+  - id: excel-examples
+    type: file
+    path: examples/excel/
+  - id: ppt-examples
+    type: file
+    path: examples/ppt/
+  - id: excel-cell-cli
+    type: file
+    path: examples/excel/cell-formatting.sh
+  - id: excel-cell-sdk
+    type: file
+    path: examples/excel/cell-formatting.py
+---
+
+The examples corpus is the practical proving ground for OfficeCLI's document features. It covers Word, Excel, and PowerPoint, and most examples ship as a four-file set: a Markdown walkthrough, a shell script that drives the CLI, a Python script that drives the SDK, and a generated `.docx`, `.xlsx`, or `.pptx` output file [@examples-readme]. Use it to learn command shapes, test feature changes, and confirm that the CLI and SDK paths stay equivalent.
+
+## Pick The Area
+
+Word examples live under `examples/word/` and cover formatting, charts, content controls, fields, pictures, numbering, diagrams, revisions, sections, tables, and text boxes [@examples-readme] [@word-examples]. Excel examples live under `examples/excel/` and include cell formatting, conditional formatting, data validation, sheet and workbook settings, sparklines, pivot tables, slicers, shapes, and a large chart set [@examples-readme] [@excel-examples]. PowerPoint examples live under `examples/ppt/` and cover presentations, settings, diagrams, animations, video, 3D models, charts, tables, transitions, shapes, text boxes, pictures, OLE embedding, and template builders [@examples-readme] [@ppt-examples].
+
+Start with the Markdown walkthrough when you need intent. Run the `.sh` script when testing the command-line surface. Run the `.py` twin when testing the [SDK path](using-sdks). Compare the generated Office file when the visual or structural output matters [@examples-readme].
+
+## Run And Verify
+
+Each standard example can be regenerated with either `bash <name>.sh` or `python3 <name>.py` [@examples-readme]. The shell scripts show direct `officecli create`, `add`, `set`, `get`, `close`, and `validate` usage [@examples-readme]. The Python scripts use the same batch-shaped command dictionaries sent through the SDK resident client [@examples-readme].
+
+`examples/excel/cell-formatting` is a useful template for feature coverage. Its shell version creates a workbook, opens a resident, issues many `set` and `add` commands, closes the file, reads selected cells back with `get --json`, and validates the final workbook [@excel-cell-cli]. Its Python twin creates the same workbook with `officecli.create(..., "--force")` and groups equivalent command dictionaries into `doc.batch(...)` calls [@excel-cell-sdk].
+
+## Add Or Update An Example
+
+When adding feature coverage, keep the example small enough to read but complete enough to regenerate its output. The README's contributor notes ask for a clear script, tested output, placement in the right document-type directory, and an update to the appropriate directory documentation [@examples-readme]. If a feature exists on both CLI and SDK paths, add both scripts so future changes can catch drift between direct commands and resident batch delivery.

--- a/almanac/guides/installing-and-platform-detection.md
+++ b/almanac/guides/installing-and-platform-detection.md
@@ -1,0 +1,42 @@
+---
+title: "Installing And Platform Detection"
+summary: "Installers choose the correct OfficeCLI asset, verify it when possible, place it in the user install location, and optionally install agent skills or MCP fallback configuration."
+topics: [guides, install]
+sources:
+  - id: unix-installer
+    type: file
+    path: install.sh
+  - id: windows-installer
+    type: file
+    path: install.ps1
+  - id: npm-installer
+    type: file
+    path: npm/lib/install-binary.js
+  - id: cli-installer
+    type: file
+    path: src/officecli/Core/Installer.cs
+---
+
+Installing OfficeCLI means selecting the right platform asset, proving the download when a checksum manifest is available, and putting the binary where future commands can find it. The shell installer covers macOS and Linux, the PowerShell installer covers Windows, npm postinstall vendors a binary inside the package, and the built-in `officecli install` command can copy a running self-contained binary into the user install location [@unix-installer] [@windows-installer] [@npm-installer] [@cli-installer].
+
+## Pick The Asset
+
+On macOS and Linux, `install.sh` derives the asset from `uname -s` and `uname -m`; Linux also checks `ldd --version` and `/etc/alpine-release` to distinguish glibc from musl, producing Alpine asset names for musl systems [@unix-installer]. On Windows, `install.ps1` currently targets `officecli-win-x64.exe` for the script download path [@windows-installer]. The npm installer performs the same selection in Node: `darwin`, `linux`, and `win32` map with `x64` or `arm64`, and Linux calls `isMusl()` before choosing a glibc or Alpine asset [@npm-installer].
+
+If you are changing asset names, update all three surfaces together. The platform names in the install scripts must match the names emitted by the [self-contained binary build](../architecture/build/self-contained-binary-and-embedded-resources) and uploaded by the release workflow.
+
+## Download And Verify
+
+The shell and PowerShell installers try `https://d.officecli.ai` first and fall back to GitHub releases [@unix-installer] [@windows-installer]. Both scripts first resolve the latest tag and prefer `/releases/download/vX.Y.Z/...` over `/releases/latest/download/...` so a new release is not mixed with cached latest assets [@unix-installer] [@windows-installer]. If `SHA256SUMS` is available, both scripts match the exact filename column and compare the expected hash with the downloaded file's SHA-256 hash [@unix-installer] [@windows-installer].
+
+The npm installer pins downloads to the package version. It derives tag `v<version>` from `npm/package.json`, strips prerelease or build suffixes for the binary tag, downloads mirror-first then GitHub, and verifies `SHA256SUMS` with exact filename matching [@npm-installer].
+
+## Place The Binary
+
+For a script install, an existing `officecli` on `PATH` decides the upgrade directory; otherwise Unix installs to `~/.local/bin` and Windows installs to `%LOCALAPPDATA%\OfficeCLI` [@unix-installer] [@windows-installer]. The Unix installer stages the binary as `officecli.new`, applies executable permissions, handles macOS quarantine/signing, and renames it into place [@unix-installer]. The PowerShell script copies to `%LOCALAPPDATA%\OfficeCLI\officecli.exe` and updates the user PATH when needed [@windows-installer].
+
+The built-in installer uses the same canonical install locations and skips copying when the process is already running from the target path, from Homebrew-managed paths, or from a small framework-dependent development build [@cli-installer]. It can also install agent skills and MCP fallback configuration; specific MCP-only targets such as VS Code and LM Studio skip the skill phase [@cli-installer].
+
+## Recovery Checks
+
+After installer changes, verify the selected asset on each affected platform, then check that `officecli --version` runs from the final location. For npm, remove `npm/vendor/officecli` or `officecli.exe` before a local postinstall test so `ensureBinary()` cannot return early from an existing file [@npm-installer].

--- a/almanac/guides/release-build-and-checksum-flow.md
+++ b/almanac/guides/release-build-and-checksum-flow.md
@@ -1,0 +1,42 @@
+---
+title: "Release Build And Checksum Flow"
+summary: "A release builds every platform asset, signs and smoke-tests the runnable binaries, creates SHA256SUMS, and publishes npm only after the GitHub release is public."
+topics: [guides, release, build]
+sources:
+  - id: build-script
+    type: file
+    path: build.sh
+  - id: build-workflow
+    type: file
+    path: .github/workflows/build.yml
+  - id: npm-workflow
+    type: file
+    path: .github/workflows/publish-npm.yml
+  - id: npm-package
+    type: file
+    path: npm/package.json
+---
+
+The release flow turns the [self-contained binary](../architecture/build/self-contained-binary-and-embedded-resources) into named assets, verifies that representative binaries can create and mutate Office files, generates checksums, and only then publishes npm packages that download those public assets. The key invariant is order: npm publication happens after a GitHub Release is published, because postinstall needs the platform binaries and `SHA256SUMS` to already be reachable [@npm-workflow].
+
+## Build The Assets
+
+For local work, `./build.sh release` builds the current platform, `./build.sh debug` builds the current platform in Debug, and `./build.sh all` builds all release targets [@build-script]. The script maps runtime identifiers to asset names for macOS, Linux glibc, Linux musl, and Windows, then writes outputs under `bin/release` or `bin/debug` [@build-script].
+
+CI uses the same asset set in a matrix. The build workflow publishes `osx-arm64`, `osx-x64`, `linux-x64`, `linux-arm64`, `linux-musl-x64`, `linux-musl-arm64`, `win-x64`, and `win-arm64`, then renames each publish output to the release asset name [@build-workflow].
+
+## Sign And Smoke Test
+
+macOS assets are Developer ID signed with hardened runtime and an entitlement file that keeps self-contained CoreCLR JIT execution working; the workflow then verifies the signature and checks that the `allow-jit` entitlement was embedded [@build-workflow]. macOS binaries are submitted to Apple notarization as zipped bare binaries because a bare Mach-O cannot be stapled [@build-workflow].
+
+The workflow smoke-tests runnable host/asset combinations by creating a `.docx`, adding a paragraph, reading it back, and closing the file [@build-workflow]. It also runs a Linux `dotnet/runtime:8.0` container smoke test for the `linux-x64` self-contained binary and tests both the built-in `install` command and the public `install.sh` or `install.ps1` script on supported runners [@build-workflow].
+
+## Publish Checksums And npm
+
+On tag builds, the release job downloads all artifacts, flattens them into one directory, and runs `sha256sum officecli-* > SHA256SUMS` before creating a draft GitHub Release [@build-workflow]. The draft step matters: a human can inspect assets and checksums before publishing.
+
+The npm workflow runs when a release is published or manually dispatched [@npm-workflow]. It sets the package name and version for both `@officecli/officecli` and `@aionui/officecli`, rewrites README package commands, and publishes with npm trusted publishing and provenance when the package already exists [@npm-workflow]. The npm package exposes an `officecli` bin shim and runs `node install.js` on postinstall [@npm-package].
+
+## Maintainer Check
+
+Before publishing npm, confirm that the GitHub Release is public and includes every asset plus `SHA256SUMS`. That check protects immediate `npm install` users, because npm postinstall downloads from the release tag rather than building a binary locally [@npm-workflow].

--- a/almanac/guides/resident-save-close-flush.md
+++ b/almanac/guides/resident-save-close-flush.md
@@ -1,0 +1,53 @@
+---
+title: "Resident Save Close Flush"
+summary: "When to use resident open, save, close, and flush settings so in-memory edits become visible on disk."
+topics: [guides, resident]
+sources:
+  - id: command-builder
+    type: file
+    path: src/officecli/CommandBuilder.cs
+  - id: save-command
+    type: file
+    path: src/officecli/CommandBuilder.Save.cs
+  - id: flush-policy
+    type: file
+    path: src/officecli/Core/ResidentFlushPolicy.cs
+  - id: resident-server
+    type: file
+    path: src/officecli/ResidentServer.cs
+  - id: readme
+    type: file
+    path: README.md
+---
+
+A resident session keeps one document open in memory so repeated commands avoid reopening the Office package. Use `open` to start or reuse that session, `save` to flush in-memory edits while keeping it warm, and `close` to flush and stop it [@command-builder] [@save-command]. The successful outcome is simple: OfficeCLI commands see current edits immediately, and non-OfficeCLI readers see current disk bytes after an explicit or automatic flush.
+
+## Open The Session
+
+Run `officecli open <file>` before a long edit sequence. If a resident is already running, `open` reuses it and upgrades its idle timeout to the normal 12-minute window [@command-builder]. `create` can also auto-start a short-lived resident; a later `open` turns that into the longer-lived session [@command-builder].
+
+Keep passing the file path on every command. The CLI uses that path to find the per-file resident pipe, so resident mode changes transport and lifetime, not the command vocabulary [@command-builder].
+
+## Save Before External Reads
+
+Run `officecli save <file>` when another program needs to read the package directly while the resident should stay alive. The save command probes for an existing resident instead of auto-starting one, sends a resident `save` request, and returns the resident's stdout, stderr, and exit code [@save-command].
+
+Calling `save` with no resident is safe. In non-resident mode each mutation has already saved to disk, so the command reports that the file is already saved and exits successfully [@save-command]. Inside the resident, `save` skips work when there are no pending changes and otherwise calls the handler save, clears the dirty flag, records save duration, and prints `Saved <file>` [@resident-server].
+
+## Close When Ownership Ends
+
+Run `officecli close <file>` when the editing session is done. A live resident receives a close request, flushes through ordered shutdown, releases the handler, and stops responding only after the handler has disposed [@command-builder] [@resident-server]. If no resident owns the file, `close` is also a successful no-op because the disk is already current in non-resident mode [@command-builder].
+
+Treat close warnings as important. If the resident reports an error during shutdown, the CLI returns that error; if the backing path vanished after a successful dispose, the resident emits a warning explaining that a rename may be safe but a delete may lose changes [@command-builder] [@resident-server].
+
+## Tune Flush Policy
+
+The default flush policy is `auto`: after mutations, an idle resident autosaves after an adaptive debounce between 2 and 10 seconds, based on measured save duration [@flush-policy] [@resident-server]. This makes direct disk readers see recent edits shortly after the session goes idle without paying a save after every command [@resident-server].
+
+Set `OFFICECLI_RESIDENT_FLUSH=each` when deterministic disk visibility matters more than throughput. Set it to an integer number of seconds for a fixed idle debounce, or to `off` or `0` when only explicit `save`, `close`, or shutdown should write the disk snapshot [@flush-policy] [@resident-server]. The legacy `OFFICECLI_RESIDENT_IDLE_SAVE_SECONDS` variable is still honored when the newer flush variable is unset [@resident-server].
+
+## Verify The Flush
+
+Use an OfficeCLI read, such as `get`, `query`, or `view`, to verify logical content while the resident is active; these commands read the resident's in-memory handler [@resident-server]. Use `save` or `close` before checking with third-party tools such as Office, Python package readers, or external renderers, because those tools read disk bytes [@resident-server].
+
+The README's quick-start sequence ends edits with `close`, which is the safest final handoff step because it both saves and releases the resident-owned file [@readme]. For deeper background, see [resident sessions](../concepts/resident-sessions) and [resident process and pipes](../architecture/runtime/resident-process-and-pipes).

--- a/almanac/guides/using-batch-safely.md
+++ b/almanac/guides/using-batch-safely.md
@@ -1,0 +1,47 @@
+---
+title: "Using Batch Safely"
+summary: "How to prepare, run, verify, and recover OfficeCLI batch operations without command-shape or flush mistakes."
+topics: [guides, batch]
+sources:
+  - id: batch-command
+    type: file
+    path: src/officecli/CommandBuilder.Batch.cs
+  - id: batch-types
+    type: file
+    path: src/officecli/BatchTypes.cs
+  - id: readme
+    type: file
+    path: README.md
+---
+
+Use batch when many OfficeCLI operations must run against one document in one pass. A safe batch is a JSON array of small command objects, not a list of shell commands: each item names a bare verb such as `add`, `set`, `remove`, `move`, `swap`, `get`, or `query`, and puts arguments in sibling fields such as `path`, `parent`, `type`, `props`, `to`, and `path2` [@batch-command] [@batch-types]. The successful outcome is a replay that reports every item result, leaves the document readable by later commands, and does not hide malformed fields or partial failures.
+
+## Write Items In Protocol Shape
+
+Start from the [batch item protocol](../concepts/batch-item-protocol), not from a command-line transcript. Do not put `add /slide[1] --type shape` inside `command`; write `"command": "add"`, `"parent": "/slide[1]"`, `"type": "shape"`, and a `props` object instead [@batch-command]. `props` can also be an array of `key=value` strings, because the batch deserializer accepts both the object form and the CLI-style array form [@batch-types].
+
+Use only known item fields. The CLI pre-validates every object before deserialization and rejects unknown fields with a message that names the invalid fields and lists valid ones [@batch-command]. This is the first thing to check when a batch fails before opening the document.
+
+## Choose One Input Source
+
+Pass the JSON array with `--commands`, `--input <file>`, `--input -`, or stdin. Do not combine `--commands` and `--input`; the command rejects that combination [@batch-command]. If stdin is redirected while `--commands` or a real `--input` file is also present, OfficeCLI warns that stdin will be ignored unless `OFFICECLI_BATCH_ALLOW_STDIN_REDIRECT=1` is set [@batch-command].
+
+If piping from another OfficeCLI command, keep the normal JSON envelope. Batch unwraps a root object whose `data` property is an array, so output shaped like `{"success":true,"data":[...]}` can feed back into `batch` without an extra transform [@batch-command].
+
+## Pick Failure Behavior
+
+The default batch behavior is continue-on-error: failed rows are recorded and later rows still run [@batch-command]. Use `--stop-on-error` when a later item would be unsafe after an earlier failure, such as applying formatting to a node that should have been created by the previous item [@batch-command].
+
+Read the result as a per-item report. Each failed `BatchResult` includes the item index, the error, and the original item, so the caller can inspect or retry only the failed operation [@batch-types]. In JSON mode the outer batch succeeds only when all rows succeed; a single failed row flips the envelope success and exits non-zero even if other rows completed [@batch-command].
+
+## Run Against The Right Lifetime
+
+A non-resident batch opens the file once, runs all items, and saves once when the handler is disposed [@batch-command]. That is the safest default for a standalone replay because it avoids repeated open/save cycles.
+
+If a resident process already owns the file, the CLI sends the whole batch to that resident as one `batch` request [@batch-command]. The resident applies changes in memory; disk bytes are made current by `save`, `close`, idle autosave, or `OFFICECLI_RESIDENT_FLUSH=each` [@batch-command]. See [batch execution](../architecture/cli/batch-execution) for the shared replay path.
+
+## Verify And Recover
+
+After a mutating batch, verify through OfficeCLI first. Resident reads see the live in-memory document even before a disk flush, while a separate program that opens the file directly may still see old bytes until `save`, `close`, or idle autosave runs [@batch-command].
+
+When a batch partially fails, keep the output. The index and original item on each failed row are the recovery map [@batch-types]. Fix the item shape, remove successful rows that should not run twice, and rerun either the corrected subset or the full batch with idempotent operations. The README's quick-start flow also treats `close` as the final flush step after edits, which is a useful habit before handing the file to another tool [@readme].

--- a/almanac/guides/using-sdks.md
+++ b/almanac/guides/using-sdks.md
@@ -1,0 +1,40 @@
+---
+title: "Using SDKs"
+summary: "The Node and Python SDKs are thin resident clients that open or create one OfficeCLI session, send batch-shaped commands over the pipe, and leave command semantics to the CLI."
+topics: [guides, sdk]
+sources:
+  - id: node-readme
+    type: file
+    path: sdk/node/README.md
+  - id: node-sdk
+    type: file
+    path: sdk/node/index.js
+  - id: python-readme
+    type: file
+    path: sdk/python/README.md
+  - id: python-sdk
+    type: file
+    path: sdk/python/officecli.py
+---
+
+Use the SDKs when a program needs repeated OfficeCLI operations on the same file. Both SDKs start or reuse a resident process for `open` or `create`, then send the same object shape used by the [batch item protocol](../concepts/batch-item-protocol) over the resident pipe [@node-readme] [@python-readme]. They do not define a second command vocabulary; new CLI fields can pass through as command arguments or `props` without adding SDK-specific methods [@node-sdk] [@python-sdk].
+
+## Open The Session
+
+In Node, install and import `@officecli/sdk`, then call `create(path, args?, options?)` or `open(path, options?)` [@node-readme]. In Python, install `officecli-sdk`, import `officecli`, and use `officecli.create(...)` or `officecli.open(...)` [@python-readme]. `create` accepts extra CLI flags such as `--force` or `--type`, because the SDK forwards them to the CLI process [@node-sdk] [@python-sdk].
+
+Treat `with officecli.create(...) as doc:` in Python or `try/finally { await doc.close(); }` in Node as ownership. Closing stops the resident and flushes the in-memory document to disk [@node-sdk] [@python-sdk]. If you only borrow a resident owned by another process, avoid the context manager and do not call `close()` [@node-readme] [@python-readme].
+
+## Send Commands
+
+Use `doc.send({ command, path, props })` for one operation and `doc.batch([...])` for many operations in one pipe round-trip [@node-readme] [@python-readme]. `command` or `op` selects the CLI command, `props` becomes the property map, and every other key is forwarded as a command argument [@node-sdk] [@python-sdk].
+
+For JSON-returning commands, the SDKs parse object or array stdout into the returned value [@node-sdk] [@python-sdk]. For text-style commands such as `view`, `raw`, or `dump`, pass `asJson = false` in Node or `as_json=False` in Python to request plain text [@node-readme] [@python-readme].
+
+## Handle Failure
+
+Transport and process failures raise `OfficeCliError`, but business outcomes remain in the returned envelope's `success` field [@node-readme] [@python-readme]. If a resident is gone, both SDKs restart it with `officecli open` and retry the command once [@node-sdk] [@python-sdk]. If the ping pipe proves the resident is alive but the main pipe is busy or unresponsive, the SDK raises instead of bypassing the live resident and risking a save race [@node-sdk] [@python-sdk].
+
+## Installation Notes
+
+The Node SDK prefers the bundled `@officecli/officecli` binary when it exists, then checks `PATH`, then the official install location, and can provision the bundled binary or run the official installer when `autoInstall` is enabled [@node-sdk]. The Python SDK checks `PATH`, then the official install location, and can run `install.sh` or `install.ps1` on first use unless `auto_install=False` is passed [@python-sdk]. See [installing and platform detection](installing-and-platform-detection) when changing those locations.

--- a/almanac/reference/batch-item-fields.md
+++ b/almanac/reference/batch-item-fields.md
@@ -1,0 +1,62 @@
+---
+title: "Batch Item Fields"
+summary: "Exact reference for the JSON fields accepted by OfficeCLI batch items and how those fields map to resident requests and per-item results."
+topics: [reference, cli, batch]
+sources:
+  - id: batch-types
+    type: file
+    path: src/officecli/BatchTypes.cs
+  - id: batch-command
+    type: file
+    path: src/officecli/CommandBuilder.Batch.cs
+  - id: batch-dispatch
+    type: file
+    path: src/officecli/CommandBuilder.cs
+---
+
+A batch item is one JSON object that names a bare OfficeCLI verb and supplies that verb's arguments as sibling fields. The accepted item keys are fixed by `BatchItem.KnownFields`, while deserialization is lenient about `command` versus `op` and about `props` object versus `["key=value"]` array form [@batch-types]. The CLI `batch` command pre-validates unknown fields before deserializing and then replays the items through the shared batch dispatcher described in [Batch Execution](../architecture/cli/batch-execution) and [Batch Item Protocol](../concepts/batch-item-protocol) [@batch-command].
+
+## Field Table
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `command` | string | Canonical verb field. Use a bare verb such as `add`, `set`, `remove`, `move`, `swap`, `get`, `query`, `view`, `raw`, `raw-set`, `add-part`, or `validate` [@batch-types] [@batch-dispatch]. |
+| `op` | string | Alias for `command` during deserialization [@batch-types]. |
+| `path` | string | Target path for `get`, `set`, `remove`, `move`, `raw` fallback defaults, and other path-oriented verbs; `query` also accepts it as a selector alias in the dispatcher [@batch-types] [@batch-dispatch]. |
+| `parent` | string | Parent path for `add` and `add-part` [@batch-types] [@batch-dispatch]. |
+| `type` | string | Element or part type for `add` and `add-part` [@batch-types] [@batch-dispatch]. |
+| `from` | string | Source path for copy-style `add` operations [@batch-types]. |
+| `index` | integer | Insert or move index; it is serialized to resident request args as a string [@batch-types]. |
+| `after` | string | Relative insertion or move anchor after a path [@batch-types]. |
+| `before` | string | Relative insertion or move anchor before a path [@batch-types]. |
+| `to` | string | Move destination parent and legacy second path for `swap` [@batch-types]. |
+| `path2` | string | Canonical second path for `swap`; both `path2` and legacy `to` are accepted [@batch-types]. |
+| `props` | object or string array | Property dictionary. Object values may be string, number, boolean, or null; array form must contain `key=value` strings and splits on the first equals sign [@batch-types]. |
+| `selector` | string | Selector for `query` and selector-based operations [@batch-types]. |
+| `text` | string | Text argument carried into the resident request argument map [@batch-types]. |
+| `mode` | string | View mode or command-specific mode value [@batch-types]. |
+| `depth` | integer | Depth for node reads; it is serialized to resident request args as a string [@batch-types]. |
+| `part` | string | Raw OOXML part path for `raw` and `raw-set` [@batch-types] [@batch-dispatch]. |
+| `xpath` | string | XPath target for `raw-set` [@batch-types] [@batch-dispatch]. |
+| `action` | string | Raw-set action such as append, prepend, replace, remove, or setattr [@batch-types] [@batch-dispatch]. |
+| `xml` | string | XML fragment or attribute payload for `raw-set` [@batch-types] [@batch-dispatch]. |
+
+## Known Fields And Unknown Fields
+
+`BatchItem.KnownFields` contains exactly `command`, `op`, `path`, `parent`, `type`, `from`, `index`, `after`, `before`, `to`, `path2`, `props`, `selector`, `text`, `mode`, `depth`, `part`, `xpath`, `action`, and `xml` [@batch-types]. The converter itself skips unknown JSON properties, but the CLI batch command scans each object first and rejects unknown field names with the valid-field list [@batch-types] [@batch-command].
+
+## Props Conversion
+
+`props` may be an object or an array. Object values are converted into strings: strings stay strings, numbers become invariant string values, booleans become `true` or `false`, and null becomes an empty string [@batch-types]. Array form accepts only strings and splits `key=value` on the first equals sign; malformed array entries without a key are skipped the same way the single-command prop parser does [@batch-types].
+
+## Resident Request Mapping
+
+`BatchItem.ToResidentRequest()` copies `Command` to `ResidentRequest.Command`, copies scalar fields into `ResidentRequest.Args`, and assigns `Props` to `ResidentRequest.Props` [@batch-types]. Integer fields such as `index` and `depth` are converted to strings in the args map, matching the resident pipe's stringly command argument model [@batch-types].
+
+## Result Fields
+
+Each `BatchResult` has `index`, `success`, optional `output`, optional `error`, and optional `item` [@batch-types]. Failed results include the original `item` so a caller can inspect and retry the failed command [@batch-types]. When `output` is valid JSON whose root is an object or array, the result converter writes it as raw JSON instead of a double-encoded string [@batch-types].
+
+## Input Envelope Rules
+
+The CLI batch command accepts an array from `--commands`, `--input`, explicit `--input -`, or stdin, and `--commands` and `--input` are mutually exclusive [@batch-command]. It also unwraps a normal JSON envelope whose root has a `data` array, so `dump --json` output can feed batch directly [@batch-command]. Non-array roots fail with a message telling the caller to wrap a single item in an array, and explicit null items are rejected by index [@batch-command].

--- a/almanac/reference/bundled-skills.md
+++ b/almanac/reference/bundled-skills.md
@@ -1,0 +1,71 @@
+---
+title: "Bundled Skills"
+summary: "Lookup reference for the OfficeCLI skill catalog, aliases, trigger summaries, bundled files, and supported installation targets."
+topics: [reference, skills, agent]
+sources:
+  - id: skill-installer
+    type: file
+    path: src/officecli/Core/SkillInstaller.cs
+  - id: root-skill
+    type: file
+    path: SKILL.md
+  - id: skills-dir
+    type: file
+    path: skills/
+---
+
+Bundled skills are the agent-facing workflow guides embedded with OfficeCLI. The umbrella `officecli` skill explains the general OfficeCLI workflow, while the named sub-skills are lazy-loaded or installed when a document type or specialized document task needs more detailed rules [@root-skill] [@skill-installer]. The conceptual role is covered in [OfficeCLI skills](../concepts/officecli-skills) and [MCP and skills](../architecture/agent/mcp-and-skills).
+
+## Catalog names
+
+`SkillInstaller` exposes these named skills through `load_skill`, `skills list`, and specific skill installation [@skill-installer].
+
+| Public name | Bundled folder | Trigger summary |
+|---|---|---|
+| `pptx` | `officecli-pptx` | Slide decks and presentations [@skill-installer] |
+| `word` | `officecli-docx` | Word documents, reports, letters, and memos [@skill-installer] |
+| `excel` | `officecli-xlsx` | Spreadsheets, financial models, and dashboards [@skill-installer] |
+| `morph-ppt` | `morph-ppt` | Cross-slide Morph animation and continuous motion [@skill-installer] |
+| `morph-ppt-3d` | `morph-ppt-3d` | 3D Morph decks with GLB models and camera work [@skill-installer] |
+| `pitch-deck` | `officecli-pitch-deck` | Fundraising and investor decks [@skill-installer] |
+| `academic-paper` | `officecli-academic-paper` | Academic papers and research reports [@skill-installer] |
+| `data-dashboard` | `officecli-data-dashboard` | Data dashboards [@skill-installer] |
+| `financial-model` | `officecli-financial-model` | Financial models and projections [@skill-installer] |
+| `word-form` | `officecli-word-form` | Fillable forms, content controls, and protected documents [@skill-installer] |
+
+The `skills/` tree contains these folders plus their `SKILL.md` entry points and any bundled references or helper files, such as `morph-ppt/reference/decision-rules.md` and helper scripts [@skills-dir]. The umbrella `officecli` skill is installed from `skills/officecli/SKILL.md` in embedded-resource builds, but it is intentionally kept out of the public `SkillMap` so `load_skill` without a name lists only sub-skills [@skill-installer].
+
+## Root skill
+
+The root skill covers `.docx`, `.xlsx`, and `.pptx`; tells agents to prefer read, DOM edit, then raw XML layers; and directs agents to check specialized skills before document work [@root-skill]. It also says `officecli help` is the authority for property names, value formats, command syntax, and schema details [@root-skill].
+
+## Loading behavior
+
+`load_skill` with no name returns a generated catalog containing each public skill name and its full routing description [@skill-installer]. `load_skill <name>` returns that skill's `SKILL.md` content with its `## Setup` section stripped and a reference-file manifest appended [@skill-installer]. `load_skill <name> --path <relpath>` returns one bundled text reference file after rejecting traversal segments, missing paths, and binary assets [@skill-installer].
+
+Binary skill assets are excluded from text-channel loading. The blocked extensions include `.pptx`, `.docx`, `.xlsx`, common image formats, `.glb`, `.pdf`, `.zip`, and `.ico`; users must install the skill to get those files on disk [@skill-installer].
+
+## Installation targets
+
+Skill installation writes to detected agent skill directories under the user's home directory [@skill-installer].
+
+| Agent | Aliases | Skill directory |
+|---|---|---|
+| Claude Code | `claude`, `claude-code` | `~/.claude/skills` [@skill-installer] |
+| GitHub Copilot | `copilot`, `github-copilot` | `~/.copilot/skills` [@skill-installer] |
+| Codex CLI | `codex`, `openai-codex` | `~/.agents/skills` [@skill-installer] |
+| Cursor | `cursor` | `~/.cursor/skills` [@skill-installer] |
+| Pi | `pi`, `pi-agent` | `~/.pi/agent/skills` [@skill-installer] |
+| Windsurf | `windsurf` | `~/.windsurf/skills` [@skill-installer] |
+| MiniMax CLI | `minimax`, `minimax-cli` | `~/.minimax/skills` [@skill-installer] |
+| OpenCode | `opencode` | `~/.opencode/skills` [@skill-installer] |
+| Hermes Agent | `hermes`, `hermes-agent` | `~/.hermes/skills` [@skill-installer] |
+| OpenClaw | `openclaw` | `~/.openclaw/skills` [@skill-installer] |
+| NanoBot | `nanobot` | `~/.nanobot/workspace/skills` [@skill-installer] |
+| ZeroClaw | `zeroclaw` | `~/.zeroclaw/workspace/skills` [@skill-installer] |
+
+`officecli skills install` and `officecli skills install all` install the umbrella skill to all detected agents [@skill-installer]. `officecli skills install <name>` installs all embedded files for one named sub-skill to all detected agents, and `officecli skills install <skill> <agent>` or the reversed argument order installs one named skill to one supported agent target [@skill-installer].
+
+## Installed file handling
+
+Specific skill installation copies every embedded file for the selected folder, rewriting Markdown cross-skill references where needed and leaving scripts or other non-Markdown files unchanged [@skill-installer]. After a binary upgrade, `RefreshInstalled` updates only skills that already have `SKILL.md` present in detected agent directories; it does not add new agents or new sub-skills [@skill-installer].

--- a/almanac/reference/bundled-skills.md
+++ b/almanac/reference/bundled-skills.md
@@ -64,7 +64,7 @@ Skill installation writes to detected agent skill directories under the user's h
 | NanoBot | `nanobot` | `~/.nanobot/workspace/skills` [@skill-installer] |
 | ZeroClaw | `zeroclaw` | `~/.zeroclaw/workspace/skills` [@skill-installer] |
 
-`officecli skills install` and `officecli skills install all` install the umbrella skill to all detected agents [@skill-installer]. `officecli skills install <name>` installs all embedded files for one named sub-skill to all detected agents, and `officecli skills install <skill> <agent>` or the reversed argument order installs one named skill to one supported agent target [@skill-installer].
+`officecli skills install` installs the umbrella skill to all detected agents; the legacy equivalent is `officecli skills all` [@skill-installer]. `officecli skills install <name>` installs all embedded files for one named sub-skill to all detected agents, and `officecli skills install <skill> <agent>` or the reversed argument order installs one named skill to one supported agent target [@skill-installer].
 
 ## Installed file handling
 

--- a/almanac/reference/command-surface.md
+++ b/almanac/reference/command-surface.md
@@ -1,0 +1,116 @@
+---
+title: "Command Surface"
+summary: "Lookup reference for OfficeCLI's public commands, early-dispatch commands, hidden compatibility commands, and their owning source files."
+topics: [reference, cli]
+sources:
+  - id: program
+    type: file
+    path: src/officecli/Program.cs
+  - id: root-builder
+    type: file
+    path: src/officecli/CommandBuilder.cs
+  - id: add-commands
+    type: file
+    path: src/officecli/CommandBuilder.Add.cs
+  - id: set-command
+    type: file
+    path: src/officecli/CommandBuilder.Set.cs
+  - id: get-query
+    type: file
+    path: src/officecli/CommandBuilder.GetQuery.cs
+  - id: watch-command
+    type: file
+    path: src/officecli/CommandBuilder.Watch.cs
+  - id: raw-commands
+    type: file
+    path: src/officecli/CommandBuilder.Raw.cs
+  - id: view-command
+    type: file
+    path: src/officecli/CommandBuilder.View.cs
+  - id: refresh-command
+    type: file
+    path: src/officecli/CommandBuilder.Refresh.cs
+  - id: validate-command
+    type: file
+    path: src/officecli/CommandBuilder.Check.cs
+  - id: save-command
+    type: file
+    path: src/officecli/CommandBuilder.Save.cs
+  - id: batch-command
+    type: file
+    path: src/officecli/CommandBuilder.Batch.cs
+  - id: dump-command
+    type: file
+    path: src/officecli/CommandBuilder.Dump.cs
+  - id: import-create-merge
+    type: file
+    path: src/officecli/CommandBuilder.Import.cs
+  - id: plugins-command
+    type: file
+    path: src/officecli/CommandBuilder.Plugins.cs
+  - id: help-command
+    type: file
+    path: src/officecli/CommandBuilder.Help.cs
+  - id: integration-stubs
+    type: file
+    path: src/officecli/CommandBuilder.IntegrationStubs.cs
+---
+
+The OfficeCLI command surface is split between process-level commands handled before the root parser and normal subcommands registered by `CommandBuilder.BuildRootCommand()`. The normal surface covers resident lifecycle, document viewing, node lookup, selectors, mutations, raw OOXML access, validation, batch replay, import/create/merge utilities, plugins, and schema-aware help; early dispatch keeps installer, MCP, skill, config, and schema CRC behavior outside the reusable document parser [@program] [@root-builder]. See [Command Dispatch](../architecture/cli/command-dispatch) for the runtime boundary and [Command Layers](../concepts/command-layers) for the semantic layers behind the verbs.
+
+## Early Dispatch
+
+These commands are recognized in `Program.cs` before the System.CommandLine root is invoked [@program].
+
+| Token | Behavior | Notes |
+| --- | --- | --- |
+| `--output-schema-crc` | Prints the CRC32 fingerprint for embedded `schemas/help/**` resources. | This is a single flag, not a root subcommand [@program]. |
+| `--help`, `-h`, `-?` | Rewrites to `help`, preserving trailing tokens. | Only the first or second argv token is rewritten so property values named `--help` are not corrupted [@program]. |
+| `mcp` | Starts the MCP stdio server with no target, registers a target, unregisters a target, or lists target status. | `mcp-serve` is a legacy alias for starting the server [@program]. |
+| `install` | Runs one-step binary, skill, and MCP setup. | It accepts optional target arguments through the installer path [@program]. |
+| `skills`, `skill` | Lists skills, installs the base skill, installs a named skill, or installs to one agent target. | Singular and plural forms route to the same handler [@program]. |
+| `load_skill` | Prints the skill catalog, a skill's `SKILL.md`, or a bundled reference file via `--path`. | This is read-only and mirrors the MCP `load_skill` behavior [@program]. |
+| `config` | Handles update-check configuration. | It is dispatched before the root parser [@program]. |
+| `__update-check__` | Runs the internal update refresh process. | This is an internal child-process route [@program]. |
+
+`mcp`, `skills`, and `install` also appear in root help through stub commands. The stubs do not own execution; they print the same usage text used by early dispatch and `officecli help <cmd>` [@integration-stubs] [@help-command].
+
+## Root Commands
+
+Every command below is registered by `BuildRootCommand()` unless noted as a nested subcommand [@root-builder].
+
+| Command | Purpose | Owner |
+| --- | --- | --- |
+| `open` | Starts or reuses a resident process for a document. | `CommandBuilder.cs` [@root-builder] |
+| `close` | Flushes a resident, stops it, and treats no-resident as a successful no-op. | `CommandBuilder.cs` [@root-builder] |
+| `watch` | Starts live preview; owns nested `mark`, `unmark`, `marks`, and `goto` commands. | `CommandBuilder.Watch.cs` [@watch-command] |
+| `unwatch` | Stops a watch preview server for a document. | `CommandBuilder.Watch.cs` [@watch-command] |
+| `view` | Renders document views such as text, annotated, outline, stats, issues, html, svg, screenshot, pdf, and forms. | `CommandBuilder.View.cs` [@view-command] |
+| `get` | Reads a document node by path, defaulting the path to `/`, with optional depth and binary extraction. | `CommandBuilder.GetQuery.cs` [@get-query] |
+| `query` | Runs CSS-like selectors with optional text filtering, compact output, and extra fields. | `CommandBuilder.GetQuery.cs` [@get-query] |
+| `set` | Mutates a node or selector target with `--prop`, `--find`, and `--replace`. | `CommandBuilder.Set.cs` [@set-command] |
+| `add` | Adds an element under a parent path, optionally from another element, at an index, after a path, or before a path. | `CommandBuilder.Add.cs` [@add-commands] |
+| `remove` | Removes an element, with Excel cell shifting and Word tracked-delete modifier support. | `CommandBuilder.Add.cs` [@add-commands] |
+| `move` | Moves an element to a target parent or relative position. | `CommandBuilder.Add.cs` [@add-commands] |
+| `swap` | Swaps two document nodes. | `CommandBuilder.Add.cs` [@add-commands] |
+| `refresh` | Recalculates derived Word field values; the description marks Word plus Windows as required. | `CommandBuilder.Refresh.cs` [@refresh-command] |
+| `raw` | Reads a raw document part, with Excel row and column filters. | `CommandBuilder.Raw.cs` [@raw-commands] |
+| `raw-set` | Mutates a raw XML part by XPath and action. | `CommandBuilder.Raw.cs` [@raw-commands] |
+| `add-part` | Creates a document part and returns a relationship id and path. | `CommandBuilder.Raw.cs` [@raw-commands] |
+| `validate` | Runs OpenXML validation. | `CommandBuilder.Check.cs` [@validate-command] |
+| `save` | Flushes resident in-memory changes while keeping the resident running. | `CommandBuilder.Save.cs` [@save-command] |
+| `batch` | Replays a JSON array of batch items in one pass. | `CommandBuilder.Batch.cs` [@batch-command] |
+| `dump` | Serializes a subtree into replayable batch output. | `CommandBuilder.Dump.cs` [@dump-command] |
+| `import` | Imports CSV or TSV data into an Excel sheet. | `CommandBuilder.Import.cs` [@import-create-merge] |
+| `create` | Creates a blank `.docx`, `.xlsx`, or `.pptx` file. | `CommandBuilder.Import.cs` [@import-create-merge] |
+| `merge` | Merges a template with JSON data by replacing `{{key}}` placeholders. | `CommandBuilder.Import.cs` [@import-create-merge] |
+| `plugins` | Groups plugin inspection commands. | `CommandBuilder.Plugins.cs` [@plugins-command] |
+| `help` | Shows schema-driven help, command help, flat schema dumps, raw schema JSON, and JSONL output for flat dumps. | `CommandBuilder.Help.cs` [@help-command] |
+
+## Hidden Root Commands
+
+Hidden commands are registered for internal process control or compatibility. `__resident-serve__` runs the resident server child process and is marked hidden; it takes a per-file singleton lock before opening the document [@root-builder]. Top-level `mark`, `unmark`, `get-marks`, and `goto` are hidden compatibility aliases for the corresponding `watch` subcommands [@root-builder].
+
+## Shared Flags And Help
+
+The root command defines one shared `--json` option and passes it into normal command builders, so document commands can use the same AI-friendly output switch [@root-builder]. The `help` command recognizes `add`, `set`, `get`, `query`, and `remove` as schema verbs; it can list formats, list elements, filter elements by verb, render one element schema, emit raw schema JSON, or produce flat corpus dumps through `help all`, `help all --json`, and `help all --jsonl` [@help-command].

--- a/almanac/reference/help-schema-format.md
+++ b/almanac/reference/help-schema-format.md
@@ -1,0 +1,99 @@
+---
+title: "Help Schema Format"
+summary: "Exact reference for OfficeCLI help schema files, including element metadata, paths, operations, properties, examples, inheritance, and runtime validation behavior."
+topics: [reference, cli, schemas]
+sources:
+  - id: schemas-readme
+    type: file
+    path: schemas/README.md
+  - id: schema-meta
+    type: file
+    path: schemas/help/_schema.json
+  - id: schema-loader
+    type: file
+    path: src/officecli/Help/SchemaHelpLoader.cs
+  - id: schema-renderer
+    type: file
+    path: src/officecli/Help/SchemaHelpRenderer.cs
+  - id: flat-renderer
+    type: file
+    path: src/officecli/Help/SchemaHelpFlatRenderer.cs
+  - id: help-command
+    type: file
+    path: src/officecli/CommandBuilder.Help.cs
+  - id: docx-paragraph
+    type: file
+    path: schemas/help/docx/paragraph.json
+  - id: xlsx-cell
+    type: file
+    path: schemas/help/xlsx/cell.json
+  - id: pptx-shape
+    type: file
+    path: schemas/help/pptx/shape.json
+---
+
+OfficeCLI help schemas are JSON files under `schemas/help/` that describe one format and element pair: supported operations, paths, properties, aliases, readback, children, examples, and special raw parts. The repository treats these files as the agent-facing capability source of truth for add, set, get, and readback behavior, while the runtime loader embeds and resolves them for `officecli help` [@schemas-readme] [@schema-loader]. For the loader path, see [Help Schema Loader](../architecture/cli/help-schema-loader); for the concept, see [Help Schemas](../concepts/help-schemas); for the upgrade fingerprint, see [Schema CRC](schema-crc).
+
+## File Layout
+
+The schema tree has a meta-schema at `schemas/help/_schema.json`, shared bases under `schemas/help/_shared/`, and per-format element files under `schemas/help/docx/`, `schemas/help/xlsx/`, and `schemas/help/pptx/` [@schemas-readme]. The README says PRs that change `Add`, `Set`, or `Get` behavior for an element must update the matching schema file in the same PR, with contract tests checking schema claims against handlers [@schemas-readme].
+
+## Required Top-Level Fields
+
+The JSON Schema requires `format`, `element`, `operations`, and `properties` [@schema-meta].
+
+| Field | Shape | Meaning |
+| --- | --- | --- |
+| `$schema` | string | Pointer to the meta-schema for tooling; ignored at runtime [@schema-meta]. |
+| `format` | enum | One of `docx`, `xlsx`, or `pptx` [@schema-meta]. |
+| `element` | string | CLI element name, such as `paragraph`, `cell`, or `shape` [@schema-meta]. |
+| `parent` | string or array | Parent element name or names when the element exists only under another element [@schema-meta]. |
+| `note` | string | Free-form clarification for caveats or invariants [@schema-meta]. |
+| `container` | boolean | Marks read-only root or container entities that are navigated but not created or mutated [@schema-meta]. |
+| `operations` | object | Top-level support flags for `add`, `set`, `get`, `query`, and `remove` [@schema-meta]. |
+| `addParent` | string or array | Explicit Add parent path when it cannot be derived from the element path [@schema-meta]. |
+| `paths` | object | `stable` and `positional` path examples for addressing the element [@schema-meta]. |
+| `addressing` | object | Keyed child path form, with `key`, `pathForm`, and optional `keyValues` [@schema-meta]. |
+| `properties` | object | Map of canonical property name to property definition [@schema-meta]. |
+| `children` | array | Child element references with path segment and cardinality [@schema-meta]. |
+| `parts` | array | Raw-part listing for synthetic `raw` schemas [@schema-meta]. |
+| `examples` | array | Element-level examples, especially for raw schemas [@schema-meta]. |
+| `description` | string | Element-level description [@schema-meta]. |
+| `elementAliases` | array | Alternate element names that resolve to the same schema file [@schema-meta]. |
+
+## Property Definition
+
+Each property definition must have a `type` according to the meta-schema [@schema-meta]. Allowed property types are `string`, `bool`, `number`, `color`, `length`, `font-size`, and `enum` [@schema-meta].
+
+| Field | Shape | Meaning |
+| --- | --- | --- |
+| `description` | string | Human-readable property meaning [@schema-meta]. |
+| `aliases` | array or object | Input aliases. Array form is a plain alias list; object form maps alias to canonical value [@schema-meta]. |
+| `values` | string array | Allowed values for `type: enum` [@schema-meta]. |
+| `modifiers` | object | Modifier composition rules for enum-like properties [@schema-meta]. |
+| `appliesWhen` | object | Conditional applicability; all listed state keys must match [@schema-meta]. |
+| `requires` | string array | Other same-element properties required for a well-formed OOXML result [@schema-meta]. |
+| `add`, `set`, `get` | boolean | Per-property verb participation [@schema-meta]. |
+| `examples` | string array | Property-level command examples [@schema-meta]. |
+| `readback` | string | Expected Get readback shape [@schema-meta]. |
+| `enforcement` | enum | `strict` breaks CI on drift; `report` logs drift [@schema-meta]. |
+
+Runtime property validation also accepts `propAliases` arrays in property definitions even though the meta-schema excerpt names `aliases`; the loader explicitly reads `propAliases` after `aliases` while building allowed keys [@schema-loader].
+
+## Examples In Current Schemas
+
+`schemas/help/docx/paragraph.json` declares `format: docx`, `element: paragraph`, alias `p`, all five operations, stable and positional body paragraph paths, `run` children, and `extends: _shared/paragraph` [@docx-paragraph]. `schemas/help/xlsx/cell.json` declares `parent: sheet`, all five operations, paths such as `/<sheetName>/<A1Ref>` and `/Sheet1/A1`, and cell-specific property aliases such as `bold` for `font.bold` [@xlsx-cell]. `schemas/help/pptx/shape.json` declares all five operations, stable id and positional shape paths, `extends: _shared/shape`, and shape-specific properties such as `geometry`, `opacity`, `isTitle`, and text-direction keys [@pptx-shape].
+
+## Inheritance And Aliases
+
+A schema may declare `extends` as a string or an array. The loader reads shared bases from `schemas/help/<base>.json`, applies bases in declaration order, then applies the concrete schema last [@schema-loader]. Top-level fields replace base values except `properties`: override-declared properties come first, base-only properties are appended, and same-name properties in the override replace the base property atomically [@schema-loader].
+
+Format aliases are `word` to `docx`, `excel` to `xlsx`, and `ppt` or `powerpoint` to `pptx` [@schema-loader]. Element lookup first tries the filename stem, then scans `elementAliases` inside schemas, so `p`, `col`, or `img` can resolve to canonical schema filenames when declared [@schema-loader]. The root path `/` resolves to `workbook`, `document`, or `presentation` by format [@schema-loader].
+
+## Help Rendering
+
+`officecli help` lists formats, lists elements, filters elements by schema verb, renders element detail, renders raw JSON, and emits flat dumps through `help all`, `help <format> all`, `--json`, and `--jsonl` [@help-command]. Human rendering prints header, read-only container status, description, parent, paths, addressing, operations, synthesized usage, properties filtered by verb when needed, parts, children, notes, and examples [@schema-renderer]. Flat rendering emits `ELEM` and `PROP` rows, with an `ops` legend for `add`, `set`, `get`, `query`, and `remove` [@flat-renderer].
+
+## Runtime Validation
+
+`SchemaHelpLoader.ValidateProperties()` checks property dictionaries for a format, element, and verb, but it is intentionally lenient when a format or element is unknown [@schema-loader]. It accepts declared property names, array-form `aliases`, `propAliases`, generic add/set keys such as `from`, `copyFrom`, `path`, `positional`, and `text`, dotted namespaces such as `font.`, `border.`, and `series.`, and indexed prefixes such as `series1.` and `dataLabel3.` [@schema-loader].

--- a/almanac/reference/platform-assets-and-install-surfaces.md
+++ b/almanac/reference/platform-assets-and-install-surfaces.md
@@ -1,0 +1,71 @@
+---
+title: "Platform Assets And Install Surfaces"
+summary: "Lookup reference for OfficeCLI platform asset names, installer locations, npm binary vendoring, and install-time side effects."
+topics: [reference, install]
+sources:
+  - id: readme
+    type: file
+    path: README.md
+  - id: unix-installer
+    type: file
+    path: install.sh
+  - id: windows-installer
+    type: file
+    path: install.ps1
+  - id: npm-package
+    type: file
+    path: npm/package.json
+  - id: npm-installer
+    type: file
+    path: npm/lib/install-binary.js
+---
+
+OfficeCLI ships as a self-contained native binary selected by platform and installed through shell, PowerShell, npm, package-manager, manual-download, or self-install surfaces [@readme]. This reference lists the asset names, download rules, install locations, npm behavior, and skill side effects that maintainers must keep aligned with the [installing and platform detection](../guides/installing-and-platform-detection) and [release build and checksum flow](../guides/release-build-and-checksum-flow) guides.
+
+## Platform assets
+
+| Platform | Asset name |
+|---|---|
+| macOS arm64 | `officecli-mac-arm64` [@readme] |
+| macOS x64 | `officecli-mac-x64` [@readme] |
+| Linux x64 glibc | `officecli-linux-x64` [@unix-installer] |
+| Linux arm64 glibc | `officecli-linux-arm64` [@unix-installer] |
+| Linux x64 musl or Alpine | `officecli-linux-alpine-x64` [@unix-installer] |
+| Linux arm64 musl or Alpine | `officecli-linux-alpine-arm64` [@unix-installer] |
+| Windows x64 | `officecli-win-x64.exe` [@readme] |
+| Windows arm64 | `officecli-win-arm64.exe` [@readme] [@npm-installer] |
+
+`install.sh` detects macOS and Linux with `uname`, maps `x86_64` to x64, maps `aarch64` and `arm64` to arm64, and treats Linux as musl when `ldd --version` mentions musl or `/etc/alpine-release` exists [@unix-installer]. The npm installer repeats the same platform split using Node `process.platform`, `process.arch`, `process.report`, `/etc/alpine-release`, and `ldd --version` [@npm-installer]. The PowerShell installer download path currently targets `officecli-win-x64.exe` [@windows-installer].
+
+## Download surfaces
+
+| Surface | Selection and download behavior |
+|---|---|
+| `install.sh` | Resolves the latest release tag, downloads mirror-first from `https://d.officecli.ai`, falls back to GitHub releases, and prefers immutable `/releases/download/<tag>/...` URLs [@unix-installer] |
+| `install.ps1` | Uses the same mirror-first and GitHub-fallback pattern, resolves a `vX.Y.Z` tag, and falls back to the mutable latest path only when tag resolution fails [@windows-installer] |
+| npm postinstall | Derives the release tag from `npm/package.json` version, strips prerelease and build suffixes, downloads mirror-first then GitHub, and writes the native binary under `npm/vendor/` [@npm-installer] |
+| Manual download | README lists GitHub Releases as the manual source for platform binaries [@readme] |
+
+The shell, PowerShell, and npm installers all try to verify `SHA256SUMS` when available and match the exact filename column before comparing SHA-256 hashes [@unix-installer] [@windows-installer] [@npm-installer].
+
+## Install locations
+
+| Surface | Final location |
+|---|---|
+| Unix script with existing `officecli` | Directory containing the existing command on `PATH` [@unix-installer] |
+| Unix script without existing command | `~/.local/bin/officecli` [@unix-installer] |
+| Windows script with existing `officecli.exe` | Directory containing the existing command [@windows-installer] |
+| Windows script without existing command | `%LOCALAPPDATA%\OfficeCLI\officecli.exe` [@windows-installer] |
+| npm package | `npm/vendor/officecli` or `npm/vendor/officecli.exe`, reached through package `bin` shim `officecli.js` [@npm-package] [@npm-installer] |
+
+The Unix installer stages the binary as `officecli.new`, applies executable permissions, handles macOS quarantine and signing on the staged copy, and then renames it into place [@unix-installer]. The Windows installer copies the downloaded binary to `officecli.exe` and adds the install directory to the user's `Path` if needed [@windows-installer].
+
+## Package-manager surfaces
+
+The README lists Homebrew, Scoop, npm, manual download, one-line shell or PowerShell install, and `officecli install` self-install as supported human install paths [@readme]. The npm package is named `@officecli/officecli`, supports `darwin`, `linux`, and `win32` on `x64` and `arm64`, requires Node `>=14`, and runs `node install.js` during `postinstall` [@npm-package].
+
+## Skill side effects
+
+On first script install, Unix and Windows installers detect supported AI-agent directories and download the umbrella `SKILL.md` into each detected `skills/officecli/SKILL.md` location [@unix-installer] [@windows-installer]. They create a `.officecli-skills-installed` marker in the install directory so that script path does not repeat the first-install skill download on every upgrade [@unix-installer] [@windows-installer].
+
+The README also states that `officecli install` copies the binary to `PATH` and installs the OfficeCLI skill into detected AI coding agents [@readme].

--- a/almanac/reference/plugin-discovery.md
+++ b/almanac/reference/plugin-discovery.md
@@ -1,0 +1,53 @@
+---
+title: "Plugin Discovery"
+summary: "Exact lookup reference for how OfficeCLI resolves plugin executables, probes manifests, caches results, and hardens PATH lookup."
+topics: [reference, plugins]
+sources:
+  - id: plugin-protocol
+    type: file
+    path: plugins/plugin-protocol.md
+  - id: plugin-registry
+    type: file
+    path: src/officecli/Core/Plugins/PluginRegistry.cs
+---
+
+Plugin discovery is the fixed search process OfficeCLI uses when it needs a plugin for a `(kind, extension)` pair. The protocol defines four ordered locations, and `PluginRegistry.FindFor` implements that order, normalizes extensions, probes candidates with `--info`, applies the protocol-version gate, and caches both hits and misses for the current process [@plugin-protocol] [@plugin-registry]. For the broader extension model, see the [plugin system](../architecture/plugins/plugin-system).
+
+## Lookup key
+
+Discovery is keyed by plugin kind and file extension. The supported kind wire strings are `dump-reader`, `exporter`, and `format-handler` [@plugin-protocol]. The registry normalizes extensions to lowercase and adds a leading dot when needed, so `doc` and `.DOC` resolve as `.doc` [@plugin-registry].
+
+## Search order
+
+The first matching candidate wins [@plugin-protocol].
+
+| Order | Surface | Candidate form |
+|---:|---|---|
+| 1 | Environment variable | `OFFICECLI_PLUGIN_<KIND>_<EXT>` with kind uppercased and `-` changed to `_`, such as `OFFICECLI_PLUGIN_DUMP_READER_DOC` [@plugin-registry] |
+| 2 | User plugin directory | `~/.officecli/plugins/<kind>/<ext>/plugin` or `plugin.exe` on Windows [@plugin-registry] |
+| 3 | Bundled plugin directory | `<app-base>/plugins/<kind>/<ext>/plugin` or `plugin.exe` on Windows [@plugin-registry] |
+| 4 | `PATH` lookup | `officecli-<kind>-<ext>` first, then `officecli-<ext>` [@plugin-registry] |
+
+The protocol uses extension names without the leading dot in paths and environment variable names, such as `doc`, `hwpx`, or `pdf` [@plugin-protocol]. Symlinks are allowed by the protocol, because the registry only tests whether the candidate file exists before probing it [@plugin-protocol] [@plugin-registry].
+
+## Executable names
+
+Directory-based plugins use `plugin` on Unix-like systems. On Windows, the registry checks `plugin.exe` and then `plugin` [@plugin-registry].
+
+`PATH` plugins use two name variants. The specific form is `officecli-<kind>-<ext>`, such as `officecli-dump-reader-doc`; the fallback form is `officecli-<ext>`, such as `officecli-doc` [@plugin-protocol] [@plugin-registry]. On Windows, `PATH` lookup checks both the `.exe` and extensionless forms [@plugin-registry].
+
+## Probe and match
+
+Every candidate must answer `<plugin> --info` with one JSON manifest on stdout and exit `0` [@plugin-protocol]. The registry gives this probe 5 seconds, reads stdout and stderr asynchronously to avoid pipe deadlock, rejects empty or malformed JSON, rejects nonzero exit, and treats any probe failure as "not found" for that candidate [@plugin-registry].
+
+After parsing the manifest, the registry rejects any plugin whose `protocol` is not `1` [@plugin-registry]. A parsed manifest must also contain the requested kind and requested normalized extension before it can resolve the lookup [@plugin-registry]. Manifest fields are listed in the [plugin manifest](plugin-manifest) reference.
+
+## Cache and enumeration
+
+`FindFor` caches the result for each `(kind, extension)` pair for the lifetime of the process. Negative results are cached too, so a missing or invalid plugin is not re-probed on every operation [@plugin-registry]. `InvalidateCache` clears this map for install flows that need re-discovery without restarting [@plugin-registry].
+
+`EnumerateAll` is narrower than targeted lookup. It walks only the user and bundled plugin directory trees, looking for the two-level layout `<root>/<kind>/<ext>/plugin(.exe)` [@plugin-registry]. It does not enumerate environment-variable plugins or scan arbitrary `PATH` names [@plugin-registry].
+
+## PATH hardening
+
+`PATH` lookup ignores relative entries such as `.` or `src/bin` [@plugin-registry]. On Unix-like systems, it also skips world-writable directories by checking the `OtherWrite` mode bit [@plugin-registry]. Windows returns `false` from that mode-bit check because Windows uses ACLs rather than Unix mode bits [@plugin-registry].

--- a/almanac/reference/plugin-manifest.md
+++ b/almanac/reference/plugin-manifest.md
@@ -1,0 +1,77 @@
+---
+title: "Plugin Manifest"
+summary: "Exact reference for OfficeCLI plugin manifest fields, kind names, target formats, idle-timeout rules, and format-handler vocabulary."
+topics: [reference, plugins]
+sources:
+  - id: plugin-protocol
+    type: file
+    path: plugins/plugin-protocol.md
+  - id: plugin-manifest
+    type: file
+    path: src/officecli/Core/Plugins/PluginManifest.cs
+  - id: plugin-registry
+    type: file
+    path: src/officecli/Core/Plugins/PluginRegistry.cs
+---
+
+A plugin manifest is the JSON object printed by a plugin in response to `<plugin> --info`. OfficeCLI uses it to identify plugin kind, supported extensions, protocol compatibility, target native format, idle-timeout budgets, diagnostics metadata, and format-handler vocabulary [@plugin-protocol] [@plugin-manifest]. Discovery and probe behavior are covered by [plugin discovery](plugin-discovery).
+
+## Protocol gate
+
+The supported plugin protocol major version is `1` [@plugin-registry]. The registry rejects any parsed manifest whose `protocol` value is not `1`, writes a warning to stderr, and treats the candidate as unresolved [@plugin-registry].
+
+## Kind values
+
+| Wire value | Runtime enum | Role |
+|---|---|---|
+| `dump-reader` | `PluginKind.DumpReader` | Reads a foreign format and emits OfficeCLI batch commands for a native target [@plugin-protocol] [@plugin-manifest] |
+| `exporter` | `PluginKind.Exporter` | Converts a native Office file to a foreign output file [@plugin-protocol] [@plugin-manifest] |
+| `format-handler` | `PluginKind.FormatHandler` | Owns a foreign file through a long-lived handler session [@plugin-protocol] [@plugin-manifest] |
+
+The parser accepts only these three wire strings as known plugin kinds [@plugin-manifest]. The protocol reserves `engine` and `transformer`, but v1 plugins must not declare them [@plugin-protocol].
+
+## Manifest fields
+
+| Field | Type | Required by protocol | Runtime behavior |
+|---|---|---:|---|
+| `name` | string | Yes | Stable plugin identifier stored as `Name` [@plugin-protocol] [@plugin-manifest] |
+| `version` | string | Yes | Plugin version string stored as `Version` [@plugin-protocol] [@plugin-manifest] |
+| `protocol` | integer | Yes | Must equal `1` to pass registry probing [@plugin-protocol] [@plugin-registry] |
+| `kinds` | string array | Yes | Must include the requested kind to match a lookup [@plugin-registry] |
+| `extensions` | string array | Yes | Entries include leading dots, and matching is case-insensitive after normalization [@plugin-protocol] [@plugin-registry] |
+| `idle_timeout_seconds` | object | Yes | Missing or invalid default produces a warning and runtime fallback to 60 seconds [@plugin-protocol] [@plugin-manifest] |
+| `runtime` | string | Yes | Diagnostic tag only; main does not branch on it [@plugin-protocol] [@plugin-manifest] |
+| `target` | string | Required for `dump-reader` | Must resolve to `docx`, `xlsx`, or `pptx`; omitted values default to `docx` in runtime resolution [@plugin-protocol] [@plugin-manifest] |
+| `vocabulary` | object | Required for `format-handler` | Missing vocabulary produces a warning; runtime handshake vocabulary can still be used [@plugin-protocol] [@plugin-manifest] |
+| `description` | string | No | Human-readable description [@plugin-protocol] [@plugin-manifest] |
+| `tier` | string | No | Free-form tier label [@plugin-protocol] [@plugin-manifest] |
+| `supports` | string array | No | Capability tags for diagnostics and listing [@plugin-protocol] [@plugin-manifest] |
+| `limits` | object | No | Plugin-defined limit metadata [@plugin-protocol] [@plugin-manifest] |
+| `homepage` | string | No | Plugin homepage URL [@plugin-protocol] [@plugin-manifest] |
+| `license` | string | No | License identifier [@plugin-protocol] [@plugin-manifest] |
+
+## Target format
+
+`target` names the native format produced by a `dump-reader`. Runtime resolution accepts only `docx`, `xlsx`, and `pptx` [@plugin-manifest]. If the field is omitted, `ResolveTargetFormat` falls back to `docx`; if it names any other format, runtime resolution throws an error naming the supported values [@plugin-manifest].
+
+## Idle timeout
+
+`idle_timeout_seconds` contains a mandatory positive `default` and optional positive per-verb overrides under `verbs` [@plugin-protocol]. `PluginIdleTimeout.For` uses the verb override when it is present and greater than zero, otherwise it uses the default, and finally a 60-second safe default if the manifest object is missing or invalid [@plugin-manifest].
+
+Users can override all manifest budgets with `OFFICECLI_PLUGIN_IDLE_TIMEOUT_SECONDS=<n>` [@plugin-protocol]. The runtime accepts `0` in this environment variable to disable the watchdog for the invocation, but `0` is not allowed inside the manifest itself [@plugin-protocol] [@plugin-manifest].
+
+## Format-handler vocabulary
+
+`vocabulary` has three fields: `addable_types`, `settable_props`, and `path_segments` [@plugin-protocol] [@plugin-manifest].
+
+| Field | Type | Meaning |
+|---|---|---|
+| `addable_types` | string array | Type names the plugin exposes for add operations [@plugin-protocol] |
+| `settable_props` | object mapping type to string array | Property names accepted for each type [@plugin-protocol] [@plugin-manifest] |
+| `path_segments` | string array | Document path patterns exposed by the plugin model [@plugin-protocol] [@plugin-manifest] |
+
+Manifest vocabulary is used for discovery and help output, while the format-handler open handshake returns a runtime vocabulary snapshot that the host trusts for the session [@plugin-protocol] [@plugin-manifest].
+
+## Warnings
+
+`PluginManifestExtensions.Warnings` reports soft problems without failing the manifest probe. It warns for missing or nonpositive idle-timeout defaults, empty `kinds`, unknown kind strings, unsupported explicit dump-reader targets, and missing format-handler vocabulary [@plugin-manifest].

--- a/almanac/reference/rich-object-helper-map.md
+++ b/almanac/reference/rich-object-helper-map.md
@@ -1,0 +1,63 @@
+---
+title: "Rich Object Helper Map"
+summary: "Lookup map for the shared chart, diagram, OLE, formula, and PowerPoint table-style helpers used by OfficeCLI handlers."
+topics: [reference, handlers]
+sources:
+  - id: chart-core
+    type: file
+    path: src/officecli/Core/Chart/
+  - id: diagram-core
+    type: file
+    path: src/officecli/Core/Diagram/
+  - id: ole-helper
+    type: file
+    path: src/officecli/Core/OleHelper.cs
+  - id: formula-core
+    type: file
+    path: src/officecli/Core/Formula/
+  - id: table-styles
+    type: file
+    path: src/officecli/Core/TableStyles/
+---
+
+The rich object helper map identifies the shared subsystems that handlers use for Office objects more complex than plain text, cells, slides, and paragraphs. Charts, diagrams, OLE objects, formulas, and PowerPoint table styles live under `Core` so Word, Excel, and PowerPoint behavior can share parsing, generation, rendering, and validation rules instead of duplicating them per handler [@chart-core] [@diagram-core] [@ole-helper] [@formula-core] [@table-styles]. For the architectural overview, see [rich object helpers](../architecture/handlers/rich-object-helpers).
+
+## Helper directories
+
+| Area | Primary path | Main responsibility |
+|---|---|---|
+| Charts | `src/officecli/Core/Chart/` | Build, read, set, render, style, and preset chart XML across host formats [@chart-core] |
+| Diagrams | `src/officecli/Core/Diagram/` | Parse Mermaid, lay out editable flowcharts and sequence diagrams, and optionally render Mermaid to PNG [@diagram-core] |
+| OLE | `src/officecli/Core/OleHelper.cs` | Detect ProgIDs, classify embedded payloads, create embedded parts, normalize OLE properties, and populate OLE document nodes [@ole-helper] |
+| Formulas | `src/officecli/Core/Formula/` | Convert LaTeX to OMML, evaluate Excel formulas, qualify modern functions, and guard formula recursion [@formula-core] |
+| Table styles | `src/officecli/Core/TableStyles/` | Resolve PowerPoint built-in table style GUIDs, aliases, theme colors, regions, borders, fills, and emphasis bands [@table-styles] |
+
+## Charts
+
+`ChartHelper` is the shared chart build, read, and set helper for PowerPoint, Excel, and Word handlers, and its methods operate on Open XML chart parts rather than a specific host document [@chart-core]. It recognizes chart kinds such as column, bar, line, pie, doughnut, area, scatter, bubble, radar, stock, combo, waterfall, funnel, treemap, sunburst, box-whisker, histogram, and pareto [@chart-core].
+
+`ChartExBuilder` handles Office 2016 extended chart types such as funnel, treemap, sunburst, box-whisker, histogram, and pareto [@chart-core]. `ChartSvgRenderer` extracts regular and extended chart information and renders chart previews using theme accent colors when available, falling back to Office default chart palette colors [@chart-core].
+
+## Diagrams
+
+`DiagramCompiler` is the shared entry point for `add --type diagram`; it sniffs the Mermaid header and dispatches to flowchart or sequence layout, while unsupported explicit diagram types are rejected with a clear error [@diagram-core]. `MermaidParser` handles a practical flowchart subset, including common node shapes, chained edges, edge labels, grouped endpoints, Unicode identifiers, and ignored style directives [@diagram-core].
+
+`MermaidImageRenderer` is the optional high-fidelity path. It tries `mmdc`, then a Chrome-family browser, caches Mermaid JavaScript under `~/.officecli/cache`, stamps source text with the `mermaid:` alt-text prefix, and leaves native editable synthesis as the fallback when no image backend works [@diagram-core].
+
+## OLE objects
+
+`OleHelper` maps source extensions to default ProgIDs such as `Word.Document.12`, `Excel.Sheet.12`, `PowerPoint.Show.12`, `AcroExch.Document`, `Visio.Drawing`, or `Package` [@ole-helper]. It classifies Office-family payloads as embedded package parts and arbitrary binaries as generic embedded object parts [@ole-helper].
+
+The same helper adds embedded parts to Word, Excel, PowerPoint, header, or footer host parts; handles self-embedding by writing a placeholder payload; decodes data URIs; validates ProgIDs; normalizes display values; creates placeholder icon images; wraps generic payloads as Ole10Native compound-file data; and unwraps Ole10Native payloads when reading [@ole-helper].
+
+## Formulas
+
+`FormulaParser` converts a LaTeX subset to Office Math Markup Language and includes a lenient parse path that records diagnostics and emits a valid placeholder instead of failing a whole batch [@formula-core]. It uses `DocumentLimits.MaxRecursionDepth` as the formula group-depth cap and collects unrecognized commands for warning output [@formula-core].
+
+`FormulaEvaluator` represents numeric, string, boolean, error, array, range, blank, and lambda results, and its session object memoizes formula-cell results, cross-sheet evaluators, sheet data, materialized ranges, row and column extents, and circular-reference tracking [@formula-core]. `ModernFunctionQualifier` prefixes modern Excel functions with `_xlfn.` or `_xlfn._xlws.`, detects dynamic-array formulas that need spill metadata, and can unqualify formulas for user-facing display [@formula-core].
+
+## Table styles
+
+`TableStyleRegistry` maps PowerPoint's 74 built-in table-style GUIDs to family and accent pairs, and also exposes CLI aliases such as `medium2`, `light1`, `dark2`, and `none` [@table-styles]. `TableStyleResolver` resolves a style, cell position, and theme color map into concrete fill, text color, border, and bold values [@table-styles].
+
+Table-style resolution uses region priority from lowest to highest: `wholeTbl`, banded columns, banded rows, first row, last row, first column, and last column [@table-styles]. The data model represents fills, border edges, table regions, table definitions, cell position flags, and resolved cell values [@table-styles].

--- a/almanac/reference/schema-crc.md
+++ b/almanac/reference/schema-crc.md
@@ -1,0 +1,30 @@
+---
+title: "Schema CRC"
+summary: "Lookup reference for the OfficeCLI schema CRC flag and the exact embedded help-schema bytes it fingerprints."
+topics: [reference, cli, schemas]
+sources:
+  - id: program
+    type: file
+    path: src/officecli/Program.cs
+  - id: schema-crc
+    type: file
+    path: src/officecli/Help/SchemaCrc.cs
+---
+
+Schema CRC is the eight-character lowercase hexadecimal CRC32 value printed by `officecli --output-schema-crc`. It fingerprints the embedded `schemas/help/**` resource tree by hashing each canonical resource name and the raw bytes of that resource in stable sorted order, so downstream automation can detect help-schema surface drift across binary upgrades [@program] [@schema-crc]. It is part of the help-schema contract described in [Help Schemas](../concepts/help-schemas) and loaded through [Help Schema Loader](../architecture/cli/help-schema-loader).
+
+## Command
+
+`--output-schema-crc` is handled in `Program.cs` before normal root command construction [@program]. When it is the only argument, the process prints `SchemaCrc.Compute()` and exits successfully [@program].
+
+## What Is Hashed
+
+`SchemaCrc.Compute()` scans the current assembly manifest resource names, normalizes each name by replacing backslashes with forward slashes and lowercasing it, and keeps only names that start with `schemas/help/` [@schema-crc]. It sorts those entries by canonical name, then feeds the canonical UTF-8 name followed by the resource's raw bytes into the CRC accumulator [@schema-crc].
+
+## Algorithm
+
+The implementation builds the standard reflected CRC32 table with polynomial `0xEDB88320`, starts from `0xFFFFFFFF`, appends bytes by table lookup, XORs the final value with `0xFFFFFFFF`, and formats the result as `x8` lowercase hexadecimal [@schema-crc]. Resource streams are read in chunks of 81,920 bytes [@schema-crc].
+
+## Stability Boundary
+
+The source comment defines the CRC as a fingerprint of the embedded help-schema tree only. It covers schema files and their canonical resource names, but it does not cover serialization behavior implemented in code, JSON field order produced by renderers, command parsing behavior, handlers, or wiki prose [@schema-crc].

--- a/almanac/reference/security-policy.md
+++ b/almanac/reference/security-policy.md
@@ -1,0 +1,58 @@
+---
+title: "Security Policy"
+summary: "Lookup reference for OfficeCLI vulnerability reporting and the repository's file-opening, resource-limit, and remote-fetch guards."
+topics: [reference, security]
+sources:
+  - id: security-policy
+    type: file
+    path: SECURITY.md
+  - id: handler-factory
+    type: file
+    path: src/officecli/Handlers/DocumentHandlerFactory.cs
+  - id: ssrf-guard
+    type: file
+    path: src/officecli/Core/SsrfGuard.cs
+  - id: document-limits
+    type: file
+    path: src/officecli/Core/DocumentLimits.cs
+---
+
+OfficeCLI's security policy combines private vulnerability reporting with runtime guards for untrusted Office files and caller-supplied remote URLs. The public policy asks reporters to use GitHub private vulnerability reporting, while the code centralizes file admission, decompression-bomb checks, recursion limits, regex timeouts, and SSRF protection in shared helpers [@security-policy] [@handler-factory] [@document-limits] [@ssrf-guard]. The opening path is part of the [document handler lifecycle](../architecture/handlers/document-handler-lifecycle), and plugin resolution is covered by the [plugin system](../architecture/plugins/plugin-system).
+
+## Reporting
+
+Security vulnerabilities should be reported privately through GitHub's "Security -> Report a vulnerability" flow, not as public issues [@security-policy]. Reports should include a description and impact, reproduction steps or a minimal sample file, the OfficeCLI version from `officecli --version`, and the reporter's operating system [@security-policy].
+
+Security fixes are applied to the latest released version, and reporters are asked to upgrade to the latest version before reporting [@security-policy].
+
+## File admission
+
+`DocumentHandlerFactory.Open` is the shared gate for document opening [@handler-factory]. It rejects empty paths with code `file_required`, missing paths with code `file_not_found`, and zero-byte files with code `corrupt_file` before handler construction [@handler-factory].
+
+For native `.docx`, `.xlsx`, and `.pptx` files, the factory checks the zip directory before the Open XML SDK opens the package [@handler-factory]. It rejects archives with more than `100000` entries, more than `2 GiB` total uncompressed data, or an overall compression ratio above `1000x` once compressed data exceeds 64 KiB [@handler-factory] [@document-limits].
+
+## Repair before open
+
+The factory repairs two producer defects centrally. It strips dangling internal package relationships before open when native packages contain relationships to missing parts, and it rewrites unsupported XML encoding declarations to UTF-8 before retrying [@handler-factory]. These repairs are applied before dispatch to native or plugin-backed handlers [@handler-factory].
+
+## Resource limits
+
+`DocumentLimits` is the shared source for denial-of-service limits [@document-limits].
+
+| Limit | Value | Guarded risk |
+|---|---:|---|
+| `MaxRecursionDepth` | `256` | Deep document trees or formulas exhausting process stack [@document-limits] |
+| `MaxUncompressedBytes` | `2 GiB` | OOXML zip decompression bombs [@document-limits] |
+| `MaxZipEntries` | `100000` | Archives with excessive entry counts [@document-limits] |
+| `MaxCompressionRatio` | `1000` | Highly compressed crafted archives [@document-limits] |
+| `RegexMatchTimeout` | `5 seconds` | Catastrophic backtracking in user-supplied regex patterns [@document-limits] |
+
+`EnsureDepth` throws a `CliException` with code `max_depth_exceeded` when depth exceeds the limit or the runtime stack probe reports insufficient remaining execution stack [@document-limits].
+
+## Remote fetch guard
+
+`SsrfGuard` is the shared HTTP/HTTPS protection for remote image and file sources [@ssrf-guard]. Its guarded handler validates the actual IP address in `ConnectCallback` for each connection, including redirect hops, so DNS rebinding between pre-resolution and connect is not accepted [@ssrf-guard].
+
+Only globally routable addresses are allowed. The guard blocks loopback, unspecified, private IPv4 ranges, link-local ranges including `169.254.0.0/16`, CGNAT, multicast or reserved IPv4, IPv6 link-local, site-local, multicast, and IPv6 unique-local `fc00::/7` addresses [@ssrf-guard].
+
+Remote response bodies are bounded by `SsrfGuard.MaxRemoteBytes`, which is `100 MB` [@ssrf-guard]. `ReadBounded` refuses reads that exceed that limit even when the server omits or lies about `Content-Length` [@ssrf-guard].

--- a/almanac/reference/selector-grammar-by-format.md
+++ b/almanac/reference/selector-grammar-by-format.md
@@ -1,0 +1,53 @@
+---
+title: "Selector Grammar By Format"
+summary: "Lookup reference comparing the Word, Excel, and PowerPoint selector grammars implemented by OfficeCLI handlers."
+topics: [reference, cli, selectors]
+sources:
+  - id: word-selector
+    type: file
+    path: src/officecli/Handlers/Word/WordHandler.Selector.cs
+  - id: excel-selector
+    type: file
+    path: src/officecli/Handlers/Excel/ExcelHandler.Selector.cs
+  - id: ppt-selector
+    type: file
+    path: src/officecli/Handlers/Pptx/PowerPointHandler.Selector.cs
+---
+
+OfficeCLI selectors are CSS-like filters, but each document format owns its own grammar in the handler. Word selectors focus on paragraphs, runs, inline Word structures, attributes, text containment, and one child combinator; Excel selectors focus on sheet-scoped cells, columns, values, formulas, emptiness, types, and cell formatting; PowerPoint selectors focus on slides, shapes, media, tables, charts, text containment, generic attributes, and explicit rejection of unsupported CSS combinators [@word-selector] [@excel-selector] [@ppt-selector]. Use this page with [Selectors Vs Slash Paths](../concepts/selectors-vs-slash-paths).
+
+## Summary Table
+
+| Format | Main subjects | Attribute operators | Pseudo-selectors | Scoping and combinators |
+| --- | --- | --- | --- | --- |
+| Word | `paragraph`/`p`, `run`/`r`, and special run payloads such as `ptab`, `fieldChar`, `instrText`, `tab`, `break`, `br`, and `pagebreak` [@word-selector]. | `[attr=value]`, `[@attr=value]`, and `[attr!=value]` after zsh escape cleanup [@word-selector]. | `:contains(...)`, `:empty`, and `:no-alt` are parsed [@word-selector]. | Supports one top-level `>` child split while ignoring `>` inside brackets [@word-selector]. |
+| Excel | Cell selectors, column selectors such as `B`, sheet-prefixed selectors, and path-style sheet selectors [@excel-selector]. | `[key=value]` and `[key!=value]` for value, type, formula, empty, and format keys [@excel-selector]. | `:contains(...)`, `cell:text` shorthand, `:empty`, `:not(:empty)`, `:has(formula)`, and `:not(:has(formula))` [@excel-selector]. | Accepts `Sheet1!cell[...]`, quoted sheet names, and `/Sheet1/cell[...]` normalization [@excel-selector]. |
+| PowerPoint | `shape`, `textbox`, `title`, `picture`/`pic`, `video`, `audio`, `equation`, `table`, `chart`, `placeholder`, `connector`, `group`, `notes`, `zoom`, `tr`, `row`, `tc`, and `cell` [@ppt-selector]. | `[attr=value]`, `[attr!=value]`, and `[attr~=value]` for generic attributes [@ppt-selector]. | `:contains(...)`, `shape:text` shorthand, and `:no-alt` [@ppt-selector]. | Accepts `slide[N]`, `slide > X`, `slide X`, and limited path-style slide prefixes; flags unsupported `+`, bare `~`, and most descendant whitespace forms [@ppt-selector]. |
+
+## Word
+
+Word parses the element name before any bracket or colon modifier, lowercases element names, and treats attribute values as case-sensitive at parse time but many comparisons are case-insensitive later [@word-selector]. Attribute names may start with `@`, which lets path-style forms such as `revision[@type=ins]` behave like `revision[type=ins]` [@word-selector].
+
+Paragraph selectors accept `p` and `paragraph`. Paragraph attributes include style keys, alignment, indentation, numbering keys, list style, direction aliases, `rtl`, and selected run-level checks from the first text-bearing run such as bold, italic, font, size, color, underline, strike, and highlight [@word-selector]. Run selectors accept `r` and `run`, plus special inline element names such as `ptab`, `positionaltab`, `fieldChar`, `fldChar`, `instrText`, `tab`, `break`, `br`, and `pagebreak` [@word-selector].
+
+The Word child combinator is one `>` split at top level. `paragraph[style=Heading1] > run[bold=true]` is parsed as a parent selector plus a child selector, while `>` inside brackets such as `[size>=14pt]` does not split the selector [@word-selector].
+
+## Excel
+
+Excel normalizes leading slash selectors before parsing. `/Sheet1/cell[...]` becomes sheet-scoped selector form, and `/cell` drops only the leading slash [@excel-selector]. It also accepts `Sheet1!cell[...]`, with top-level `!` detection that ignores exclamation marks inside brackets or quoted text and strips quotes from quoted sheet names [@excel-selector].
+
+Cell filters include equality and inequality for `value` and `type`, formula and empty flags, text containment, and column matching by a short all-letter element token that is not `row`, `cell`, or `col` [@excel-selector]. Value equality compares both display value and raw stored value, so formatted values can match either representation [@excel-selector].
+
+Format selectors accept canonical format keys and short aliases. The alias map resolves `bold` to `font.bold`, `italic` to `font.italic`, `font` to `font.name`, `size` to `font.size`, and `color` to `font.color`, while `underline` and `strike` stay as identity keys [@excel-selector]. Color comparisons normalize a leading `#`, so `#FF0000` and `FF0000` match [@excel-selector].
+
+## PowerPoint
+
+PowerPoint selector parsing first handles slide scope. `slide[2] shape`, `slide[2]>shape`, and `/slide[2]/shape` can resolve the slide number and subject element, and unindexed `slide > shape` or `slide shape` scopes the subject without a specific slide number [@ppt-selector]. The parser also strips a remaining ancestor prefix before the final subject so forms such as `slide > table > tr` resolve to `tr` [@ppt-selector].
+
+PowerPoint element names include shape-like objects, media, charts, tables, table rows and cells, notes, zooms, connectors, placeholders, and groups [@ppt-selector]. The `title` element sets the title filter, `textbox` excludes title shapes, and picture matching is limited to `picture`, `pic`, `video`, and `audio` subjects [@ppt-selector].
+
+Generic attributes support equality, inequality, and contains. A `~=` value beginning with `r"..."` or `r'...'` is treated as a regex if possible, with fallback to literal contains on malformed regex [@ppt-selector]. Name matching is aware of the `!!` morph prefix, and color comparisons normalize a leading `#` [@ppt-selector].
+
+## Unsupported PowerPoint Combinators
+
+PowerPoint has explicit scanners for unsupported combinators. A top-level `+` or bare `~` is detected as an unsupported sibling combinator, while `~=` inside an attribute is not treated as the sibling operator [@ppt-selector]. Top-level descendant whitespace is allowed only for slide-scoped forms; other whitespace between selector subjects is rejected as an unsupported descendant shape [@ppt-selector].

--- a/almanac/topics.yaml
+++ b/almanac/topics.yaml
@@ -1,0 +1,109 @@
+topics:
+  - slug: concepts
+    title: Concepts
+    description: Core vocabulary and mental models for this codebase.
+    parents: []
+  - slug: architecture
+    title: Architecture
+    description: System areas, runtime boundaries, and cross-file flows.
+    parents: []
+  - slug: guides
+    title: Guides
+    description: Task-focused procedures for maintainers and integrators.
+    parents: []
+  - slug: decisions
+    title: Decisions
+    description: Durable architectural choices and their consequences.
+    parents: []
+  - slug: reference
+    title: Reference
+    description: Exact lookup material for commands, schemas, fields, and contracts.
+    parents: []
+  - slug: cli
+    title: CLI
+    description: Command dispatch, command families, help, and public command contracts.
+    parents: [architecture]
+  - slug: batch
+    title: Batch
+    description: Batch item shape, replay behavior, and multi-command workflows.
+    parents: [cli]
+  - slug: runtime
+    title: Runtime
+    description: Long-lived process behavior, pipes, liveness, and runtime policy.
+    parents: [architecture]
+  - slug: resident
+    title: Resident
+    description: Per-file resident sessions, deferred flush, and resident pipe clients.
+    parents: [runtime]
+  - slug: mcp
+    title: MCP
+    description: Model Context Protocol integration and its single-tool command bridge.
+    parents: [runtime, agent]
+  - slug: agent
+    title: Agent Integration
+    description: Agent-facing skills, MCP, SDKs, and workflow guidance.
+    parents: [architecture]
+  - slug: skills
+    title: Skills
+    description: Bundled OfficeCLI skill catalog and lazy agent workflow guides.
+    parents: [agent]
+  - slug: sdk
+    title: SDK
+    description: Node and Python resident clients and SDK usage boundaries.
+    parents: [agent, resident]
+  - slug: handlers
+    title: Handlers
+    description: Word, Excel, PowerPoint, and shared document handler behavior.
+    parents: [architecture]
+  - slug: selectors
+    title: Selectors
+    description: Selector grammars and their relationship to slash paths.
+    parents: [handlers, cli]
+  - slug: rendering
+    title: Rendering
+    description: Preview, screenshot, and renderer behavior.
+    parents: [handlers]
+  - slug: preview
+    title: Preview
+    description: Live and static document preview workflows.
+    parents: [rendering]
+  - slug: watch
+    title: Watch
+    description: Live preview server, marks, goto, and update notifications.
+    parents: [preview]
+  - slug: charts
+    title: Charts
+    description: Shared rich-object chart helpers and chart rendering.
+    parents: [handlers]
+  - slug: schemas
+    title: Schemas
+    description: Embedded help schemas, schema rendering, and schema fingerprints.
+    parents: [cli]
+  - slug: plugins
+    title: Plugins
+    description: Plugin protocol, discovery, manifests, and sidecar process flows.
+    parents: [architecture]
+  - slug: build
+    title: Build
+    description: Self-contained binary construction and embedded resources.
+    parents: [architecture]
+  - slug: install
+    title: Install
+    description: Installer behavior, platform detection, and installation surfaces.
+    parents: [build]
+  - slug: release
+    title: Release
+    description: Release assets, checksums, signing, and package publishing.
+    parents: [build]
+  - slug: examples
+    title: Examples
+    description: Example corpus and generated Office document demonstrations.
+    parents: [guides]
+  - slug: security
+    title: Security
+    description: Vulnerability reporting and runtime safety guards.
+    parents: [reference]
+  - slug: wiki
+    title: Wiki
+    description: CodeAlmanac build metadata and local wiki maintenance.
+    parents: [reference]


### PR DESCRIPTION
## What changed

- Adds a repo-local `almanac/` wiki with 50 source-grounded content pages.
- Covers the command model, document handlers, rendering and watch flows, batch and resident execution, MCP and skills, plugins, schemas, SDKs, install/release behavior, security, and contributor workflows.
- Includes a frozen coverage map, getting-started router, and topic taxonomy.

## Why

OfficeCLI spans multiple Office formats, execution modes, integrations, and distribution paths. This wiki gives contributors and coding agents a navigable map of the current architecture, durable decisions, operational gotchas, and source evidence.

## Preview the wiki locally

Install CodeAlmanac:

```bash
curl -fsSL https://codealmanac.com/install.sh | sh
```

Then, from a checkout of this PR:

```bash
cd OfficeCLI
codealmanac serve
```

The wiki is already included in this PR, so `codealmanac init` is not needed.

## Automate ongoing maintenance (optional)

For maintenance automation setup, see the [CodeAlmanac repository](https://github.com/AlmanacCode/codealmanac).

## Impact

Documentation only. No runtime, build, package, or generated product artifacts are changed.

## Validation

- `codealmanac validate`
- `codealmanac health` (zero orphans, broken links, dead references, citation issues, or empty pages/topics)
- Coverage map parity check: all 50 planned content pages exist
- `git diff upstream/main...HEAD --check`
