### PR TITLE
fix(xlsx): round MROUND midpoints away from zero

### DIFF
--- a/src/officecli/Core/Formula/FormulaEvaluator.Functions.cs
+++ b/src/officecli/Core/Formula/FormulaEvaluator.Functions.cs
@@ -60,7 +60,7 @@ internal partial class FormulaEvaluator
             "ODD" => FR(OddF(num(0))),
             "PRODUCT" => CheckRangeErrors(args) ?? FR(nums().Aggregate(1.0, (a, b) => a * b)),
             "QUOTIENT" => num(1) != 0 ? FR(Math.Truncate(num(0) / num(1))) : FormulaResult.Error("#DIV/0!"),
-            "MROUND" => num(1) != 0 ? FR(Math.Round(num(0) / num(1)) * num(1)) : FormulaResult.Error("#NUM!"),
+            "MROUND" => num(1) != 0 ? FR(Math.Round(num(0) / num(1), MidpointRounding.AwayFromZero) * num(1)) : FormulaResult.Error("#NUM!"),
             "ROMAN" => FR_S(ToRoman((int)num(0))),
             "ARABIC" => FR(FromRoman(str(0))),
             "BASE" => FR_S(Convert.ToString((long)num(0), (int)num(1)).ToUpperInvariant()),


### PR DESCRIPTION
Fixes #219.

## Summary
- Pass `MidpointRounding.AwayFromZero` when evaluating `MROUND`.
- This matches Excel's documented midpoint behavior instead of .NET's default banker's rounding (`ToEven`).

## Validation
- `git diff --check`
- Numerical sanity check:
  - default rounding: `0.5 -> 0`, `2.5 -> 2`
  - away-from-zero rounding: `0.5 -> 1`, `2.5 -> 3`

Not run: `dotnet publish` / CLI smoke, because this local machine does not have a .NET SDK installed.