### PR TITLE
fix(pptx): notes slides get the package relationships they require

### DIFF
--- a/src/officecli/Handlers/PowerPointHandler.cs
+++ b/src/officecli/Handlers/PowerPointHandler.cs
@@ -1429,9 +1429,12 @@ public partial class PowerPointHandler : IDocumentHandler, Rendering.IRenderMode
                         // demand so the ImagePart has a host to attach to.
                         // CONSISTENCY(grow-on-rawset): mirrors slideMaster/layout
                         // auto-grow above and /notesMaster on-demand creation.
+                        // EnsureNotesSlidePart (not a bare AddNewPart) so the
+                        // created part gets a NotesSlide root and its
+                        // notesMaster relationship; the following raw-set
+                        // replaces the root but keeps the relationships.
                         var hostSlide = sldParts[nsIdx - 1];
-                        imageHost = hostSlide.NotesSlidePart
-                            ?? hostSlide.AddNewPart<NotesSlidePart>();
+                        imageHost = EnsureNotesSlidePart(hostSlide);
                     }
                     else
                         throw new ArgumentException(
@@ -1572,7 +1575,7 @@ public partial class PowerPointHandler : IDocumentHandler, Rendering.IRenderMode
                     var parts = GetSlideParts().ToList();
                     if (i < 1 || i > parts.Count) throw new ArgumentException($"noteSlide index {i} out of range");
                     var hostSlide = parts[i - 1];
-                    hlHost = hostSlide.NotesSlidePart ?? hostSlide.AddNewPart<NotesSlidePart>();
+                    hlHost = EnsureNotesSlidePart(hostSlide);
                 }
                 else
                     throw new ArgumentException(

--- a/src/officecli/Handlers/Pptx/PowerPointHandler.Mutations.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.Mutations.cs
@@ -1724,6 +1724,9 @@ public partial class PowerPointHandler
             // the package and conformant readers throw on the missing
             // relationship — even though the deck itself has a valid master.
             newNotesPart.AddPart(EnsureNotesMasterPart(presentationPart));
+            // Pictures / hyperlinks living in the notes themselves, plus the
+            // rId remap their cloned XML needs.
+            CopyNotesSlideParts(srcNotesPart, newNotesPart);
         }
 
         newSlidePart.Slide.Save();
@@ -1763,15 +1766,55 @@ public partial class PowerPointHandler
     /// </summary>
     private static void CopySlideParts(SlidePart source, SlidePart target)
     {
+        // SlideLayoutPart is already linked by the caller; NotesSlidePart is
+        // cloned separately by CopyNotesSlideParts, which needs its own rId
+        // remap target (the notes XML, not the slide XML).
+        var rIdMap = CopyPartsAndRelationships(source, target,
+            part => part is SlideLayoutPart or NotesSlidePart);
+        if (rIdMap.Count > 0 && target.Slide != null)
+        {
+            RemapRelationshipIds(target.Slide, rIdMap);
+            target.Slide.Save();
+        }
+    }
+
+    /// <summary>
+    /// Copy a duplicated slide's notes-slide sub-parts. Speaker notes can carry
+    /// their own pictures and external hyperlinks; without this the clone kept
+    /// the r:embed / r:id in its notes XML while the relationships stayed behind
+    /// on the source part, leaving a dangling reference that makes PowerPoint
+    /// offer to repair the file.
+    ///
+    /// NotesMasterPart and SlidePart are skipped: CloneSlide wires those
+    /// explicitly to the NEW slide and the deck's notes master, and copying the
+    /// source's would point the clone back at the original slide.
+    /// </summary>
+    private static void CopyNotesSlideParts(NotesSlidePart source, NotesSlidePart target)
+    {
+        var rIdMap = CopyPartsAndRelationships(source, target,
+            part => part is NotesMasterPart or SlidePart);
+        if (rIdMap.Count > 0 && target.NotesSlide != null)
+        {
+            RemapRelationshipIds(target.NotesSlide, rIdMap);
+            target.NotesSlide.Save();
+        }
+    }
+
+    /// <summary>
+    /// Shared part + relationship copier behind CopySlideParts and
+    /// CopyNotesSlideParts. Returns the old rId -&gt; new rId map that the caller
+    /// must replay over its own cloned XML.
+    /// </summary>
+    private static Dictionary<string, string> CopyPartsAndRelationships(
+        OpenXmlPartContainer source, OpenXmlPartContainer target,
+        Func<OpenXmlPart, bool> skip)
+    {
         // Build a map of old rId → new rId for all parts that need copying
         var rIdMap = new Dictionary<string, string>();
 
         foreach (var part in source.Parts)
         {
-            // Skip SlideLayoutPart (already linked above)
-            if (part.OpenXmlPart is SlideLayoutPart) continue;
-            // Skip NotesSlidePart (handled separately)
-            if (part.OpenXmlPart is NotesSlidePart) continue;
+            if (skip(part.OpenXmlPart)) continue;
 
             // Charts and embedded objects MUST be deep-copied — both slides
             // sharing the same ChartPart instance makes real PowerPoint reject
@@ -1843,22 +1886,9 @@ public partial class PowerPointHandler
             catch { }
         }
 
-        // Remap any changed relationship IDs in the slide XML
-        if (rIdMap.Count > 0 && target.Slide != null)
-        {
-            RemapRelationshipIds(target.Slide, rIdMap);
-            target.Slide.Save();
-        }
+        return rIdMap;
     }
 
