### PR TITLE
fix(doc): Document the shipped SDK quick-start API

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,18 +604,26 @@ officecli validate report.docx && officecli view report.docx issues --json
 
 ```python
 # Python — `pip install officecli-sdk`
-from officecli import Doc
-with Doc("deck.pptx") as d:
-    d.add("/", type="slide", title="Q4 Report")
-    print(d.get("/slide[1]"))
+import officecli
+
+with officecli.create("deck.pptx", "--force") as doc:
+    doc.send({"command": "add", "parent": "/", "type": "slide",
+              "props": {"title": "Q4 Report"}})
+    print(doc.send({"command": "get", "path": "/slide[1]"}))
 ```
 
 ```javascript
 // Node.js — `npm install @officecli/sdk`
-import { Doc } from "@officecli/sdk";
-await using d = await Doc.open("deck.pptx");
-await d.add("/", { type: "slide", title: "Q4 Report" });
-console.log(await d.get("/slide[1]"));
+const oc = require("@officecli/sdk");
+
+const doc = await oc.create("deck.pptx", ["--force"]);
+try {
+  await doc.send({ command: "add", parent: "/", type: "slide",
+                   props: { title: "Q4 Report" } });
+  console.log(await doc.send({ command: "get", path: "/slide[1]" }));
+} finally {
+  await doc.close();
+}
 ```
 
 Both SDKs auto-provision the native CLI when missing (mirror-first, Windows-capable) and announce the install rather than doing it silently.


### PR DESCRIPTION
Fixes #250

## Summary
- Replace the nonexistent `Doc` wrapper examples with the shipped `create/open` and `Document.send` API.
- Use `parent` for the slide add command, matching the batch-item command shape.

## Verification
- `PYTHONPATH=sdk/python python3 -c "import officecli; print(officecli.Document)"`
- `node --input-type=module -e "import * as sdk from "./sdk/node/index.js"; console.log(typeof sdk.create, typeof sdk.open)"`
- Executed both README workflows with the built CLI; each creates a deck, adds a slide, and reads it back.