### PR TITLE
fix(xlsx): preserve non-space whitespace in TRIM

### DIFF
--- a/src/officecli/Core/Formula/FormulaEvaluator.Functions.cs
+++ b/src/officecli/Core/Formula/FormulaEvaluator.Functions.cs
@@ -187,7 +187,8 @@ internal partial class FormulaEvaluator
             "RIGHT" => FR_S(str(0).Length >= (int)num(1) ? str(0)[^(int)num(1)..] : str(0)),
             "MID" => EvalMid(args),
             "LEN" => FR(str(0).Length),
-            "TRIM" => FR_S(Regex.Replace(str(0).Trim(), @"\s+", " ")),
+            // Excel TRIM only removes ASCII spaces (U+0020); tabs and newlines are data.
+            "TRIM" => FR_S(Regex.Replace(str(0).Trim(' '), " {2,}", " ")),
             "CLEAN" => FR_S(Regex.Replace(str(0), @"[\x00-\x1F]", "")),
             "UPPER" => FR_S(str(0).ToUpperInvariant()),
             "LOWER" => FR_S(str(0).ToLowerInvariant()),


### PR DESCRIPTION
## Summary

Make the formula evaluator's `TRIM` implementation match Excel's documented semantics: it removes and collapses ASCII spaces (`U+0020`) only. Tabs and line breaks are preserved as cell data.

## Root cause

The prior `\s+` regex treated every .NET whitespace character as a space, silently converting tabs and CR/LF into ordinary spaces.

## Validation

- `dotnet build src/officecli/officecli.csproj --no-restore --nologo -v:minimal` (succeeds; one pre-existing nullable warning in `ExcelHandler.SheetShift.cs:538`)
- Reproduced through the built CLI using an `.xlsx` file:
  - `TRIM("hello<TAB>world")` now returns `"hello<TAB>world"`.
  - `TRIM("hello<CRLF>world")` now returns `"hello<CRLF>world"`.
  - `TRIM("  alpha   beta  ")` still returns `"alpha beta"`.

Closes #220.
