### PR TITLE
fix(word): preserve segment name case in resolved textbox/shape path

### DIFF
--- a/src/officecli/Handlers/Word/WordHandler.Navigation.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Navigation.cs
@@ -1624,7 +1624,7 @@ public partial class WordHandler
             // like /<host>/textbox[N]/tbl[K]/tr[J] fail with
             // "No txbxContent found at /body".
             if (canonName == "txbxContent" || canonName == "wsp")
-                canonName = seg.Name.ToLowerInvariant();
+                canonName = seg.Name;
             if (next is Paragraph navPara && !string.IsNullOrEmpty(navPara.ParagraphId?.Value))
             {
                 parentPath += "/" + canonName + $"[@paraId={navPara.ParagraphId.Value}]";


### PR DESCRIPTION
## Problem
`get` returns a resolved path in which the `txbxContent` (and `wsp`) segment is lowercased to `txbxcontent`. Generic path navigation matches a child's `LocalName` case-sensitively, so this returned path is not re-navigable — feeding it back into `get` fails even though it came straight out of the tool.

Repro (from #258):
```
officecli query error.docx t --json
# -> .../wsp[1]/txbx[1]/txbxContent[1]/p[1]/r[1]/t[1]

officecli get error.docx /.../wsp[1]/txbx[1]/txbxContent[1]/p[1]/r[1] --json
# returns path .../wsp[1]/txbx[1]/txbxcontent[1]/p[@paraId=...]/r[1]   <- lowercased

officecli get error.docx /.../txbx[1]/txbxcontent[1]/p[@paraId=...]/r[1]
# Error: No txbxcontent found ... Available children: txbxContent(1)
```

## Cause
In `NavigateToElement` (WordHandler.Navigation.cs), the resolved-path builder applies `seg.Name.ToLowerInvariant()` to the `txbxContent`/`wsp` segment. The adjacent comment states the goal is to "preserve the user-supplied segment name so resolvedPath stays re-navigable", but lowercasing corrupts the canonical `txbxContent` that `query` emits.

## Fix
Preserve the user-supplied segment name verbatim. The friendly aliases `textbox`/`shape` are already lowercase, so only raw `txbxContent`/`wsp` segments change behavior — they now round-trip between `query` and `get`.

Fixes #258
