### PR TITLE
Preserve Excel drawing hyperlinks and grouped shapes during round-trip

### DIFF
--- a/schemas/help/xlsx/shape.json
+++ b/schemas/help/xlsx/shape.json
@@ -19,6 +19,20 @@
   "note": "Aliases: textbox. Anchor: 'anchor=B2:F7' (cell range) or x/y/width/height in cell units. 'ref=B2' expands to a 1x1 cell rectangle. Font/text props accept either bare ('size', 'bold', 'color', 'font') or dotted ('font.size', 'font.bold', 'font.color', 'font.name') forms.",
   "extends": "_shared/shape",
   "properties": {
+    "hyperlink": {
+      "type": "string",
+      "description": "Shape-level hyperlink. External URL (https://...) or in-document jump (#SheetName!A1).",
+      "aliases": [
+        "link"
+      ],
+      "add": true,
+      "set": false,
+      "get": true,
+      "examples": [
+        "--prop hyperlink=#Sheet2!A1"
+      ],
+      "enforcement": "report"
+    },
     "reflection": {
       "type": "string",
       "description": "reflection effect. Accepts 'true' / 'tight' / 'half' / 'full' to enable a reflection of varying length, a numeric percentage 0-100, or 'none' to clear.",

--- a/src/officecli/Handlers/DocumentHandlerFactory.cs
+++ b/src/officecli/Handlers/DocumentHandlerFactory.cs
@@ -71,26 +71,26 @@ public static class DocumentHandlerFactory
         // `dump`/`query` traversal — where it escapes this try/catch and crashes
         // the command. Real producers ship such decks (e.g. a diagramDrawing
         // rId pointing at a diagrams/drawingN.xml that was never written) and
-        // PowerPoint tolerates them. Strip the dangling rels up-front so every
-        // command (not just Open) survives, reusing the same in-place repair the
-        // reactive path uses. The scan is read-only and only rewrites when a
-        // dangling rel is actually present, so the clean-file path pays only a
-        // cheap .rels read.
-        if ((ext is ".docx" or ".xlsx" or ".pptx") && HasDanglingInternalRels(filePath))
+        // PowerPoint tolerates them. For editable handlers, strip the dangling
+        // rels up-front so every mutating command survives. A read-only open
+        // must never rewrite the caller's source file as a side effect.
+        if (editable
+            && (ext is ".docx" or ".xlsx" or ".pptx")
+            && HasDanglingInternalRels(filePath))
             StripDanglingPackageRels(filePath);
 
         try
         {
             return OpenHandler(filePath, ext, editable);
         }
-        catch (Exception ex) when (IsEncodingException(ex))
+        catch (Exception ex) when (editable && IsEncodingException(ex))
         {
             // Files created by python-pptx (lxml) use encoding="ascii" which Open XML SDK rejects.
             // Fix the XML declarations in-place and retry.
             FixXmlEncoding(filePath);
             return OpenHandler(filePath, ext, editable);
         }
-        catch (Exception ex) when (IsDanglingPartException(ex))
+        catch (Exception ex) when (editable && IsDanglingPartException(ex))
         {
             // Some producers strip a part (e.g. a sensitivity-label
             // docMetadata/LabelInfo.xml) but leave its relationship behind.
@@ -405,10 +405,28 @@ public static class DocumentHandlerFactory
     /// </summary>
     private static string? ResolveInternalRelTarget(System.Xml.Linq.XElement rel, string baseDir)
     {
+        // Hyperlink targets are URI references, not package parts. Excel can
+        // store a drawing hyperlink such as "#Sheet1!A1" in drawingN.xml.rels
+        // without TargetMode="External". Treating that target as an OPC part
+        // makes the dangling-rel repair delete the relationship while leaving
+        // <a:hlinkClick r:id="..."> behind, and Excel then repairs drawingN.xml.
+        var relationshipType = (string?)rel.Attribute("Type");
+        if (relationshipType?.EndsWith("/hyperlink", StringComparison.OrdinalIgnoreCase) == true)
+            return null;
+
         if (string.Equals((string?)rel.Attribute("TargetMode"), "External", StringComparison.OrdinalIgnoreCase))
             return null;
         var target = (string?)rel.Attribute("Target");
         if (string.IsNullOrEmpty(target)) return null;
+        if (target.StartsWith("#", StringComparison.Ordinal)) return null;
+
+        // A non-hyperlink internal relationship may legally carry a fragment;
+        // only the URI path identifies the package part.
+        var fragmentIndex = target.IndexOf('#');
+        if (fragmentIndex >= 0)
+            target = target.Substring(0, fragmentIndex);
+        if (target.Length == 0) return null;
+
         var resolved = target.StartsWith("/")
             ? target.TrimStart('/')
             : (baseDir.Length > 0 ? baseDir + "/" + target : target);

--- a/src/officecli/Handlers/Excel/ExcelBatchEmitter.Elements.cs
+++ b/src/officecli/Handlers/Excel/ExcelBatchEmitter.Elements.cs
@@ -29,7 +29,7 @@ public static partial class ExcelBatchEmitter
         EmitSparklines(xl, sheetPath, counts.Sparklines, items, warnings);
         var drawingCounts = xl.GetDumpDrawingCounts(sheetName);
         EmitPictures(xl, sheetName, sheetPath, drawingCounts.Pictures, items, warnings);
-        EmitShapes(xl, sheetPath, drawingCounts.Shapes, items, warnings);
+        EmitShapes(xl, sheetName, sheetPath, items, warnings);
         EmitOles(xl, sheetName, sheetPath, items, warnings);
         EmitAutoFilterCriteria(xl, sheetPath, items, warnings);
     }
@@ -603,15 +603,37 @@ public static partial class ExcelBatchEmitter
 
     // ==================== Shapes ====================
 
-    private static void EmitShapes(ExcelHandler xl, string sheetPath, int count,
+    private static void EmitShapes(ExcelHandler xl, string sheetName, string sheetPath,
         List<BatchItem> items, List<UnsupportedWarning> warnings)
     {
         // Skip mc:Fallback placeholder shapes (slicer down-level rectangles):
         // the owning feature regenerates them on replay; re-adding them as
         // real shapes duplicates content and breaks dump idempotency.
         var fallbackFlags = xl.GetDumpShapeFallbackFlags(sheetPath.TrimStart('/'));
-        for (int i = 1; i <= count; i++)
+        var replayItems = xl.GetDumpShapeReplayItems(sheetName);
+        foreach (var replay in replayItems)
         {
+            if (replay.GroupAnchorXml != null)
+            {
+                var groupProps = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["anchor-xml"] = replay.GroupAnchorXml,
+                    ["hyperlinks"] = ExcelHandler.EncodeDumpDrawingHyperlinks(replay.GroupHyperlinks),
+                };
+                items.Add(new BatchItem
+                {
+                    Command = "add-part",
+                    Parent = sheetPath,
+                    Type = "drawing-group",
+                    Props = groupProps,
+                });
+                continue;
+            }
+
+            if (!replay.ShapeIndex.HasValue) continue;
+            var i = replay.ShapeIndex.Value;
+            if (!string.IsNullOrEmpty(replay.Warning))
+                warnings.Add(new UnsupportedWarning("group", $"{sheetPath}/shape[{i}]", replay.Warning));
             if (i - 1 < fallbackFlags.Count && fallbackFlags[i - 1]) continue;
             DocumentNode shp;
             try { shp = xl.Get($"{sheetPath}/shape[{i}]"); }
@@ -641,6 +663,7 @@ public static partial class ExcelBatchEmitter
             CopyValue(shp, "rotation", props, "rotation");
             CopyString(shp, "flip", props, "flip");
             CopyString(shp, "line", props, "line");
+            CopyString(shp, "hyperlink", props, "hyperlink");
             // Effect + text-inset props. Get surfaces them (shadow=#000000,
             // glow=#4472C4-8, softEdge=5pt, margin=7.2pt) and Add re-consumes
             // those exact forms, but the copy-list omitted them so dump dropped

--- a/src/officecli/Handlers/Excel/ExcelHandler.Add.Drawings.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Add.Drawings.cs
@@ -531,10 +531,10 @@ public partial class ExcelHandler
         }
 
         // P8: picture-level hyperlink — <a:hlinkClick> under <xdr:cNvPr>.
-        // External URL → add rel on DrawingsPart, reference its rId.
-        // Internal (starts with '#') → no rel, use Location attribute.
-        // CONSISTENCY(xlsx-hyperlink): mirrors cell link handling in
-        // commit 60e1455.
+        // DrawingML hyperlinks always reference a relationship. Internal
+        // workbook jumps use a non-external hyperlink relationship whose
+        // target is a fragment such as "#Sheet2!A1"; @location is not part of
+        // CT_Hyperlink and makes the drawing schema-invalid.
         var picHlink = properties.GetValueOrDefault("hyperlink")
             ?? properties.GetValueOrDefault("link");
         if (!string.IsNullOrWhiteSpace(picHlink))
@@ -542,22 +542,13 @@ public partial class ExcelHandler
             var picCNvPr = anchor.Descendants<XDR.NonVisualDrawingProperties>().FirstOrDefault();
             if (picCNvPr != null)
             {
-                Drawing.HyperlinkOnClick hlClick;
-                if (picHlink.StartsWith("#"))
-                {
-                    // No rel, no @r:id — pure in-document jump via @location.
-                    hlClick = new Drawing.HyperlinkOnClick { Id = "" };
-                    hlClick.SetAttribute(new OpenXmlAttribute(
-                        "", "location", "", picHlink.Substring(1)));
-                }
-                else
-                {
-                    // CONSISTENCY(hyperlink-scheme-allowlist).
+                var isInternal = picHlink.StartsWith("#", StringComparison.Ordinal);
+                if (!isInternal)
                     Core.HyperlinkUriValidator.RequireSafeScheme(picHlink, "link");
-                    var hlUri = new Uri(picHlink, UriKind.RelativeOrAbsolute);
-                    var hlRel = picDrawingsPart.AddHyperlinkRelationship(hlUri, isExternal: true);
-                    hlClick = new Drawing.HyperlinkOnClick { Id = hlRel.Id };
-                }
+                var hlUri = new Uri(picHlink, UriKind.RelativeOrAbsolute);
+                var hlRel = picDrawingsPart.AddHyperlinkRelationship(
+                    hlUri, isExternal: !isInternal);
+                var hlClick = new Drawing.HyperlinkOnClick { Id = hlRel.Id };
                 picCNvPr.AppendChild(hlClick);
             }
         }
@@ -900,6 +891,25 @@ public partial class ExcelHandler
             spPr,
             txBody
         );
+
+        // Shape-level hyperlinks use the same relationship-backed DrawingML
+        // representation as pictures. Internal workbook jumps are non-external
+        // relationships targeting a #Sheet!A1 fragment.
+        var shpHlink = properties.GetValueOrDefault("hyperlink")
+            ?? properties.GetValueOrDefault("link");
+        if (!string.IsNullOrWhiteSpace(shpHlink))
+        {
+            var isInternal = shpHlink.StartsWith("#", StringComparison.Ordinal);
+            if (!isInternal)
+                Core.HyperlinkUriValidator.RequireSafeScheme(shpHlink, "link");
+            var hlUri = new Uri(shpHlink, UriKind.RelativeOrAbsolute);
+            var hlRel = shpDrawingsPart.AddHyperlinkRelationship(
+                hlUri, isExternal: !isInternal);
+            var hlClick = new Drawing.HyperlinkOnClick { Id = hlRel.Id };
+            shape.NonVisualShapeProperties?
+                .GetFirstChild<XDR.NonVisualDrawingProperties>()?
+                .AppendChild(hlClick);
+        }
 
         var shpAnchor = new XDR.TwoCellAnchor(
             new XDR.FromMarker(

--- a/src/officecli/Handlers/Excel/ExcelHandler.Add.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Add.cs
@@ -1086,6 +1086,89 @@ public partial class ExcelHandler
                 var chartIdx = drawingsPart.ChartParts.ToList().IndexOf(chartPart);
                 return (relId, $"/{sheetName}/chart[{chartIdx + 1}]");
 
+            case "drawing-group":
+            {
+                // Verbatim DrawingML group carrier for xlsx dump→batch.
+                // The full hosting anchor is preserved because flattening a
+                // <xdr:grpSp> loses the child coordinate system, z-order,
+                // styles and the fact that the objects are grouped. Only
+                // hyperlink relationships are carried here; dump falls back
+                // to semantic leaf shapes when a group references package
+                // parts such as images/charts.
+                var groupSheetName = parentPartPath.TrimStart('/');
+                var groupWorksheet = FindWorksheet(groupSheetName)
+                    ?? throw new ArgumentException(
+                        $"Sheet not found: {groupSheetName}. drawing-group must be added under a sheet.");
+                properties ??= new Dictionary<string, string>();
+                var anchorXml = properties.GetValueOrDefault("anchor-xml")
+                    ?? throw new ArgumentException(
+                        "'anchor-xml' property is required for drawing-group (verbatim xdr anchor XML)");
+
+                XDR.TwoCellAnchor groupAnchor;
+                try
+                {
+                    groupAnchor = new XDR.TwoCellAnchor(anchorXml);
+                }
+                catch (Exception ex)
+                {
+                    throw new ArgumentException(
+                        $"drawing-group anchor XML is not a valid xdr:twoCellAnchor: {ex.Message}", ex);
+                }
+                if (groupAnchor.GetFirstChild<XDR.GroupShape>() == null)
+                    throw new ArgumentException(
+                        "drawing-group anchor XML must contain a top-level xdr:grpSp.");
+
+                List<DumpDrawingHyperlinkSpec> groupHyperlinks;
+                try
+                {
+                    groupHyperlinks = DecodeDumpDrawingHyperlinks(
+                        properties.GetValueOrDefault("hyperlinks") ?? "");
+                }
+                catch (FormatException ex)
+                {
+                    throw new ArgumentException(
+                        $"drawing-group 'hyperlinks' carrier is invalid: {ex.Message}", ex);
+                }
+
+                Modified = true;
+                var groupDrawingsPart = groupWorksheet.DrawingsPart
+                    ?? groupWorksheet.AddNewPart<DrawingsPart>();
+                if (groupDrawingsPart.WorksheetDrawing == null)
+                {
+                    groupDrawingsPart.WorksheetDrawing = new XDR.WorksheetDrawing();
+                    groupDrawingsPart.WorksheetDrawing.Save();
+                }
+                var groupSheet = GetSheet(groupWorksheet);
+                if (groupSheet.GetFirstChild<SpreadsheetDrawing>() == null)
+                {
+                    var drawingRelId = groupWorksheet.GetIdOfPart(groupDrawingsPart);
+                    groupSheet.Append(new SpreadsheetDrawing { Id = drawingRelId });
+                    SaveWorksheet(groupWorksheet);
+                }
+
+                // Relationship IDs are scoped to the destination drawing part.
+                // Create fresh IDs (avoids collisions with pictures/charts
+                // emitted earlier), then rewrite every r:id/r:embed/r:link in
+                // the verbatim group anchor that referenced the source ID.
+                foreach (var hyperlink in groupHyperlinks)
+                {
+                    if (string.IsNullOrEmpty(hyperlink.Id) || string.IsNullOrEmpty(hyperlink.Target))
+                        throw new ArgumentException(
+                            "drawing-group hyperlink entries require non-empty Id and Target.");
+                    var uri = new Uri(hyperlink.Target, UriKind.RelativeOrAbsolute);
+                    var replayRel = groupDrawingsPart.AddHyperlinkRelationship(
+                        uri, hyperlink.IsExternal);
+                    RemapDrawingRelationshipId(groupAnchor, hyperlink.Id, replayRel.Id);
+                }
+
+                groupDrawingsPart.WorksheetDrawing.AppendChild(groupAnchor);
+                groupDrawingsPart.WorksheetDrawing.Save();
+                var groupIndex = groupDrawingsPart.WorksheetDrawing
+                    .Elements<XDR.TwoCellAnchor>()
+                    .Count(a => a.GetFirstChild<XDR.GroupShape>() != null);
+                return ("group", $"/{groupSheetName}/group[{groupIndex}]");
+            }
+
             case "chartex":
             {
                 // Extended (cx:) chart carrier for dump→batch round-trip.
@@ -1258,7 +1341,24 @@ public partial class ExcelHandler
 
             default:
                 throw new ArgumentException(
-                    $"Unknown part type: {partType}. Supported: chart, chartex, ole");
+                    $"Unknown part type: {partType}. Supported: chart, chartex, drawing-group, ole");
+        }
+    }
+
+    private static void RemapDrawingRelationshipId(
+        OpenXmlElement root, string sourceId, string destinationId)
+    {
+        const string relNs =
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+        foreach (var element in root.Descendants().Prepend(root))
+        {
+            foreach (var attr in element.GetAttributes()
+                .Where(a => a.NamespaceUri == relNs && a.Value == sourceId)
+                .ToList())
+            {
+                element.SetAttribute(new OpenXmlAttribute(
+                    attr.Prefix, attr.LocalName, attr.NamespaceUri, destinationId));
+            }
         }
     }
 

--- a/src/officecli/Handlers/Excel/ExcelHandler.Helpers.Drawing.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Helpers.Drawing.cs
@@ -470,6 +470,151 @@ public partial class ExcelHandler
         }
     }
 
