### PR TITLE
fix(skills): make dashboard frontmatter schema-compatible

### DIFF
--- a/skills/officecli-data-dashboard/SKILL.md
+++ b/skills/officecli-data-dashboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: officecli-data-dashboard
-description: "Use this skill to build a multi-element Excel dashboard — Dashboard sheet on open, multiple formula-driven KPI cards, multiple charts, sparklines, and conditional formatting — from CSV or tabular input. Trigger on: 'dashboard', 'KPI dashboard', 'analytics dashboard', 'executive dashboard', 'metrics dashboard', 'CSV to dashboard', 'data visualization'. Output is a single .xlsx. Scene-layer on officecli-xlsx: inherits every xlsx hard rule. DO NOT invoke for: a single budget tracker / one-sheet CSV-with-formatting (use xlsx), a 3-statement / DCF / LBO financial model (use financial-model), a weekly report with ≤ 1 chart and < 10 rows (use xlsx)."
+description: "Use this skill to build a multi-element Excel dashboard — Dashboard sheet on open, multiple formula-driven KPI cards, multiple charts, sparklines, and conditional formatting — from CSV or tabular input. Trigger on: 'dashboard', 'KPI dashboard', 'analytics dashboard', 'executive dashboard', 'metrics dashboard', 'CSV to dashboard', 'data visualization'. Output is a single .xlsx. Scene-layer on officecli-xlsx: inherits every xlsx hard rule. DO NOT invoke for: a single budget tracker / one-sheet CSV-with-formatting (use xlsx), a 3-statement / DCF / LBO financial model (use financial-model), a weekly report with at most 1 chart and fewer than 10 rows (use xlsx)."
 ---
 
 # Data Dashboard (scene-layer on officecli-xlsx)


### PR DESCRIPTION
## Summary

- replace the raw `<` comparison in the dashboard skill description with equivalent natural language
- preserve the existing triggers, exclusions, and dashboard workflow behavior

## Why

OPL's managed companion validator rejects angle brackets in skill descriptions. The current wording makes `officecli-data-dashboard` fail with `invalid_frontmatter_description`, which blocks OPL Flow policy readiness.

## Validation

- Skill Creator `quick_validate.py`: pass
- `git diff --check`: pass
- isolated `opl skill companion apply --mode managed --json`: `synced`, frontmatter `valid`, resources `complete`
- current OPL Flow repair: skill `ready`, package status `available`
