### PR TITLE
fix: dispose backing FileStream on ExcelHandler/PowerPointHandler constructor failure

### DIFF
--- a/src/officecli/Handlers/ExcelHandler.cs
+++ b/src/officecli/Handlers/ExcelHandler.cs
@@ -96,10 +96,17 @@ public partial class ExcelHandler : IDocumentHandler, Rendering.IRenderModelHost
                     .Where(n => !string.IsNullOrEmpty(n)) ?? Enumerable.Empty<string>(),
                 StringComparer.OrdinalIgnoreCase);
         }
-        catch (DocumentFormat.OpenXml.Packaging.OpenXmlPackageException ex)
+        catch
         {
-            throw new InvalidOperationException(
-                $"Cannot open {Path.GetFileName(filePath)}: {ex.Message}", ex);
+            // A failed open must not leak the backing FileStream — the
+            // factory's repair-and-retry paths (FixXmlEncoding /
+            // StripDanglingPackageRels) reopen the file for in-place fixes
+            // and would hit "file is being used by another process".
+            // Matches the cleanup pattern in WordHandler's constructor.
+            _doc?.Dispose();
+            _filteredPackageStream?.Dispose();
+            _backingStream?.Dispose();
+            throw;
         }
     }
 

--- a/src/officecli/Handlers/PowerPointHandler.cs
+++ b/src/officecli/Handlers/PowerPointHandler.cs
@@ -115,9 +115,23 @@ public partial class PowerPointHandler : IDocumentHandler, Rendering.IRenderMode
         var share = editable ? FileShare.Read : FileShare.ReadWrite;
         var access = editable ? FileAccess.ReadWrite : FileAccess.Read;
         _backingStream = new FileStream(filePath, FileMode.Open, access, share);
-        _doc = PresentationDocument.Open(_backingStream, editable);
-        if (editable)
-            InitShapeIdCounter();
+        try
+        {
+            _doc = PresentationDocument.Open(_backingStream, editable);
+            if (editable)
+                InitShapeIdCounter();
+        }
+        catch
+        {
+            // A failed open must not leak the backing FileStream — the
+            // factory's repair-and-retry paths (FixXmlEncoding /
+            // StripDanglingPackageRels) reopen the file for in-place fixes
+            // and would hit "file is being used by another process".
+            // Matches the cleanup pattern in WordHandler's constructor.
+            _doc?.Dispose();
+            _backingStream?.Dispose();
+            throw;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- `ExcelHandler` constructor only catches `OpenXmlPackageException`; other failures (`IOException`, `UnauthorizedAccessException`) leave `_backingStream` undisposed
- `PowerPointHandler` constructor has no try/catch — any failure from `PresentationDocument.Open` leaks the FileStream
- `WordHandler` already has the correct pattern: try/catch that disposes both `_doc` and `_backingStream` on failure

## Root cause

When opening a corrupted or locked Office file, the SDK's `Open` method may throw exceptions beyond `OpenXmlPackageException`. The factory's repair-and-retry paths (`FixXmlEncoding` / `StripDanglingPackageRels`) reopen the file for in-place fixes — but the leaked FileStream from the first attempt causes "file is being used by another process".

## Fix

Apply the same cleanup pattern as `WordHandler` (line 342-350):

- **ExcelHandler**: catch-all block disposes `_doc`, `_filteredPackageStream`, and `_backingStream`
- **PowerPointHandler**: wrap `PresentationDocument.Open` + `InitShapeIdCounter` in try/catch; dispose `_doc` and `_backingStream`

Both handlers now use catch-all (matching WordHandler) so the original exception propagates directly — the factory's `IsEncodingException` / `IsDanglingPartException` checks walk the exception chain and continue to work correctly.

## Verification

```bash
# 1. Create a truncated xlsx file
python -c "open('broken.xlsx','wb').write(b'PK\x03\x04broken')"

# 2. Run command — should get clean error, no leaked handle
officecli get broken.xlsx / --json
# Before fix: file handle leaked, subsequent ops may fail with "file is being used"
# After fix: clean error reported, file handle released

# 3. Verify no lingering handle (Linux)
lsof | grep broken.xlsx  # should produce no output

# 4. Verify normal files are unaffected
officecli create test.xlsx
officecli add test.xlsx /Sheet1 cell --prop value=hello
officecli get test.xlsx /Sheet1/A1
```

## Testing

- [x] Verified on Windows 11 — corrupted file reports error cleanly, no handle leak
- [x] Verified normal xlsx/pptx open/edit/save cycle unaffected
- [x] Verified factory retry paths (encoding fix, dangling rel strip) still work
- [ ] Linux/macOS — maintainer may wish to verify

## Breaking Changes

None. The exception propagation path changes slightly (original exception rethrown directly instead of wrapped in `InvalidOperationException`), but the factory's catch chain handles both forms correctly. End users see the same `corrupt_file` CLI error.

## Notes

- Changes follow the existing `WordHandler` pattern exactly (~27 lines across 2 files)
- No test project exists in the repo — CONTRIBUTING.md states tests are handled by maintainer post-merge
