### PR TITLE
fix(xlsx): render requested screenshot range

### DIFF
--- a/src/officecli/CommandBuilder.View.cs
+++ b/src/officecli/CommandBuilder.View.cs
@@ -304,7 +304,7 @@ static partial class CommandBuilder
                     }
                 }
                 else if (handler is OfficeCli.Handlers.ExcelHandler excelHandler)
-                    html = RenderViaRegistry(excelHandler, "xlsx", new OfficeCli.Core.Rendering.RenderOptions())!;
+                    html = RenderViaRegistry(excelHandler, "xlsx", new OfficeCli.Core.Rendering.RenderOptions { CellRange = clipArg })!;
                 else if (handler is OfficeCli.Handlers.WordHandler wordHandlerGrid && gridCols != 0)
                 {
                     // Contact-sheet grid: tile every page into an N-column (or auto)

--- a/src/officecli/Core/Rendering/RenderOptions.cs
+++ b/src/officecli/Core/Rendering/RenderOptions.cs
@@ -46,4 +46,9 @@ public sealed class RenderOptions
 
     /// <summary>Target raster height in px for Png/Pdf output. 0 = renderer default.</summary>
     public int RasterHeightPx { get; init; }
+
+    /// <summary>Xlsx cell range ("Sheet1!A1:J20" or "/Sheet1/A1:J20") whose cells must
+    /// exist in the rendered grid, so a screenshot --range crop can resolve corner
+    /// cells beyond the used range. Null = used range only. Non-Excel renderers ignore it.</summary>
+    public string? CellRange { get; init; }
 }

--- a/src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.HtmlPreview.cs
@@ -148,8 +148,12 @@ public partial class ExcelHandler
     /// Supports cell formatting (font, fill, borders, alignment), merged cells,
     /// column widths, row heights, frozen panes, and sheet tab switching.
     /// </summary>
-    public string ViewAsHtml()
+    /// <param name="ensureRange">Optional cell range ("Sheet1!A1:J20" or "/Sheet1/A1:J20").
+    /// The named sheet's grid is extended to cover it, so screenshot --range corner
+    /// cells beyond the used range still resolve to real grid cells.</param>
+    public string ViewAsHtml(string? ensureRange = null)
     {
+        var ensure = ParseViewRange(ensureRange, ignoreInvalid: true);
         using var _cul = InvariantCultureScope.Enter();
         var sb = new StringBuilder();
         var sheets = GetWorksheets();
@@ -242,7 +246,9 @@ public partial class ExcelHandler
             var pictures = CollectSheetPictures(worksheetPart);
             if (pictures.Count > 0)
                 charts.AddRange(pictures);
-            RenderSheetTable(sb, sheetName, renderPart, stylesheet, renderStyles, charts, sheetIdx, showGridLines);
+            var ensureCell = ensure != null && string.Equals(ensure.Value.Sheet, sheetName, StringComparison.OrdinalIgnoreCase)
+                ? (ensure.Value.R2, ensure.Value.C2) : ((int, int)?)null;
+            RenderSheetTable(sb, sheetName, renderPart, stylesheet, renderStyles, charts, sheetIdx, showGridLines, ensureCell);
             sb.AppendLine("</div>");
         }
         sb.AppendLine("</div>");
@@ -307,11 +313,12 @@ public partial class ExcelHandler
         return -1;
     }
 
+
     // ==================== Sheet Rendering ====================
 
     private void RenderSheetTable(StringBuilder sb, string sheetName, WorksheetPart worksheetPart, Stylesheet? stylesheet, RenderStyleArrays renderStyles,
         List<(int fromRow, int toRow, int fromCol, int toCol, double colOffsetPt, string html)>? charts = null, int sheetIdx = 0,
-        bool showGridLines = true)
+        bool showGridLines = true, (int Row, int Col)? ensureCell = null)
     {
         var ws = GetSheet(worksheetPart);
         var sheetData = ws.GetFirstChild<SheetData>();
@@ -463,6 +470,15 @@ public partial class ExcelHandler
                 if (toCol > maxCol) maxCol = toCol;
                 if (toRow > maxRow) maxRow = toRow;
             }
+        // Extend maxRow/maxCol to cover an explicitly requested screenshot range
+        // (issue #246): its corner cells must exist in the grid or the clip-crop
+        // union collapses to whichever corner is inside the used range. Subject
+        // to the same render caps below.
+        if (ensureCell != null)
+        {
+            if (ensureCell.Value.Row > maxRow) maxRow = ensureCell.Value.Row;
+            if (ensureCell.Value.Col > maxCol) maxCol = ensureCell.Value.Col;
+        }
 
         // Column cap: >200 cols is unusable in a browser table regardless of rendering mode.
         // Row cap: default 5000; overridable via OnGetHtmlRowCap when the rendering backend

--- a/src/officecli/Handlers/Excel/ExcelHandler.View.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.View.cs
@@ -80,13 +80,13 @@ public partial class ExcelHandler
     }
 
     /// <summary>
