### PR TITLE
fix(cli): decode piped stdin as UTF-8 without mutating the console

### DIFF
--- a/src/officecli/CommandBuilder.Batch.cs
+++ b/src/officecli/CommandBuilder.Batch.cs
@@ -1,4 +1,4 @@
-// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
+﻿// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
 // SPDX-License-Identifier: Apache-2.0
 
 using System.CommandLine;
@@ -188,7 +188,7 @@ static partial class CommandBuilder
                 {
                     var stdinPeek = System.Threading.Tasks.Task.Run(() =>
                     {
-                        try { return Console.In.Peek() != -1; }
+                        try { return StdIn.Peek() != -1; }
                         catch { return false; }
                     });
                     stdinHasInput = stdinPeek.Wait(TimeSpan.FromMilliseconds(50)) && stdinPeek.Result;
@@ -225,7 +225,7 @@ static partial class CommandBuilder
                 // skipped on purpose — '-' is not a path.)
                 if (inputFile.Name == "-")
                 {
-                    jsonText = StripBom(Console.In.ReadToEnd());
+                    jsonText = StripBom(StdIn.ReadToEnd());
                 }
                 else
                 {
@@ -244,7 +244,7 @@ static partial class CommandBuilder
                 // System.Text.Json.Parse with "'﻿' is an invalid start of
                 // a value" while `batch --input utf8bom.json` succeeded —
                 // splitting the contract on the input source.
-                jsonText = StripBom(Console.In.ReadToEnd());
+                jsonText = StripBom(StdIn.ReadToEnd());
             }
 
             // Pre-validate: check for unknown JSON fields before deserializing
@@ -637,9 +637,39 @@ static partial class CommandBuilder
     }
 
     // UTF-8 BOM trim. File.ReadAllText handles this implicitly via
-    // StreamReader's detect-encoding; Console.In feeds raw chars.
+    // StreamReader's detect-encoding; the stdin reader feeds raw chars.
     private static string StripBom(string s)
         => !string.IsNullOrEmpty(s) && s[0] == '﻿' ? s.Substring(1) : s;
+
+    /// <summary>
+    /// UTF-8 view of the process's stdin, used everywhere this CLI reads piped
+    /// input (batch JSON, import CSV/TSV).
+    ///
+    /// Console.In would decode with Console.InputEncoding, which on Windows is
+    /// the console's input code page (CP437 on en-US, CP936 on zh-CN) and never
+    /// UTF-8 — piped payloads arrived mojibaked. Setting Console.InputEncoding
+    /// fixes the decode but calls SetConsoleCP on the console object, which is
+    /// shared with the parent shell and outlives this process: every officecli
+    /// run would leave the user's terminal pinned to CP 65001, breaking
+    /// non-ASCII keyboard input for legacy console programs run afterwards.
+    /// Gating on Console.IsInputRedirected does not help — a piped run has a
+    /// console attached too, so it leaks in exactly the case the decode fix is
+    /// for. Reading through our own StreamReader gets correct UTF-8 with no
+    /// global console mutation. Same approach McpServer already uses.
+    ///
+    /// One shared instance, because the batch path Peeks before it Reads and a
+    /// second reader would swallow whatever the first one buffered. Wrapped in
+    /// TextReader.Synchronized to match Console.In's thread-safety — the Peek
+    /// runs on a worker thread that may be abandoned on timeout.
+    /// </summary>
+    private static readonly Lazy<TextReader> LazyStdIn = new(() =>
+        TextReader.Synchronized(new StreamReader(
+            Console.OpenStandardInput(),
+            new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            // StripBom owns BOM handling; don't let detection also switch encodings.
+            detectEncodingFromByteOrderMarks: false)));
+
+    internal static TextReader StdIn => LazyStdIn.Value;
 
     /// <summary>
     /// The atomic temp name adds ~45 bytes of affixes around the document's

--- a/src/officecli/CommandBuilder.Import.cs
+++ b/src/officecli/CommandBuilder.Import.cs
@@ -1,4 +1,4 @@
-// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
+﻿// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
 // SPDX-License-Identifier: Apache-2.0
 
 using System.CommandLine;
