### PR TITLE
fix(raw): preserve insertbefore fragment order

### DIFF
--- a/src/officecli/Core/RawXmlHelper.cs
+++ b/src/officecli/Core/RawXmlHelper.cs
@@ -183,7 +183,7 @@ internal static class RawXmlHelper
                     if (xml == null) throw new ArgumentException("--xml is required for insertbefore");
                     RequireParent(node, "insertbefore");
                     var beforeFragment = ParseFragment(xml, xDoc);
-                    foreach (var el in beforeFragment.AsEnumerable().Reverse())
+                    foreach (var el in beforeFragment)
                         node.AddBeforeSelf(el);
                     affected++;
                     break;


### PR DESCRIPTION
## Summary

- preserve the source order of multi-element XML fragments passed to `raw-set --action insertbefore`
- remove the reverse iteration that caused `A, B, C` to be written as `C, B, A`

## Root cause

`XElement.AddBeforeSelf` inserts each element immediately before the same anchor while retaining previously inserted siblings. Iterating the fragment in reverse therefore persisted the reverse of the caller-supplied order.

## User impact

Raw XML edits using `insertbefore` no longer silently reorder the supplied fragment.

## Validation

Built the current source with .NET SDK 10.0.302:

```text
dotnet build src/officecli/officecli.csproj --no-restore --nologo
Build succeeded: 0 errors
```

Ran the same command-level reproduction before and after the change against a disposable DOCX:

```bash
officecli create issue222.docx
officecli raw-set issue222.docx /document \
  --xpath '//w:sectPr' \
  --action insertbefore \
  --xml '<w:p><w:r><w:t>ISSUE222_A</w:t></w:r></w:p><w:p><w:r><w:t>ISSUE222_B</w:t></w:r></w:p><w:p><w:r><w:t>ISSUE222_C</w:t></w:r></w:p>'
officecli close issue222.docx
unzip -p issue222.docx word/document.xml
```

```text
Expected: ISSUE222_A,ISSUE222_B,ISSUE222_C
Before:   ISSUE222_C,ISSUE222_B,ISSUE222_A
After:    ISSUE222_A,ISSUE222_B,ISSUE222_C
```

The build still reports one pre-existing nullable warning in `ExcelHandler.SheetShift.cs:538`; this change introduces no new warning.

Fixes #222