-    /// <summary>
-    /// Parts that carry per-slide mutable data and must be cloned (not shared)
-    /// when a slide is duplicated. ChartParts especially: real PowerPoint
-    /// rejects (422) a file in which two slides point to the same chart part,
-    /// even though the SDK validator passes it. Embedded packages / OLE
-    /// objects have the same constraint. Image and media parts are immutable
-    /// after creation and safe to share.
-    /// </summary>
     /// <summary>
     /// Create a fresh part of the same concrete type as <paramref name="source"/>
     /// hung off <paramref name="parent"/>. Using the strongly-typed AddNewPart
@@ -1899,6 +1929,14 @@ public partial class PowerPointHandler
         };
     }
 
+    /// <summary>
+    /// Parts that carry per-slide mutable data and must be cloned (not shared)
+    /// when a slide is duplicated. ChartParts especially: real PowerPoint
+    /// rejects (422) a file in which two slides point to the same chart part,
+    /// even though the SDK validator passes it. Embedded packages / OLE
+    /// objects have the same constraint. Image and media parts are immutable
+    /// after creation and safe to share.
+    /// </summary>
     private static bool NeedsDeepCopy(OpenXmlPart part) => part is
         DocumentFormat.OpenXml.Packaging.ChartPart
         or DocumentFormat.OpenXml.Packaging.ExtendedChartPart

--- a/src/officecli/Handlers/Pptx/PowerPointHandler.Mutations.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.Mutations.cs
@@ -1717,6 +1717,13 @@ public partial class PowerPointHandler
                 : new NotesSlide();
             // Link notes to the new slide
             newNotesPart.AddPart(newSlidePart);
+            // BUG(notes-orphan): the clone must also carry the source's
+            // notesMaster relationship. Its placeholders have an empty
+            // <p:spPr/> and inherit geometry from the master, so without this
+            // the duplicated notes text has no position or size anywhere in
+            // the package and conformant readers throw on the missing
+            // relationship — even though the deck itself has a valid master.
+            newNotesPart.AddPart(EnsureNotesMasterPart(presentationPart));
         }
 
         newSlidePart.Slide.Save();

--- a/src/officecli/Handlers/Pptx/PowerPointHandler.Notes.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.Notes.cs
@@ -161,6 +161,226 @@ public partial class PowerPointHandler
         }
     }
 
