### PR TITLE
修复 Windows 下 resident 进程继承管道句柄导致的挂起（#207）

### DIFF
--- a/src/officecli/CommandBuilder.cs
+++ b/src/officecli/CommandBuilder.cs
@@ -116,13 +116,19 @@ static partial class CommandBuilder
 
         // ==================== __resident-serve__ (internal, hidden) ====================
         var serveFileArg = new Argument<FileInfo>("file") { Description = "Office document path (required even with open/close mode)" };
+        var serveIdleOption = new Option<int?>("--idle-seconds")
+        {
+            Description = "Initial idle timeout in seconds (1..86400)"
+        };
         var serveCommand = new Command("__resident-serve__", "Internal: run resident server (do not call directly)");
         serveCommand.Hidden = true;
         serveCommand.Add(serveFileArg);
+        serveCommand.Add(serveIdleOption);
 
         serveCommand.SetAction(result =>
         {
             var file = result.GetValue(serveFileArg)!;
+            var idleSeconds = result.GetValue(serveIdleOption);
             // Per-file singleton guard. TryResident's probe-then-spawn has an
             // inherent race: N clients probing an un-owned file concurrently
             // all fail the ping and all spawn a resident. Each spawned server
@@ -156,7 +162,10 @@ static partial class CommandBuilder
             }
             if (residentLock == null) return;
             using var heldLock = residentLock;
-            using var server = new ResidentServer(file.FullName);
+            TimeSpan? initialIdle = idleSeconds.HasValue
+                ? TimeSpan.FromSeconds(idleSeconds.Value)
+                : null;
+            using var server = new ResidentServer(file.FullName, initialIdleTimeout: initialIdle);
             server.RunAsync().GetAwaiter().GetResult();
         });
 
@@ -210,9 +219,9 @@ static partial class CommandBuilder
     // pipe to respond, so callers get a definitive success/fail answer.
     //
     // `idleSeconds` overrides the child's idle-exit timeout via the
-    // OFFICECLI_RESIDENT_IDLE_SECONDS env var (1..86400). Passing null
-    // inherits the server default (12 minutes). `create` passes 60 so
-    // an auto-started resident that nobody follows up on exits quickly.
+    // --idle-seconds command-line option (1..86400). Passing null inherits
+    // the server default (12 minutes). `create` passes 60 so an auto-started
+    // resident that nobody follows up on exits quickly.
     //
     // Caller must first verify no resident is already running for this
     // file (e.g. via ResidentClient.TryConnect) — this helper always
@@ -227,66 +236,76 @@ static partial class CommandBuilder
             return false;
         }
 
-        // On Windows, .NET's UseShellExecute=false always calls CreateProcess
-        // with bInheritHandles=TRUE (even without explicit redirects), which
-        // leaks the caller's pipe handles into the resident child.  When the
-        // caller's stdout is a pipe ($(), | cat, CI, SDK), the pipe never
-        // gets EOF until the resident exits (~60s idle), blocking the caller.
+        bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        // On Windows, .NET's UseShellExecute=false calls CreateProcess with
+        // bInheritHandles=TRUE, leaking the caller's pipe handles into the
+        // resident child. When the caller's stdout is a pipe ($(), | cat,
+        // CI, SDK), the pipe never gets EOF until the resident exits (~60s
+        // idle), blocking the caller.
         //
-        // Fix: temporarily mark our own std handles as non-inheritable before
-        // spawning, then restore.  This prevents the shell's pipe handles
-        // from leaking into the resident while still allowing .NET's internal
-        // handle plumbing to work.
+        // Fix: on Windows use UseShellExecute=true, which routes through the
+        // shell and does NOT inherit handles. Trade-offs:
+        //   - RedirectStandardOutput/Error cannot be used, so the parent cannot
+        //     read the child's stderr directly. Startup errors are still surfaced
+        //     via the process exit code and are logged to the optional CLI log.
+        //   - ProcessStartInfo.Environment cannot be used, so the idle timeout
+        //     is passed via the --idle-seconds command-line argument.
+        //   - In restricted/sandboxed environments where shell execution is
+        //     blocked, TryStartResidentProcess fails with an actionable error
+        //     that tells the user to set OFFICECLI_NO_AUTO_RESIDENT=1 or start
+        //     the resident manually via __resident-serve__.
         //
         // On macOS/Linux, posix_spawn inherits fds unless the child's
