### PR TITLE
fix(xlsx): round-trip in-cell images through dump

### DIFF
--- a/src/officecli/Handlers/Excel/ExcelBatchEmitter.cs
+++ b/src/officecli/Handlers/Excel/ExcelBatchEmitter.cs
@@ -57,7 +57,8 @@ public static partial class ExcelBatchEmitter
     {
         "type", "formula", "cachedValue", "computedValue", "evaluated", "empty",
         "merge", "link", "tooltip", "display", "arrayformula", "arrayref", "numFmtId",
-        "quotePrefix", "phonetic", "__raw", "__richruns",
+        "quotePrefix", "phonetic", "image.contentType", "image.fileSize", "alt",
+        "__raw", "__richruns", "__imageDataUri",
     };
 
     // Sheet-level Format(Get) key → Set key mapping. Only pairs verified on
@@ -736,6 +737,30 @@ public static partial class ExcelBatchEmitter
                     ["runs"] = runsJson,
                 },
             });
+            return null;
+        }
+
+        // In-cell images cannot ride the CSV value baseline. Replay their
+        // package bytes through the existing set image=<data-uri> vocabulary.
+        if (type == "Image")
+        {
+            if (cell.Format.TryGetValue("__imageDataUri", out var imageValue)
+                && imageValue is string imageDataUri && imageDataUri.Length > 0)
+            {
+                var props = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["image"] = imageDataUri,
+                };
+                if (cell.Format.TryGetValue("alt", out var altValue)
+                    && altValue is string alt && alt.Length > 0)
+                    props["alt"] = alt;
+                corrective.Add(new BatchItem { Command = "set", Path = cell.Path, Props = props });
+            }
+            else
+            {
+                warnings.Add(new UnsupportedWarning("cell.image", cell.Path ?? "",
+                    "in-cell image part could not be read; skipped"));
+            }
             return null;
         }
 

--- a/src/officecli/Handlers/Excel/ExcelHandler.DumpSupport.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.DumpSupport.cs
@@ -134,6 +134,18 @@ public partial class ExcelHandler
                 var raw = cell.CellValue?.Text;
                 if (!string.IsNullOrEmpty(raw))
                     cellNode.Format["__raw"] = raw;
+                // Image bytes are dump-only: normal Get keeps its compact
+                // metadata surface instead of embedding a large data URI.
+                if (cellNode.Format.TryGetValue("type", out var cellType)
+                    && cellType is string typeName && typeName == "Image"
+                    && TryGetInCellImage(cell, out var imageInfo))
+                {
+                    using var imageStream = imageInfo.Part.GetStream(FileMode.Open, FileAccess.Read);
+                    using var imageBytes = new MemoryStream();
+                    imageStream.CopyTo(imageBytes);
+                    cellNode.Format["__imageDataUri"] =
+                        $"data:{imageInfo.ContentType};base64,{Convert.ToBase64String(imageBytes.ToArray())}";
+                }
                 // Rich-text carrier: inline-string runs or a rich shared-string
                 // entry can't ride the CSV baseline. Serialize the runs into
                 // the `runs=<json>` shape ApplyRichTextToCell consumes so the

--- a/src/officecli/Handlers/Excel/ExcelHandler.RichValueImage.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.RichValueImage.cs
@@ -56,7 +56,8 @@ public partial class ExcelHandler
         "<key name=\"_ClassificationId\"><flag name=\"ExcludeFromCalcComparison\" value=\"1\"/></key>" +
         "</keyFlags></global></rvTypesInfo>";
 
-    internal readonly record struct InCellImageInfo(string ContentType, long FileSize, string? Alt, string RelId);
+    internal readonly record struct InCellImageInfo(
+        string ContentType, long FileSize, string? Alt, string RelId, OpenXmlPart Part);
 
     // ==================== write ====================
 
@@ -314,7 +315,7 @@ public partial class ExcelHandler
 
             long size;
             using (var s = imgPart.GetStream(FileMode.Open, FileAccess.Read)) size = s.Length;
-            info = new InCellImageInfo(imgPart.ContentType, size, alt, relId);
+            info = new InCellImageInfo(imgPart.ContentType, size, alt, relId, imgPart);
             return true;
         }
         catch (Exception)


### PR DESCRIPTION
## Summary

- serialize in-cell image package bytes as a dump-only data URI
- replay image cells through `set image=...` while preserving alt text
- keep normal `get` output compact and avoid serializing the literal `[image]` placeholder

Fixes #247.

## Validation

Build:

```bash
dotnet build src/officecli/officecli.csproj
```

Reproduction and round-trip:

```bash
officecli create original.xlsx
officecli set original.xlsx /Sheet1/C3 \
  --prop "image=assets/showcase/employee-handbook.png" \
  --prop "alt=Site photo"
officecli dump original.xlsx / --out dump.json

# v1.0.139: dump.json contains an import field with literal "[image]".
# This PR: dump.json contains a set command with image=data:image/png;base64,...
# and alt="Site photo".

officecli create replay.xlsx
officecli batch replay.xlsx --input dump.json
officecli get replay.xlsx /Sheet1/C3 --json
officecli validate replay.xlsx --json

cmp \
  <(unzip -p original.xlsx xl/media/image.png) \
  <(unzip -p replay.xlsx xl/media/image.png)
```

Observed after the fix:

- `C3` remains `type: Image`
- content type is `image/png`, file size is `10086`, and alt is `Site photo`
- source and replayed media SHA-256 hashes are identical
- OpenXML validation reports zero errors