+    // ==================== Notes master ====================
+
+    // The default 7.5" x 10" notes page. The placeholder rectangles in
+    // BuildNotesMasterXml are PowerPoint's own numbers for this page size;
+    // NotesMasterRect scales them for decks that override <p:notesSz>.
+    private const long StdNotesCx = 6858000;
+    private const long StdNotesCy = 9144000;
+
+    /// <summary>
+    /// Scale one of PowerPoint's stock notes-master rectangles to the deck's
+    /// actual &lt;p:notesSz&gt;, passing the stock numbers through unchanged on
+    /// the default notes page.
+    /// </summary>
+    private static (long X, long Y, long Cx, long Cy) NotesMasterRect(
+        long pageCx, long pageCy, long x, long y, long cx, long cy)
+    {
+        long sx(long v) => pageCx == StdNotesCx ? v : (long)Math.Round(v * (double)pageCx / StdNotesCx);
+        long sy(long v) => pageCy == StdNotesCy ? v : (long)Math.Round(v * (double)pageCy / StdNotesCy);
+        return (sx(x), sy(y), sx(cx), sy(cy));
+    }
+
+    /// <summary>
+    /// Create the presentation's notes master if it has none, wire its theme
+    /// relationship, and register it in &lt;p:notesMasterIdLst&gt;.
+    ///
+    /// BUG(notes-orphan): notes slides emit empty &lt;p:spPr/&gt; on their
+    /// placeholders and inherit position, size and text style from the notes
+    /// master. Before this, `add /slide[N] --type notes` wrote notesSlide1.xml
+    /// with no master to inherit from and no notesSlide rels part at all, so the
+    /// notes text had no geometry anywhere in the package. Text extraction still
+    /// worked, which is why it went unnoticed; conformant readers (python-pptx)
+    /// throw on the missing notesMaster relationship. The equivalent creation
+    /// code already existed, but only on the raw-set /notesMaster dump-replay
+    /// path in PowerPointHandler.cs — which the add/set notes verbs never reach.
+    /// </summary>
+    private static NotesMasterPart EnsureNotesMasterPart(PresentationPart presentationPart)
+    {
+        if (presentationPart.NotesMasterPart != null) return presentationPart.NotesMasterPart;
+
+        var notesSz = presentationPart.Presentation?.NotesSize;
+        long w = notesSz?.Cx?.Value ?? SlideSizeDefaults.NotesPortraitCx;
+        long h = notesSz?.Cy?.Value ?? SlideSizeDefaults.NotesPortraitCy;
+        var sldSz = presentationPart.Presentation?.SlideSize;
+        long slideCx = sldSz?.Cx?.Value ?? SlideSizeDefaults.Widescreen16x9Cx;
+        long slideCy = sldSz?.Cy?.Value ?? SlideSizeDefaults.Widescreen16x9Cy;
+
+        var nmPart = presentationPart.AddNewPart<NotesMasterPart>();
+        nmPart.NotesMaster = new NotesMaster(BuildNotesMasterXml(w, h, slideCx, slideCy));
+
+        // A notes master must carry a theme relationship; the +mn-lt / tx1
+        // references in its notesStyle resolve through it. Give it its OWN
+        // theme part rather than sharing the presentation's — GrowSlideMasterParts
+        // clones for grown slide masters for the same reason, PptxBatchEmitter
+        // emits `add-part theme /notesMaster` whenever the notes master has a
+        // theme at all, and PowerPoint itself writes a separate theme2.xml.
+        // Sharing made every dump->replay round-trip grow a duplicate theme.
+        // Fall back to a slide master's theme for decks where theme1.xml hangs
+        // off the master rather than the presentation.
+        var themeSource = presentationPart.ThemePart?.Theme
+            ?? presentationPart.SlideMasterParts.FirstOrDefault()?.ThemePart?.Theme;
+        var nmTheme = nmPart.AddNewPart<ThemePart>();
+        nmTheme.Theme = themeSource != null
+            ? (Drawing.Theme)themeSource.CloneNode(true)
+            : new Drawing.Theme();
+        nmTheme.Theme.Save();
+
+        // AddNewPart only wires the relationship. Without a <p:notesMasterId>
+        // entry the part is an orphan reference and PowerPoint refuses the
+        // file. An existing but empty or stale <p:notesMasterIdLst> leaves it
+        // just as orphaned as a missing one, so test the entries, not the list.
+        // Schema order (CT_Presentation): sldMasterIdLst -> notesMasterIdLst
+        // -> handoutMasterIdLst -> sldIdLst.
+        var pres = presentationPart.Presentation;
+        if (pres != null)
+        {
+            var nmIdLst = pres.NotesMasterIdList;
+            if (nmIdLst == null)
+            {
+                nmIdLst = new NotesMasterIdList();
+                if (pres.SlideMasterIdList != null)
+                    pres.InsertAfter(nmIdLst, pres.SlideMasterIdList);
+                else
+                    pres.PrependChild(nmIdLst);
+            }
+            bool declared = nmIdLst.Elements<NotesMasterId>().Any(e =>
+                !string.IsNullOrEmpty(e.Id?.Value)
+                && presentationPart.Parts.Any(p => p.RelationshipId == e.Id!.Value));
+            if (!declared)
+            {
+                nmIdLst.RemoveAllChildren<NotesMasterId>();
+                nmIdLst.AppendChild(new NotesMasterId { Id = presentationPart.GetIdOfPart(nmPart) });
+            }
+            pres.Save();
+        }
+
+        nmPart.NotesMaster.Save();
+        return nmPart;
+    }
+
+    /// <summary>
+    /// Build notesMaster1.xml. Written as XML rather than an SDK object graph
+    /// because it is six near-identical placeholders plus nine near-identical
+    /// notesStyle levels; the object-graph form is ~200 lines of constructor
+    /// soup with the geometry buried in it.
+    /// </summary>
+    private static string BuildNotesMasterXml(long pageCx, long pageCy, long slideCx, long slideCy)
+    {
+        var hdr = NotesMasterRect(pageCx, pageCy, 0, 0, 2971800, 458788);
+        var dt = NotesMasterRect(pageCx, pageCy, 3884613, 0, 2971800, 458788);
+        var ftr = NotesMasterRect(pageCx, pageCy, 0, 8685213, 2971800, 458787);
+        var num = NotesMasterRect(pageCx, pageCy, 3884613, 8685213, 2971800, 458787);
+
+        // The slide-image placeholder is a thumbnail of the slide, so its height
+        // follows the deck's aspect ratio rather than a fixed number — PowerPoint
+        // recomputes it the same way (4572000-wide box: 2571750 high on 16:9,
+        // 3429000 on 4:3). Getting this wrong letterboxes every notes page.
+        var imgBox = NotesMasterRect(pageCx, pageCy, 1143000, 685800, 4572000, 0);
+        long imgCy = slideCx > 0 ? (long)Math.Round(imgBox.Cx * (double)slideCy / slideCx) : imgBox.Cy;
+        var img = (imgBox.X, imgBox.Y, imgBox.Cx, Cy: imgCy);
+
+        // Body sits below the thumbnail, snapped to the next quarter-inch grid
+        // line strictly below it. Reproduces PowerPoint's 3429000 on 16:9 and
+        // 4343400 on 4:3 decks.
+        const long QuarterInch = 228600;
+        var bodyBox = NotesMasterRect(pageCx, pageCy, 685800, 0, 5486400, 4114800);
+        // Never let a tall thumbnail push the notes box into the footer band.
+        // Clamping the height alone is not enough: on a wide/short notes page
+        // the snapped origin can already sit below the footer, which would make
+        // the height term negative.
+        long bodyY = Math.Min(
+            (imgBox.Y + imgCy) / QuarterInch * QuarterInch + QuarterInch,
+            Math.Max(imgBox.Y, ftr.Y - QuarterInch));
+        long bodyCy = Math.Max(QuarterInch, Math.Min(bodyBox.Cy, ftr.Y - bodyY));
+        var body = (bodyBox.X, Y: bodyY, bodyBox.Cx, Cy: bodyCy);
+
+        static string Xfrm((long X, long Y, long Cx, long Cy) r) =>
+            $"<a:xfrm><a:off x=\"{r.X}\" y=\"{r.Y}\"/><a:ext cx=\"{r.Cx}\" cy=\"{r.Cy}\"/></a:xfrm>"
+            + "<a:prstGeom prst=\"rect\"><a:avLst/></a:prstGeom>";
+
+        // Header/footer/date/slide-number text bodies: 12pt, anchored to the
+        // outer edge of the notes page like PowerPoint's.
+        static string Banner(string algn, string? field) =>
+            "<p:txBody><a:bodyPr vert=\"horz\" lIns=\"91440\" tIns=\"45720\" rIns=\"91440\" bIns=\"45720\"/>"
+            + $"<a:lstStyle><a:lvl1pPr algn=\"{algn}\"><a:defRPr sz=\"1200\"/></a:lvl1pPr></a:lstStyle>"
+            + "<a:p>"
+            + (field ?? "")
+            + "<a:endParaRPr lang=\"en-US\"/></a:p></p:txBody>";
+
+        // No cached <a:t>: the reader computes the value, so we never bake a
+        // stale date or page number into the file.
+        const string DateField =
+            "<a:fld id=\"{B1E4B0A2-5C8E-4E5F-9C1D-2F3A4B5C6D71}\" type=\"datetimeFigureOut\">"
+            + "<a:rPr lang=\"en-US\"/></a:fld>";
+        const string SlideNumField =
+            "<a:fld id=\"{B1E4B0A2-5C8E-4E5F-9C1D-2F3A4B5C6D72}\" type=\"slidenum\">"
+            + "<a:rPr lang=\"en-US\"/></a:fld>";
+
+        var notesStyle = new System.Text.StringBuilder("<p:notesStyle>");
+        for (int lvl = 1; lvl <= 9; lvl++)
+        {
+            notesStyle.Append(
+                $"<a:lvl{lvl}pPr marL=\"{(lvl - 1) * 457200}\" algn=\"l\" defTabSz=\"914400\" rtl=\"0\" "
+                + "eaLnBrk=\"1\" latinLnBrk=\"0\" hangingPunct=\"1\">"
+                + "<a:defRPr sz=\"1200\" kern=\"1200\">"
+                + "<a:solidFill><a:schemeClr val=\"tx1\"/></a:solidFill>"
+                + "<a:latin typeface=\"+mn-lt\"/><a:ea typeface=\"+mn-ea\"/><a:cs typeface=\"+mn-cs\"/>"
+                + $"</a:defRPr></a:lvl{lvl}pPr>");
+        }
+        notesStyle.Append("</p:notesStyle>");
+
+        return "<p:notesMaster xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\" "
+            + "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" "
+            + "xmlns:p=\"http://schemas.openxmlformats.org/presentationml/2006/main\">"
+            + "<p:cSld><p:spTree>"
+            + "<p:nvGrpSpPr><p:cNvPr id=\"1\" name=\"\"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>"
+            + "<p:grpSpPr><a:xfrm><a:off x=\"0\" y=\"0\"/><a:ext cx=\"0\" cy=\"0\"/>"
+            + "<a:chOff x=\"0\" y=\"0\"/><a:chExt cx=\"0\" cy=\"0\"/></a:xfrm></p:grpSpPr>"
+
+            + "<p:sp><p:nvSpPr><p:cNvPr id=\"2\" name=\"Header Placeholder 1\"/>"
+            + "<p:cNvSpPr><a:spLocks noGrp=\"1\"/></p:cNvSpPr>"
+            + "<p:nvPr><p:ph type=\"hdr\" sz=\"quarter\"/></p:nvPr></p:nvSpPr>"
+            + $"<p:spPr>{Xfrm(hdr)}</p:spPr>{Banner("l", null)}</p:sp>"
+
+            + "<p:sp><p:nvSpPr><p:cNvPr id=\"3\" name=\"Date Placeholder 2\"/>"
+            + "<p:cNvSpPr><a:spLocks noGrp=\"1\"/></p:cNvSpPr>"
+            + "<p:nvPr><p:ph type=\"dt\" idx=\"1\"/></p:nvPr></p:nvSpPr>"
+            + $"<p:spPr>{Xfrm(dt)}</p:spPr>{Banner("r", DateField)}</p:sp>"
+
+            + "<p:sp><p:nvSpPr><p:cNvPr id=\"4\" name=\"Slide Image Placeholder 3\"/>"
+            + "<p:cNvSpPr><a:spLocks noGrp=\"1\" noRot=\"1\" noChangeAspect=\"1\"/></p:cNvSpPr>"
+            + "<p:nvPr><p:ph type=\"sldImg\" idx=\"2\"/></p:nvPr></p:nvSpPr>"
+            + $"<p:spPr>{Xfrm(img)}<a:noFill/>"
+            + "<a:ln w=\"12700\"><a:solidFill><a:prstClr val=\"black\"/></a:solidFill></a:ln></p:spPr>"
+            + "<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:endParaRPr lang=\"en-US\"/></a:p></p:txBody></p:sp>"
+
+            + "<p:sp><p:nvSpPr><p:cNvPr id=\"5\" name=\"Notes Placeholder 4\"/>"
+            + "<p:cNvSpPr><a:spLocks noGrp=\"1\"/></p:cNvSpPr>"
+            + "<p:nvPr><p:ph type=\"body\" sz=\"quarter\" idx=\"3\"/></p:nvPr></p:nvSpPr>"
+            + $"<p:spPr>{Xfrm(body)}</p:spPr>"
+            + "<p:txBody><a:bodyPr vert=\"horz\" lIns=\"91440\" tIns=\"45720\" rIns=\"91440\" bIns=\"45720\"/>"
+            + "<a:lstStyle/><a:p><a:endParaRPr lang=\"en-US\"/></a:p></p:txBody></p:sp>"
+
+            + "<p:sp><p:nvSpPr><p:cNvPr id=\"6\" name=\"Footer Placeholder 5\"/>"
+            + "<p:cNvSpPr><a:spLocks noGrp=\"1\"/></p:cNvSpPr>"
+            + "<p:nvPr><p:ph type=\"ftr\" sz=\"quarter\" idx=\"4\"/></p:nvPr></p:nvSpPr>"
+            + $"<p:spPr>{Xfrm(ftr)}</p:spPr>{Banner("l", null)}</p:sp>"
+
+            + "<p:sp><p:nvSpPr><p:cNvPr id=\"7\" name=\"Slide Number Placeholder 6\"/>"
+            + "<p:cNvSpPr><a:spLocks noGrp=\"1\"/></p:cNvSpPr>"
+            + "<p:nvPr><p:ph type=\"sldNum\" sz=\"quarter\" idx=\"5\"/></p:nvPr></p:nvSpPr>"
+            + $"<p:spPr>{Xfrm(num)}</p:spPr>{Banner("r", SlideNumField)}</p:sp>"
+
+            + "</p:spTree></p:cSld>"
+            + "<p:clrMap bg1=\"lt1\" tx1=\"dk1\" bg2=\"lt2\" tx2=\"dk2\" accent1=\"accent1\" "
+            + "accent2=\"accent2\" accent3=\"accent3\" accent4=\"accent4\" accent5=\"accent5\" "
+            + "accent6=\"accent6\" hlink=\"hlink\" folHlink=\"folHlink\"/>"
+            + notesStyle
+            + "</p:notesMaster>";
+    }
+
     private static NotesSlidePart EnsureNotesSlidePart(SlidePart slidePart)
     {
         if (slidePart.NotesSlidePart != null) return slidePart.NotesSlidePart;
@@ -204,8 +424,21 @@ public partial class PowerPointHandler
                         )
                     )
                 )