@@ -62,7 +62,7 @@ static partial class CommandBuilder
             string csvContent;
             if (useStdin)
             {
-                csvContent = Console.In.ReadToEnd();
+                csvContent = StdIn.ReadToEnd();
             }
             else if (source != null)
             {

--- a/src/officecli/Program.cs
+++ b/src/officecli/Program.cs
@@ -5,6 +5,12 @@
 // Ensure UTF-8 output on all platforms (Windows defaults to system codepage e.g. GBK)
 Console.OutputEncoding = System.Text.Encoding.UTF8;
 
+// The input side is deliberately NOT handled here. Console.InputEncoding would
+// decode piped stdin correctly but calls SetConsoleCP on the console object,
+// which is shared with the parent shell and outlives this process — every
+// officecli run would leave the user's terminal pinned to CP 65001. Stdin is
+// read through an explicit UTF-8 reader instead; see CommandBuilder.StdIn.
+
 // Snapshot the OS user culture BEFORE we pin the thread to Invariant.
 // Read by `create --locale` (when no explicit tag is given) to bake the
 // user's actual locale into the new doc, mirroring what Word / Pages /


### PR DESCRIPTION
## Problem

`Program.cs` pins `Console.OutputEncoding` to UTF-8 but leaves the input side at its default. On Windows, `Console.In` decodes redirected stdin with `Console.InputEncoding` — the console's input code page (CP437 on an en-US console, CP936 on zh-CN) — never UTF-8. Every command that reads stdin therefore corrupts non-ASCII payloads:

| Command | Site | Payload |
|---|---|---|
| `batch` | `CommandBuilder.Batch.cs:247` (implicit stdin), `:228` (`--input -`) | piped JSON |
| `import --stdin` | `CommandBuilder.Import.cs:65` | piped CSV/TSV |

`•` arrives as `ΓÇó`, `—` as `ΓÇö`, `é` as `├⌐`, and CJK is destroyed outright — while the identical payload passed via `--input` or `--commands` is correct. The contract splits on the input source.

It fails **silently**: the run still reports `Batch complete: 1 succeeded, 0 failed` and exits 0, so nothing surfaces until someone reads the text back.

POSIX already defaults to UTF-8, so this reproduces on Windows only — which is also why the `ubuntu-latest` CI jobs never caught it.

## Fix

Read stdin through an explicit UTF-8 `StreamReader` (`CommandBuilder.StdIn`) instead of `Console.In`. Correct decoding, and no mutation of global console state.

**This PR previously took the one-line approach of pinning `Console.InputEncoding`, and that turned out to be unshippable.** The setter calls `SetConsoleCP` on the console object, which is shared with the parent shell and outlives the process. Measured with `GetConsoleCP` immediately either side of a run:

```
baseline console CP        : 437
after plain officecli run  : 65001   ❌ leaked
after piped officecli run  : 65001   ❌ leaked
```

So every `officecli` invocation would leave the user's terminal pinned to CP 65001 — a documented cause of broken non-ASCII keyboard input for legacy console programs run afterwards in that same window. Gating on `Console.IsInputRedirected` does **not** avoid it: a piped run has a console attached too, so it still leaks in exactly the case the decode fix exists for.

With the reader approach:

```
baseline console CP        : 437
after plain officecli run  : 437     ✓
after piped officecli run  : 437     ✓
```

This is also the approach `McpServer.cs:23` already uses on the same stream (`new StreamReader(Console.OpenStandardInput())`), so the CLI now matches it rather than diverging.

### On the `Peek()` hazard

The earlier revision of this PR rejected a `StreamReader` because `Batch.cs:191` calls `Peek()` on stdin before the `--input -` branch reads it, and a second independent reader would silently drop whatever bytes the peek had buffered. That objection was correct, and it is why `StdIn` is a **single shared `Lazy<TextReader>`** rather than a reader constructed per call site — the peek and the read go through the same buffer, exactly as they did through `Console.In`.

It is wrapped in `TextReader.Synchronized` to match `Console.In`'s own thread-safety, because that `Peek()` runs on a worker thread that may be abandoned on the 50 ms timeout.

`detectEncodingFromByteOrderMarks` is off so that `StripBom` (`Batch.cs:641`) remains the single owner of BOM handling.

## Validation

`ops.json`, UTF-8 without BOM:

```json
[{"command":"add","parent":"/slide[1]","type":"shape","props":{"name":"Probe","x":"1cm","y":"1cm","width":"20cm","height":"3cm","text":"BULLET • DASH — QUOTE “x” CJK 中文测试 ACCENT café"}}]
```

```bash
officecli create t.pptx
officecli add t.pptx / --type slide --prop layout=blank
cat ops.json | officecli batch t.pptx
officecli view t.pptx text
```

**Before** (1.0.140, en-US console):
```
BULLET ΓÇó DASH ΓÇö QUOTE ΓÇ£xΓÇ¥ CJK Σ╕¡µûçµ╡ïΦ»ò ACCENT caf├⌐     ❌
```

**After:**
```
BULLET • DASH — QUOTE “x” CJK 中文测试 ACCENT café                  ✓
```

Same root cause, same fix, second command:

```bash
printf '产品,销量\n咖啡 • 深烘,1234\ncafé,567\n' > zh.csv
officecli create s.xlsx
cat zh.csv | officecli import s.xlsx /Sheet1 --stdin
officecli view s.xlsx text
```

**Before:**
```
[/Sheet1/row[1]] A1=Σ║ºσôü      B1=ΘöÇΘçÅ
[/Sheet1/row[2]] A2=σÆûσòí ΓÇó µ╖▒τâÿ   B2=1234
[/Sheet1/row[3]] A3=caf├⌐       B3=567                              ❌
```

**After:**
```
[/Sheet1/row[1]] A1=产品        B1=销量
[/Sheet1/row[2]] A2=咖啡 • 深烘  B2=1234
[/Sheet1/row[3]] A3=café        B3=567                             ✓
```

### Regressions checked

- **UTF-8 BOM on stdin** — still parses; `StripBom` path untouched and now the sole BOM owner
- **`batch --input -`** (explicit stdin alias, the branch that shares the reader with `Peek()`) — correct
- **`batch --input <file>`** and **`batch --commands`** via argv — still correct (were already correct)
- **`import --stdin`** — correct
- **Console code page** — `GetConsoleCP()` unchanged across both plain and piped runs (see above)
- `dotnet build -c Release` — clean; the only warning is the pre-existing `CS8602` in `ExcelHandler.SheetShift.cs:538`

## Atomicity (Rule 1)

One root cause, one mechanism. All three affected call sites read through the same stdin reader, so a single change fixes them together — there is no smaller decomposition, and splitting by command would leave the shared cause half-fixed.