-    /// Parse a `view text --range` target ('Sheet1!A1:C10', '/Sheet1/A1:C10',
+    /// Parse an xlsx cell-range target ('Sheet1!A1:C10', '/Sheet1/A1:C10',
     /// or a single cell 'Sheet1!B5') into an inclusive 1-based rectangle.
     /// Corner order is normalized (C10:A1 works). The sheet must exist —
-    /// unknown names throw not_found listing the available sheets, mirroring
-    /// screenshot mode's range_target_not_found actionability.
+    /// unknown names throw not_found listing the available sheets.
+    /// Set <paramref name="ignoreInvalid"/> for callers that also accept non-cell paths.
     /// </summary>
-    private (string Sheet, int R1, int C1, int R2, int C2)? ParseViewRange(string? range)
+    private (string Sheet, int R1, int C1, int R2, int C2)? ParseViewRange(string? range, bool ignoreInvalid = false)
     {
         if (string.IsNullOrWhiteSpace(range)) return null;
         var c = range.Trim();
@@ -96,9 +96,12 @@ public partial class ExcelHandler
             c = "/" + c[..bang] + "/" + c[(bang + 1)..];
         var m = Regex.Match(c, @"^/([^/]+)/([A-Za-z]{1,3}\d+)(?::([A-Za-z]{1,3}\d+))?$");
         if (!m.Success)
+        {
+            if (ignoreInvalid) return null;
             throw new Core.CliException(
                 $"Invalid --range '{range}'. Expected 'Sheet1!A1:C10', '/Sheet1/A1:C10', or a single cell 'Sheet1!B5'.")
             { Code = "invalid_value" };
+        }
 
         var sheet = m.Groups[1].Value;
         var names = GetWorksheets().Select(s => s.Item1).ToList();

--- a/src/officecli/Handlers/Rendering/BasicRenderers.cs
+++ b/src/officecli/Handlers/Rendering/BasicRenderers.cs
@@ -58,7 +58,7 @@ public sealed class ExcelBasicRenderer : IRenderer
     {
         var h = (input as HandlerRenderInput)?.Handler as ExcelHandler
                 ?? throw new InvalidOperationException("ExcelHandler render input expected");
-        return RenderResult.Html(h.ViewAsHtml());
+        return RenderResult.Html(h.ViewAsHtml(options.CellRange));
     }
 }
 

--- a/src/officecli/ResidentServer.cs
+++ b/src/officecli/ResidentServer.cs
@@ -1640,7 +1640,7 @@ public class ResidentServer : IDisposable
                 }
             }
             else if (_handler is OfficeCli.Handlers.ExcelHandler excelShotHandler)
-                html = CommandBuilder.RenderViaRegistry(excelShotHandler, "xlsx", new OfficeCli.Core.Rendering.RenderOptions())!;
+                html = CommandBuilder.RenderViaRegistry(excelShotHandler, "xlsx", new OfficeCli.Core.Rendering.RenderOptions { CellRange = rangeArg })!;
             else if (_handler is OfficeCli.Handlers.WordHandler wordShotGrid && gridCols != 0)
             {
                 // Contact-sheet grid — mirrors CommandBuilder.View.cs's docx grid


### PR DESCRIPTION
## Summary

- pass xlsx screenshot cell ranges into the HTML renderer in both one-shot and resident paths
- extend the rendered sheet grid through the requested range corner before clipping
- reuse the existing xlsx range parser while preserving element clips such as `/Sheet1/chart[1]`

Fixes #246

## Root cause

`CaptureClipped` resolves an xlsx range through its two corner cells. The HTML renderer only emitted cells through the sheet's computed data/drawing extent, so when the requested lower-right corner was outside that grid it did not exist in the DOM. The crop union then contained only the surviving upper-left corner and collapsed to that cell, excluding the chart and the rest of the requested area.

On current `main`, the default full-sheet screenshot already renders this repro chart. The remaining reproducible defect is the `--range` path when the requested range extends past the generated grid.

## Validation

Repro workbook: populated cells in `A1:B13` plus a floating chart starting at `D1`, then:

```bash
officecli view repro.xlsx screenshot \
  --range "Sheet1!A1:J20" \
  -o range.png
```

Observed result:

| Version | PNG dimensions | Content |
| --- | ---: | --- |
| current `main` | 120 x 40 | only `A1`; chart omitted |
| this branch | 1182 x 800 | full `A1:J20` range and chart |

Additional checks:

```bash
# Existing element clip still works: 710 x 680
officecli view repro.xlsx screenshot --range '/Sheet1/chart[1]' -o chart.png

# Existing in-grid cell range is unchanged: 238 x 520
officecli view repro.xlsx screenshot --range 'Sheet1!A1:B13' -o cells.png

dotnet build src/officecli/officecli.csproj -c Release
```

The build succeeds with the pre-existing nullable warning in `ExcelHandler.SheetShift.cs`.