-            )
+            ),
+            // Notes slides inherit the notes master's color map verbatim.
+            new ColorMapOverride(new Drawing.MasterColorMapping())
         );
+
+        // The notes slide's placeholders carry an empty <p:spPr/> and inherit
+        // geometry and text style from the notes master, so the master must
+        // exist and be related from this part. Without it the notes text has no
+        // position or size anywhere in the package. PowerPoint also links the
+        // notes slide back to its slide; mirror that.
+        var presentationPart = (slidePart.OpenXmlPackage as PresentationDocument)?.PresentationPart;
+        if (presentationPart != null)
+            notesPart.AddPart(EnsureNotesMasterPart(presentationPart));
+        notesPart.AddPart(slidePart);
+
         notesPart.NotesSlide.Save();
         return notesPart;
     }


### PR DESCRIPTION
Fix #255  

Speaker notes are written without the package relationships they depend on. Two places produce an orphaned notes slide; both leave the notes with no geometry and a dangling reference, and both are invisible to text extraction and to `officecli validate`.

## Defect 1 — notes slides have no notes master to inherit from

Adding speaker notes writes `ppt/notesSlides/notesSlideN.xml` and nothing else:

| Part | PowerPoint | officecli 1.0.140 |
|---|---|---|
| `ppt/notesSlides/notesSlide1.xml` | ✅ | ✅ |
| `ppt/notesSlides/_rels/notesSlide1.xml.rels` | ✅ | ❌ missing |
| `ppt/notesMasters/notesMaster1.xml` | ✅ | ❌ missing |
| `ppt/notesMasters/_rels/notesMaster1.xml.rels` | ✅ | ❌ missing |
| `<p:notesMasterIdLst>` in `presentation.xml` | ✅ | ❌ missing |