-        // stdout/stderr are explicitly redirected.  RedirectStandardOutput /
+        // stdout/stderr are explicitly redirected. RedirectStandardOutput /
         // RedirectStandardError = true makes .NET plumb a fresh pipe from
-        // parent to child, so the caller's shell pipe (e.g. `| tail -1`,
-        // $(...)) is NOT inherited and EOFs promptly when the client exits.
-        // See ResidentStdoutInheritanceTests for the regression lock-in.
-        // CONSISTENCY(child-process-args): forward verb + path via ArgumentList,
-        // not a hand-quoted Arguments string. .NET re-parses the Arguments
-        // string with Windows-style quoting rules even on Unix, so a filePath
-        // containing a literal '"' (legal on macOS/Linux) or a trailing '\'
-        // would split into stray argv and the resident would reject startup.
-        // ArgumentList passes argv losslessly. Matches BlankDocCreator /
-        // FormatHandlerSession, which fork this same exe the same way.
+        // parent to child, so the caller's shell pipe is NOT inherited and
+        // EOFs promptly when the client exits. See
+        // ResidentStdoutInheritanceTests for the regression lock-in.
         var startInfo = new ProcessStartInfo
         {
             FileName = exePath,
-            ArgumentList = { "__resident-serve__", filePath },
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true
+            UseShellExecute = isWindows,
+            CreateNoWindow = true
         };
 
-        if (idleSeconds.HasValue)
-            startInfo.Environment["OFFICECLI_RESIDENT_IDLE_SECONDS"] = idleSeconds.Value.ToString();
-
-        // Prevent the shell's pipe handles from leaking into the resident.
-        bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-        nint hStdOut = 0, hStdErr = 0, hStdIn = 0;
         if (isWindows)
         {
-            hStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
-            hStdErr = GetStdHandle(STD_ERROR_HANDLE);
-            hStdIn  = GetStdHandle(STD_INPUT_HANDLE);
-            SetHandleInformation(hStdOut, HANDLE_FLAG_INHERIT, 0);
-            SetHandleInformation(hStdErr, HANDLE_FLAG_INHERIT, 0);
-            SetHandleInformation(hStdIn,  HANDLE_FLAG_INHERIT, 0);
+            // Windows: UseShellExecute=true requires a hand-quoted Arguments
+            // string. Quote the file path safely; literal '"' and trailing
+            // '\' are legal on NTFS and must be escaped per CommandLineToArgvW.
+            var args = new List<string> { "__resident-serve__", filePath };
+            if (idleSeconds.HasValue)
+            {
+                args.Add("--idle-seconds");
+                args.Add(idleSeconds.Value.ToString());
+            }
+            startInfo.Arguments = string.Join(" ", args.Select(EscapeWindowsArgument));
+        }
+        else
+        {
+            // Unix: UseShellExecute=false with ArgumentList gives lossless argv.
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
+            startInfo.ArgumentList.Add("__resident-serve__");
+            startInfo.ArgumentList.Add(filePath);
+            if (idleSeconds.HasValue)
+            {
+                startInfo.ArgumentList.Add("--idle-seconds");
+                startInfo.ArgumentList.Add(idleSeconds.Value.ToString());
+            }
         }
 
         Process? process;
         try { process = Process.Start(startInfo); }