+    internal sealed class DumpDrawingHyperlinkSpec
+    {
+        public string Id { get; set; } = "";
+        public string Target { get; set; } = "";
+        public bool IsExternal { get; set; }
+    }
+
+    internal sealed class DumpShapeReplayItem
+    {
+        // Exactly one of ShapeIndex / GroupAnchorXml is populated.
+        public int? ShapeIndex { get; set; }
+        public string? GroupAnchorXml { get; set; }
+        public List<DumpDrawingHyperlinkSpec> GroupHyperlinks { get; set; } = [];
+        public string? Warning { get; set; }
+    }
+
+    // Compact, trimming-safe carrier used inside the dump JSON string value:
+    // base64(id),base64(target),0|1 entries separated by '|'. Base64 never
+    // contains ',' or '|', so no reflection-based JSON serializer is needed
+    // inside the single-file published executable.
+    internal static string EncodeDumpDrawingHyperlinks(
+        IEnumerable<DumpDrawingHyperlinkSpec> hyperlinks)
+    {
+        static string B64(string value) => Convert.ToBase64String(
+            System.Text.Encoding.UTF8.GetBytes(value));
+        return string.Join("|", hyperlinks.Select(h =>
+            $"{B64(h.Id)},{B64(h.Target)},{(h.IsExternal ? "1" : "0")}"));
+    }
+
+    internal static List<DumpDrawingHyperlinkSpec> DecodeDumpDrawingHyperlinks(
+        string encoded)
+    {
+        static string FromB64(string value) => System.Text.Encoding.UTF8.GetString(
+            Convert.FromBase64String(value));
+        var result = new List<DumpDrawingHyperlinkSpec>();
+        if (string.IsNullOrEmpty(encoded)) return result;
+        foreach (var entry in encoded.Split('|', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var fields = entry.Split(',');
+            if (fields.Length != 3 || (fields[2] != "0" && fields[2] != "1"))
+                throw new FormatException(
+                    "Expected base64(id),base64(target),0|1 entries separated by '|'.");
+            result.Add(new DumpDrawingHyperlinkSpec
+            {
+                Id = FromB64(fields[0]),
+                Target = FromB64(fields[1]),
+                IsExternal = fields[2] == "1",
+            });
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Build the dump replay sequence for worksheet shapes without destroying
+    /// real DrawingML groups. A grouped TwoCellAnchor is carried verbatim when
+    /// every relationship referenced inside it is a hyperlink relationship;
+    /// those lightweight relationships can be recreated safely on replay.
+    ///
+    /// Groups that reference package parts (pictures/charts/etc.) fall back to
+    /// the existing leaf-shape path with an explicit warning. Copying those
+    /// parts requires a recursive part-graph carrier and raw XML alone would
+    /// leave dangling r:embed/r:id values.
+    /// </summary>
+    internal List<DumpShapeReplayItem> GetDumpShapeReplayItems(string sheetName)
+    {
+        var result = new List<DumpShapeReplayItem>();
+        var worksheet = FindWorksheet(sheetName);
+        var drawingsPart = worksheet?.DrawingsPart;
+        var wsDrawing = drawingsPart?.WorksheetDrawing;
+        if (drawingsPart == null || wsDrawing == null) return result;
+
+        const string relNs =
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+        int leafIndex = 0;
+
+        foreach (var anchor in wsDrawing.Elements<XDR.TwoCellAnchor>())
+        {
+            var leaves = anchor.Descendants<XDR.Shape>().ToList();
+            var firstLeafIndex = leafIndex + 1;
+            leafIndex += leaves.Count;
+
+            var group = anchor.GetFirstChild<XDR.GroupShape>();
+            if (group == null)
+            {
+                for (int i = 0; i < leaves.Count; i++)
+                    result.Add(new DumpShapeReplayItem { ShapeIndex = firstLeafIndex + i });
+                continue;
+            }
+
+            var referencedIds = anchor
+                .Descendants()
+                .Prepend(anchor)
+                .SelectMany(e => e.GetAttributes())
+                .Where(a => a.NamespaceUri == relNs
+                    && (a.LocalName == "id" || a.LocalName == "embed" || a.LocalName == "link")
+                    && !string.IsNullOrEmpty(a.Value))
+                .Select(a => a.Value!)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+            var hyperlinks = new List<DumpDrawingHyperlinkSpec>();
+            var unsupportedIds = new List<string>();
+            foreach (var rid in referencedIds)
+            {
+                var hyperlink = drawingsPart.HyperlinkRelationships
+                    .FirstOrDefault(r => r.Id == rid);
+                if (hyperlink == null)
+                {
+                    unsupportedIds.Add(rid);
+                    continue;
+                }
+                hyperlinks.Add(new DumpDrawingHyperlinkSpec
+                {
+                    Id = hyperlink.Id ?? rid,
+                    Target = hyperlink.Uri.ToString(),
+                    IsExternal = hyperlink.IsExternal,
+                });
+            }
+
+            if (unsupportedIds.Count == 0)
+            {
+                result.Add(new DumpShapeReplayItem
+                {
+                    GroupAnchorXml = anchor.OuterXml,
+                    GroupHyperlinks = hyperlinks,
+                });
+                continue;
+            }
+
+            var warning =
+                $"grouped drawing references non-hyperlink relationship(s) {string.Join(", ", unsupportedIds)}; "
+                + "the group was flattened because its dependent package parts cannot yet be carried safely";
+            for (int i = 0; i < leaves.Count; i++)
+            {
+                result.Add(new DumpShapeReplayItem
+                {
+                    ShapeIndex = firstLeafIndex + i,
+                    Warning = i == 0 ? warning : null,
+                });
+            }
+        }
+
+        return result;
+    }
+
     private DocumentNode? GetShapeNode(string sheetName, WorksheetPart worksheetPart, int index, string path)
     {
         var drawingsPart = worksheetPart.DrawingsPart;
@@ -490,6 +635,28 @@ public partial class ExcelHandler
         var nvProps = shape.NonVisualShapeProperties?.GetFirstChild<XDR.NonVisualDrawingProperties>();
         if (nvProps?.Name?.Value != null)
             node.Format["name"] = nvProps.Name.Value;
+
+        // Shape hyperlinks live under <xdr:cNvPr><a:hlinkClick>. Group shapes
+        // are flattened to leaf shapes for Get/dump, so preserve each leaf link.
+        if (nvProps != null)
+        {
+            var shapeHlink = nvProps.GetFirstChild<Drawing.HyperlinkOnClick>();
+            if (shapeHlink != null)
+            {
+                if (!string.IsNullOrEmpty(shapeHlink.Id?.Value))
+                {
+                    var rel = drawingsPart.HyperlinkRelationships
+                        .FirstOrDefault(r => r.Id == shapeHlink.Id.Value);
+                    if (rel != null) node.Format["hyperlink"] = rel.Uri.ToString();
+                }
+                else
+                {
+                    var loc = shapeHlink.GetAttributes()
+                        .FirstOrDefault(a => a.LocalName == "location").Value;
+                    if (!string.IsNullOrEmpty(loc)) node.Format["hyperlink"] = "#" + loc;
+                }
+            }
+        }
 
         // Text — shape TextBody has one <a:p> per paragraph, each with
         // zero-or-more <a:r>/<a:t> runs. Concatenate runs within a

--- a/src/officecli/Handlers/ExcelHandler.cs
+++ b/src/officecli/Handlers/ExcelHandler.cs
@@ -485,6 +485,21 @@ public partial class ExcelHandler : IDocumentHandler, Rendering.IRenderModelHost
             _filteredPackageStream = null;
             return;
         }
+        if (!Modified)
+        {
+            // A read-only inspection must be byte-preserving even when a caller
+            // accidentally opened the handler in editable mode. Open XML SDK
+            // serializes package relationships during Save/Dispose, which can
+            // discard DrawingML hyperlink relationships it cannot round-trip.
+            // Close the backing stream first so any dispose-time autosave has
+            // nowhere to write, then discard the in-memory package.
+            _backingStream?.Dispose();
+            _backingStream = null;
+            try { _doc.Dispose(); } catch { /* autosave hit the closed stream — intended */ }
+            _filteredPackageStream?.Dispose();
+            _filteredPackageStream = null;
+            return;
+        }
         try { FlushDirtyParts(); } catch { /* best-effort */ }
         // Mirror the PPT/Word pattern: when we own the backing FileStream the
         // package would otherwise leave the on-disk file in whatever state


### PR DESCRIPTION
## Summary
- Preserve Excel drawing and shape hyperlinks during open/close and dump → create/batch round-trips.
- Preserve grouped DrawingML shapes as grouped anchors instead of flattening or dropping them.
- Avoid rewriting unchanged or read-only workbooks and exclude valid hyperlink relationships from dangling-relationship repair.

## Details
- Rebuild internal and external drawing hyperlink relationships with valid relationship-backed IDs.
- Add a drawing-group replay carrier that preserves the original group XML and remaps relationship IDs safely.
- Add shape hyperlink schema support.
- Keep grouped shapes with unsupported package-part dependencies intact with a warning instead of creating dangling relationships.

## Validation
- Read-only open → close leaves the source workbook byte-identical.
- Group dump emits one group and no flattened top-level shapes.
- Batch succeeds and validation passes.
- The result retains the group, child shapes, anchors, and hyperlink.
- Opening and closing the result leaves it byte-identical.
- Standalone internal shape hyperlink validation passes.

There is one unrelated pre-existing nullable warning in ExcelHandler.SheetShift.cs.