Notes placeholders deliberately carry an empty `<p:spPr/>` and **inherit** position, size and text style from the notes master. With no master in the package and no relationship to one, the notes text has no geometry anywhere in the file.

```python
from pptx import Presentation
Presentation("notes.pptx").slides[0].notes_slide
# KeyError: "no relationship of type '.../notesMaster' in collection"
```

**Root cause.** `EnsureNotesSlidePart` (`PowerPointHandler.Notes.cs`) calls `AddNewPart<NotesSlidePart>()` and builds the XML but never creates a master. The equivalent creation code already exists — only on the raw-set `/notesMaster` dump-replay path (`PowerPointHandler.cs`), which the `add`/`set` notes verbs never reach.

## Defect 2 — duplicated notes drop their own pictures and hyperlinks

`CloneSlide` copies the notes slide's XML but none of the notes part's sub-parts: `CopySlideParts` walks the **slide's** parts and explicitly skips `NotesSlidePart`, and nothing walked the notes part itself. A slide whose speaker notes contain a picture or an external hyperlink clones into a notes slide that still carries `r:embed` / `r:id` in its XML while the matching relationships stay behind on the source — a dangling reference, which is what makes PowerPoint offer to repair the file.

This one bites **even in decks that already have a valid notes master**, including PowerPoint-authored ones.