-        finally
+        catch (Exception ex)
         {
-            if (isWindows)
-            {
-                SetHandleInformation(hStdOut, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
-                SetHandleInformation(hStdErr, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
-                SetHandleInformation(hStdIn,  HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
-            }
+            // Surface a concise, actionable message to the user while preserving
+            // the full exception in the optional CLI log for diagnostics in
+            // restricted / sandboxed environments where UseShellExecute may fail.
+            CliLogger.LogError($"TryStartResidentProcess failed: {ex}");
+            error = $"Failed to start resident process: {ex.Message}. Auto-start via shell failed — you can disable auto-resident with OFFICECLI_NO_AUTO_RESIDENT=1 or start the resident manually: officecli __resident-serve__ <file> --idle-seconds N.";
+            return false;
         }
 
         if (process == null)
@@ -306,12 +325,14 @@ static partial class CommandBuilder
             }
             if (process.HasExited)
             {
-                var stderr = process.StandardError.ReadToEnd();
+                var stderr = startInfo.RedirectStandardError
+                    ? process.StandardError.ReadToEnd()
+                    : "";
                 // CONSISTENCY(cli-error-first-line): the resident process dumps its
                 // full call stack on a startup crash; surface only the first line
                 // (typically the exception message). The stack is still in the
-                // resident's own log if needed for diagnostics — keeping it out
-                // of the user-facing CLI error avoids burying the actual cause.
+                // resident's own log if needed for diagnostics — keeping it out of
+                // the user-facing CLI error avoids burying the actual cause.
                 var firstLine = string.IsNullOrEmpty(stderr)
                     ? ""
                     : stderr.Split('\n', 2)[0].TrimEnd('\r').Trim();
@@ -328,19 +349,54 @@ static partial class CommandBuilder
         return false;
     }
 
-    // ==================== Win32 P/Invoke for handle inheritance control ==========
+    /// <summary>
+    /// Escapes a single argv token for the Windows command line so that
+    /// CommandLineToArgvW round-trips it exactly. Handles spaces, quotes and
+    /// trailing backslashes.
+    /// </summary>
+    private static string EscapeWindowsArgument(string arg)
+    {
+        if (string.IsNullOrEmpty(arg)) return "\"\"";
 
-    private const int STD_INPUT_HANDLE  = -10;
-    private const int STD_OUTPUT_HANDLE = -11;
-    private const int STD_ERROR_HANDLE  = -12;
-    private const uint HANDLE_FLAG_INHERIT = 0x00000001;
+        bool needsQuotes = false;
+        foreach (char c in arg)
+        {
+            if (c == ' ' || c == '\t' || c == '"')
+            {
+                needsQuotes = true;
+                break;
+            }
+        }
+        if (!needsQuotes) return arg;
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern nint GetStdHandle(int nStdHandle);
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetHandleInformation(nint hObject, uint dwMask, uint dwFlags);
+        var sb = new StringBuilder();
+        sb.Append('"');
+        int backslashCount = 0;
+        foreach (char c in arg)
+        {
+            if (c == '\\')
+            {
+                backslashCount++;
+            }
+            else if (c == '"')
+            {
+                // Backslashes preceding a quote are doubled, then add the escape.
+                sb.Append('\\', backslashCount * 2 + 1);
+                sb.Append('"');
+                backslashCount = 0;
+            }
+            else
+            {
+                sb.Append('\\', backslashCount);
+                sb.Append(c);
+                backslashCount = 0;
+            }
+        }
+        // Backslashes at the very end are doubled before the closing quote.
+        sb.Append('\\', backslashCount * 2);
+        sb.Append('"');
+        return sb.ToString();
+    }
 
     // ==================== Helper: try forwarding to resident ====================
     //

--- a/src/officecli/ResidentServer.cs
+++ b/src/officecli/ResidentServer.cs
@@ -92,18 +92,29 @@ public class ResidentServer : IDisposable
     private const int MaxIdleSeconds = 86400;
     private static readonly TimeSpan DefaultIdleTimeout = TimeSpan.FromMinutes(12);
 
-    // Initial idle timeout: env var (OFFICECLI_RESIDENT_IDLE_SECONDS) takes
-    // precedence, tests/CI use this to exercise short timeouts in seconds.
+    // Initial idle timeout resolution order:
+    //   1. explicit override from __resident-serve__ --idle-seconds (used on
+    //      Windows where env vars can't be passed to a UseShellExecute=true
+    //      child),
+    //   2. OFFICECLI_RESIDENT_IDLE_SECONDS env var for tests/CI,
+    //   3. the 12-minute default.
     // Future "open file → auto-start resident" UX can tune how aggressively
-    // the background process exits by starting the child with this env var.
-    private static TimeSpan ResolveIdleTimeout()
+    // the background process exits by starting the child with this value.
+    private static TimeSpan ResolveIdleTimeout(TimeSpan? explicitOverride = null)
     {
+        if (explicitOverride.HasValue)
+        {
+            var explicitSecs = (int)explicitOverride.Value.TotalSeconds;
+            if (explicitSecs >= MinIdleSeconds && explicitSecs <= MaxIdleSeconds)
+                return TimeSpan.FromSeconds(explicitSecs);
+        }
+
         var raw = Environment.GetEnvironmentVariable("OFFICECLI_RESIDENT_IDLE_SECONDS");
         if (!string.IsNullOrWhiteSpace(raw)
-            && int.TryParse(raw, out var secs)
-            && secs >= MinIdleSeconds && secs <= MaxIdleSeconds)
+            && int.TryParse(raw, out var envSecs)
+            && envSecs >= MinIdleSeconds && envSecs <= MaxIdleSeconds)
         {
-            return TimeSpan.FromSeconds(secs);
+            return TimeSpan.FromSeconds(envSecs);
         }
         return DefaultIdleTimeout;
     }
@@ -210,11 +221,12 @@ public class ResidentServer : IDisposable
     // PromoteToEditable(); the promotion is sticky for the resident's
     // lifetime, matching the pre-existing reopen pattern used by
     // view-screenshot/page-count/refresh.
-    public ResidentServer(string filePath, bool editable = false)
+    public ResidentServer(string filePath, bool editable = false, TimeSpan? initialIdleTimeout = null)
     {
         _filePath = Path.GetFullPath(filePath);
         _pipeName = GetPipeName(_filePath);
         _editable = editable;
+        _idleTimeoutTicks = ResolveIdleTimeout(initialIdleTimeout).Ticks;
 
         // Capture Console.Error during handler open so any warnings emitted
         // by the dump-reader / format-handler open path (which run before


### PR DESCRIPTION
## 摘要

修复 #207。

在 Windows 上，当使用 `UseShellExecute=false` 启动自动 resident 子进程时，子进程会继承调用方的 stdout/stderr 管道句柄。当通过 PowerShell（或任何将 stdout 重定向为管道的 shell，例如 CI agent / SDK 包装器）调用 officecli 时，管道会一直保持打开状态，直到 resident 的空闲超时到期（约 60 秒），因此每条命令看起来都会卡住一分钟，即使实际工作早已完成。

## 根因

.NET 的 `ProcessStartInfo` 在 `UseShellExecute=false` 时会调用 Win32 `CreateProcess` 并传入 `bInheritHandles=TRUE`，导致 resident 子进程继承父进程的控制台/管道句柄。之前尝试的 `SetHandleInformation` 方案只能标记父进程自身句柄表的继承标志，但运行时仍会为子进程创建可继承的句柄副本，因此调用方的 stdout 管道仍然保持打开。

## 修复方案

- **Windows**：使用 `UseShellExecute=true` 启动 resident，通过 shell 启动不会继承句柄。由于 `UseShellExecute=true` 时不能使用 `ProcessStartInfo.Environment`，空闲超时改为通过命令行参数 `--idle-seconds` 传递。
- **macOS/Linux**：保持现有行为（`UseShellExecute=false` + `RedirectStandardOutput/Error=true`），该方案已经能阻止调用方管道被继承。
- 新增 `EscapeWindowsArgument` 辅助函数，确保带空格、引号或尾部反斜杠的文件路径能被 `CommandLineToArgvW` 正确解析。
- `ResidentServer` 构造函数新增可选的 `initialIdleTimeout` 参数，隐藏命令 `__resident-serve__` 新增 `--idle-seconds` 选项。环境变量 `OFFICECLI_RESIDENT_IDLE_SECONDS` 仍作为测试/CI 的后备方案被保留。
- Windows 启动失败时的错误提示增加可操作的建议，引导用户使用 `OFFICECLI_NO_AUTO_RESIDENT=1` 回退或手动启动 resident；同时将完整异常写入可选的 CLI 日志（`officecli config log true`）以便运维诊断。

## 改动文件

- `src/officecli/CommandBuilder.cs`
- `src/officecli/ResidentServer.cs`

## 审计结果

在仓库中搜索了 `ProcessStartInfo.Environment`、`RedirectStandardOutput/RedirectStandardError`、`Process.StandardError/Output`、`OFFICECLI_RESIDENT_IDLE_SECONDS`、`new ResidentServer` 等关键字，确认主要影响范围如下：

- `ProcessStartInfo.Environment` 的写入点仅在 `CommandBuilder.TryStartResidentProcess` 中；PR 已将该处对 `OFFICECLI_RESIDENT_IDLE_SECONDS` 的注入改为命令行参数传递。
- `Process.StandardError.ReadToEnd()` 的读取已在 PR 中改为仅在 `startInfo.RedirectStandardError` 为 true 时才执行，避免 `UseShellExecute=true` 下抛异常。未发现仓库中其它依赖子进程 stdout/stderr 的代码路径。
- `ResidentServer` 仍从 `OFFICECLI_RESIDENT_IDLE_SECONDS` 环境变量读取作为后备；其它日志/刷新相关变量未受此次更改破坏。

## 空闲超时优先级

`ResidentServer.ResolveIdleTimeout` 的解析顺序已在代码注释中明确：

1. `__resident-serve__ --idle-seconds` 命令行参数（Windows 生产路径）
2. `OFFICECLI_RESIDENT_IDLE_SECONDS` 环境变量（测试/CI 后备）
3. 默认值 12 分钟

## 验证

所有测试均在 Windows 11 上针对从源码构建的 `officecli.exe` 执行。

### 复现

修复前，以下每条命令都会因为 PowerShell 等待被继承的管道关闭而耗时约 62 秒：

```powershell
officecli view "minimal.pptx" outline
officecli get "minimal.pptx" "/slide[1]"
officecli view "minimal.xlsx" outline
officecli get "minimal.xlsx" "/Sheet1/A1"
officecli query "minimal.xlsx" cell
```

修复后，每条自动 resident 命令均在约 1 秒内完成：

| 测试 | 模式 | 结果 | 耗时 |
|---|---|---|---|
| PPTX view | auto-resident | OK | 1.1 s |
| PPTX view | no resident | OK | 0.5 s |
| XLSX view | auto-resident | OK | 1.0 s |
| XLSX view | no resident | OK | 0.5 s |
| PPTX get /slide[1] | auto-resident | OK | 1.2 s |
| XLSX get /Sheet1/A1 | auto-resident | OK | 1.0 s |
| XLSX query cells | auto-resident | OK | 1.1 s |

### 边界测试

针对 `EscapeWindowsArgument` 和 Windows 启动路径进行了额外验证：

- 相对路径 PPTX view（auto-resident）：约 1.5 s 完成
- 带空格路径 PPTX view（auto-resident）：约 1.5 s 完成
- 带单引号路径 PPTX view（auto-resident）：约 1.6 s 完成
- 直接启动 `__resident-serve__` 并设置 `OFFICECLI_RESIDENT_IDLE_SECONDS=3`：命令正常，resident 3.0 s 后退出
- 直接启动 `__resident-serve__` 并传入 `--idle-seconds 3`：命令正常，resident 3.0 s 后退出

这些测试覆盖了 `EscapeWindowsArgument` 对空格、单引号等常见特殊字符的处理；对于尾部反斜杠、内嵌双引号、制表符、极长路径、特殊 Unicode 等更复杂的 Windows 路径场景，建议后续在 CI 中补充 round-trip 测试（构造命令行 -> `CommandLineToArgvW` 解析 -> 验证与原 args 一致）。

### 启动失败回退提示

Windows 启动失败时的错误信息现在包含：

```
Auto-start via shell failed — you can disable auto-resident with OFFICECLI_NO_AUTO_RESIDENT=1
or start the resident manually: officecli __resident-serve__ <file> --idle-seconds N.
```

完整异常会同时写入 CLI 日志（启用后），便于在受限/沙箱环境中定位问题。

### 构建

```powershell
dotnet build src\officecli\officecli.csproj -c Release
```

构建成功，0 错误（1 个与本次改动无关的预先存在的空引用警告）。

## 已知限制与后续建议（非阻塞）

- **受限/沙箱环境**：当前方案在 `UseShellExecute=true` 被阻止时会给用户明确回退提示并记录日志，但不会自动回退到旧方案。若后续收到相关反馈，可考虑增加更智能的回退策略。
- **Windows 子进程 stderr**：Windows 分支不重定向 child stderr，父进程无法直接读取。启动阶段的完整异常已通过 `CliLogger.LogError` 写入可选日志文件作为替代诊断通道。
- **自动化 round-trip 测试**：由于本仓库目前没有测试项目（`tests/` 目录不存在），本次 PR 未包含自动化测试。强烈建议维护者在建立测试基础设施后，尽快为 `EscapeWindowsArgument` 添加 `CommandLineToArgvW` round-trip 测试，覆盖空串、空格、制表符、内嵌引号、尾部多重反斜杠、极长路径、非 BMP Unicode 等边界。
