### PR TITLE
fix(docx): keep read-only commands byte-preserving

### DIFF
--- a/src/officecli/Handlers/WordHandler.cs
+++ b/src/officecli/Handlers/WordHandler.cs
@@ -2504,14 +2504,20 @@ public partial class WordHandler : IDocumentHandler, Rendering.IRenderModelHost
         }
         else
         {
-            // Read-only: we wrote nothing. Preserve the legacy post-close
-            // normalization against the file itself (a tiny in-place rewrite;
-            // FlushPendingWholeParts is a no-op with no staged parts).
+            // Read-only session (no _packageStream): we never wrote anything,
+            // so leave the on-disk bytes strictly untouched. The legacy
+            // post-close NormalizeSelfClosingInDocx ran here too, but opening
+            // the zip in Update mode rewrites the whole archive whenever
+            // document.xml contains "<w:br />"/"<w:tab />" — a pure
+            // view/get/query/validate changed the file's bytes and mtime
+            // (issue #231). Normalization still runs on every editable save
+            // via AtomicWriteBack above, which is the only path that may
+            // legitimately alter the file. _pendingWholeParts is only staged
+            // by mutations, which require an editable session, so nothing can
+            // be pending here.
             _doc.Dispose();
             _backingStream?.Dispose();
             _backingStream = null;
-            try { FlushPendingWholeParts(_filePath); } catch { /* best-effort */ }
-            try { NormalizeSelfClosingInDocx(_filePath); } catch { /* best-effort */ }
         }
     }
 


### PR DESCRIPTION
## Summary

- stop read-only `WordHandler.Dispose()` from reopening the source DOCX in update mode
- keep self-closing-tag normalization on the existing editable atomic-save path

Fixes #231

## Root cause

The read-only dispose branch called `NormalizeSelfClosingInDocx(_filePath)`. When `word/document.xml` contained SDK-style `<w:br />` or `<w:tab />`, that helper opened the package with `ZipArchiveMode.Update`, replaced the entry, and rewrote the ZIP. As a result, `get`/`view`/`query`/`validate` could change the file bytes and mtime despite issuing no mutation.

## Validation

Built with:

```bash
dotnet build src/officecli/officecli.csproj -c Release
```

Used a minimal DOCX whose `word/document.xml` contains `<w:br />`, then ran:

```bash
sha256sum readonly.docx
OFFICECLI_NO_AUTO_RESIDENT=1 officecli get readonly.docx '/body/p[1]'
sha256sum readonly.docx
```

Before this fix, the command rewrote the archive (971 B -> 973 B and a different SHA-256). After this fix, SHA-256, size, and mtime remain identical. The resident path (`get`, then `close`) is also byte-preserving.

Regression checks:

- `view`, `query`, and `validate` leave the same DOCX unchanged
- an editable `set` still persists changes and performs normalization through `AtomicWriteBack`