## Fix

`EnsureNotesMasterPart` builds `notesMaster1.xml` with PowerPoint's own six placeholders, gives it a theme, and registers `<p:notesMasterIdLst>` in schema position (`sldMasterIdLst` → `notesMasterIdLst` → `sldIdLst`). Notes slides now relate to it, carry `<p:clrMapOvr>`, and link back to their slide the way PowerPoint does. The two raw-replay sites that created a bare `NotesSlidePart` to host a notes image or hyperlink now route through `EnsureNotesSlidePart`, so all four creation paths behave identically.

An existing notes master is always **reused untouched** — registration tests `notesMasterId` entries for a resolvable `r:id` rather than the list's mere presence, so an empty or stale `<p:notesMasterIdLst>` is repaired instead of leaving the new part an orphan reference.

For defect 2, `CopySlideParts` already had the right logic — part sharing vs deep copy, the `NeedsDeepCopy` gate, external and hyperlink relationships, and an old-rId → new-rId map — it was just hard-wired to `SlidePart`. Its helpers were already generic over `OpenXmlPartContainer`, so the body moves unchanged into `CopyPartsAndRelationships(source, target, skip)`; `CopySlideParts` and the new `CopyNotesSlideParts` are thin wrappers that supply their own skip predicate and replay the map over their own root element.

