### PR TITLE
fix: reject negative --index in ExcelHandler.Add and PowerPointHandler.Add

### DIFF
--- a/src/officecli/Handlers/Excel/ExcelHandler.Add.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Add.cs
@@ -20,6 +20,14 @@ public partial class ExcelHandler
     {
         Modified = true;
         var index = position?.Index;
+
+        // Reject negative --index up front with a clean message instead of
+        // letting it fall through and surface as a raw .NET
+        // ArgumentOutOfRangeException from collection indexing. Matches
+        // the guard in WordHandler.Add.
+        if (index.HasValue && index.Value < 0)
+            throw new ArgumentException("--index must be non-negative.");
+
         // Normalize to case-insensitive lookup so camelCase keys (e.g. minColor) match lowercase lookups.
         // Preserve TrackingPropertyDictionary so handler-as-truth read
         // tracking survives — its comparer wraps OrdinalIgnoreCase already.

--- a/src/officecli/Handlers/Pptx/PowerPointHandler.Add.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.Add.cs
@@ -38,6 +38,13 @@ public partial class PowerPointHandler
         parentPath = ResolveIdPath(parentPath);
         parentPath = ResolveLastPredicates(parentPath);
 
+        // Reject negative --index up front with a clean message instead of
+        // letting it fall through and surface as a raw .NET
+        // ArgumentOutOfRangeException from collection indexing. Matches
+        // the guard in WordHandler.Add.
+        if (position?.Index.HasValue == true && position.Index.Value < 0)
+            throw new ArgumentException("--index must be non-negative.");
+
         // Resolve --after/--before to index (handles find: prefix)
         var index = ResolveAnchorPosition(parentPath, position);
 


### PR DESCRIPTION
## Summary

Add negative `--index` validation to `ExcelHandler.Add` and `PowerPointHandler.Add`, matching the existing guard in `WordHandler.Add` (line 49-54).

## Problem

`WordHandler.Add` rejects negative `--index` values with a clean `"--index must be non-negative."` error. `ExcelHandler.Add` and `PowerPointHandler.Add` lack this guard — a negative index propagates into collection indexing and surfaces as a raw .NET `ArgumentOutOfRangeException`.

## Fix

Add the same early validation check at the top of each handler's `Add` method, before the index is used for any collection operation.

## Affected paths

This guard covers all three entry points that call `handler.Add`:
- CLI non-resident: `CommandBuilder.Add.cs`
- Resident/MCP: `ResidentServer.ExecuteAdd`
- Batch: `CommandBuilder.ExecuteBatchItem`

## Verification

```bash
# 1. Excel — should get clean error
officecli create test.xlsx
officecli add test.xlsx /Sheet1 row --index -1
# Before: raw ArgumentOutOfRangeException
# After: "--index must be non-negative." error, exit 1

# 2. PowerPoint — same behavior
officecli create test.pptx
officecli add test.pptx / slide --index -1

# 3. Verify normal (non-negative) index still works
officecli add test.xlsx /Sheet1 row --index 0
# Should succeed
```

## Testing

- [x] Verified negative index rejected for xlsx
- [x] Verified negative index rejected for pptx
- [x] Verified non-negative index works normally
- [x] Verified batch path also enforces the guard (via `ExecuteBatchItem` → `handler.Add`)

## Breaking Changes

None. Only invalid inputs (negative `--index`) now get a clean error instead of undefined behavior. Valid inputs are unaffected.

## Notes

- Minimal change: +15 lines across 2 files
- Pattern copied verbatim from `WordHandler.Add.cs` line 49-54
