### PR TITLE
Add token-count badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Open-source. Single binary. No Office installation. No dependencies. Works every
 
 [![GitHub Release](https://img.shields.io/github/v/release/iOfficeAI/OfficeCLI)](https://github.com/iOfficeAI/OfficeCLI/releases)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+![tokens](https://img.shields.io/endpoint?url=https://gittokens.rsamf.com/badge/iOfficeAI/OfficeCLI)
 
 **English** | [中文](README_zh.md) | [日本語](README_ja.md) | [한국어](README_ko.md)
 


### PR DESCRIPTION
Hi! This PR adds one line to the README: a badge showing an estimate of how many LLM tokens this repo weighs. Since this project is the kind of thing people load into an LLM's context window, the number seemed genuinely useful to surface.

Preview: ![tokens](https://img.shields.io/endpoint?url=https://gittokens.rsamf.com/badge/iOfficeAI/OfficeCLI)

Full disclosure: I built the free, open-source service behind the badge (https://github.com/rsamf/gittokens), and I'm proposing it to a small, hand-picked set of repos where it seems like a good fit. If it isn't a fit here, please just close this, and I won't resubmit.