### Geometry

The slide-image placeholder is a thumbnail of the slide, so its height follows the deck's aspect ratio rather than a fixed number; the notes body snaps to the next quarter-inch grid line below it. This reproduces PowerPoint's stock numbers exactly on both common aspect ratios:

| | slide-image `ext` | notes body `off y` |
|---|---|---|
| 16:9 | `4572000 x 2571750` | `3429000` |
| 4:3 | `4572000 x 3429000` | `4343400` |

Both are clamped so a tall thumbnail on an unusual `<p:notesSz>` cannot push the body into the footer band.

The master gets its own cloned theme rather than sharing the presentation's — `GrowSlideMasterParts` already clones for grown slide masters, `PptxBatchEmitter` emits `add-part theme /notesMaster` whenever the notes master has a theme, and sharing made every `dump` → `batch` round-trip grow a duplicate theme part.

## Validation

### Defect 1

```bash
officecli create notes.pptx
officecli add notes.pptx / --type slide
officecli add notes.pptx "/slide[1]" --type notes --prop "text=Emphasize the Q3 number here."
unzip -l notes.pptx | grep -i notes
```

**Before** — one part, no rels, no master:
```
ppt/notesSlides/notesSlide1.xml
```

**After:**
```
ppt/notesSlides/notesSlide1.xml
ppt/notesSlides/_rels/notesSlide1.xml.rels
ppt/notesMasters/notesMaster1.xml
ppt/notesMasters/_rels/notesMaster1.xml.rels
ppt/notesMasters/theme/theme2.xml
```

```python
from pptx import Presentation
ns = Presentation("notes.pptx").slides[0].notes_slide
ph = ns.notes_placeholder
print(repr(ns.notes_text_frame.text), (ph.left, ph.top, ph.width, ph.height))
```

**Before:** `KeyError: "no relationship of type '.../notesMaster'"` ❌
**After:** `'Emphasize the Q3 number here.' (685800, 3429000, 5486400, 4114800)` ✓ — matching the reference deck's inherited geometry.

### Defect 2

Attach an image part to the notes slide, reference it from a `<p:pic>` in the notes shape tree, then duplicate the slide:

```bash
officecli add deck.pptx / --from "/slide[1]"
```

Comparing each notes slide's `r:embed` / `r:id` references against its own `.rels`:

**Before:**
```
notesSlide1  dangling=NONE
notesSlide2  dangling=['rIdNotesImg1']     ❌ reference with no relationship
```

**After:**
```
notesSlide1  dangling=NONE  types=['image', 'notesMaster', 'slide']
notesSlide2  dangling=NONE  types=['image', 'notesMaster', 'slide']     ✓
```

The clone's `r:embed` is remapped to its own new rId; the image part is shared rather than duplicated, matching how the slide path treats images.

### Checked

- **All four notes paths** — `add --type notes`, `set /slide[N]/notes`, slide duplication, and `dump` → `batch` replay: notes resolve in python-pptx on every one
- **Clone of a clone** — image rId remapped again cleanly, still no dangling references
- **External hyperlinks in notes** survive duplication alongside images
- **Round-trip stability** — `dump` → `batch` → `dump` is now part-list and op-count identical across generations (previously grew a theme part every cycle)
- **Existing masters untouched** — a PowerPoint-authored deck edited by officecli keeps `notesMaster1.xml` byte-identical (md5 unchanged) and its theme count unchanged; exactly one master, never duplicated
- **4:3 and 16:9** decks both reproduce PowerPoint's stock placeholder geometry
- **Degenerate `<p:notesSz>`** (wide/short notes page) — body stays above the footer with positive height
- **Empty `<p:notesMasterIdLst>`** injected by hand — repaired rather than left orphaned
- **Slide-path regression** — duplicating a slide with a picture still shares one media part and remaps correctly; chart deep-copy still produces a distinct part (`chart2` → `chart3`) rather than a share, which real PowerPoint rejects
- **No spurious parts** — all four decks in `examples/` round-trip with 0 failures and gain no notes parts
- `officecli validate` passes on every artifact; `dotnet build -c Release` clean apart from the pre-existing `CS8602` in `ExcelHandler.SheetShift.cs:538`

## Atomicity (Rule 1)

Two commits, deliberately in one PR. Rule 1's self-check is whether the pieces *could be merged or reverted independently* — these cannot. The duplication fix calls `EnsureNotesMasterPart`, introduced by the first commit; split out, it does not apply to `main`. Submitted separately, the second PR would either be blocked until the first merged or would have to carry the first's diff anyway.

They are also the same defect class with a single observable symptom: a notes slide referencing relationships that are not in its `.rels`. Landing only one leaves speaker notes still emitting orphaned parts on the other path.

The commits are kept separate so each root cause stays reviewable and revertible in isolation within the PR.

## Note

`officecli validate` cannot detect this class of bug — it passed on the broken file at every stage of this work. It checks part schemas, not the package relationship graph, so orphaned parts and missing implicit relationships are invisible to it. Worth a separate issue.
