### PR TITLE
fix(xlsx): SUBTOTAL ignores AutoFilter-hidden rows (1-11) and all hidden rows (101-111)

### DIFF
--- a/src/officecli/Core/Formula/FormulaEvaluator.Functions.cs
+++ b/src/officecli/Core/Formula/FormulaEvaluator.Functions.cs
@@ -512,7 +512,8 @@ internal partial class FormulaEvaluator
     private FormulaResult? EvalSubtotal(List<object> args)
     {
         if (args.Count < 2 || args[0] is not FormulaResult fn) return null;
-        var code = (int)fn.AsNumber() % 100; // 101-111 -> 1-11 (ignore-hidden simplification)
+        var raw = (int)fn.AsNumber(); // 1-11, or 101-111 which also ignores manually-hidden rows
+        var code = raw % 100;         // collapse 101-111 -> 1-11 for the aggregate-name switch
         var name = code switch
         {
             1 => "AVERAGE", 2 => "COUNT", 3 => "COUNTA", 4 => "MAX", 5 => "MIN",
@@ -520,20 +521,25 @@ internal partial class FormulaEvaluator
             _ => null
         };
         // Excel ignores any cell in the range whose own formula is a nested
-        // SUBTOTAL/AGGREGATE (all codes 1-11 and 101-111), so a grand total
-        // over a column of section subtotals doesn't double-count them.
+        // SUBTOTAL/AGGREGATE (all codes 1-11 and 101-111), so a grand total over a
+        // column of section subtotals doesn't double-count them; it also drops rows
+        // hidden by an AutoFilter (codes 1-11) or any hidden row (codes 101-111).
         return name == null ? null
-            : EvalFunction(name, args.Skip(1).Select(ExcludeNestedSubtotalCells).ToList());
+            : EvalFunction(name, args.Skip(1).Select(a => ExcludeNestedSubtotalCells(a, raw)).ToList());
     }
 
     /// <summary>
-    /// Blank out cells whose own formula contains a SUBTOTAL/AGGREGATE call,
-    /// mirroring Excel's nested-subtotal exclusion. Only same-sheet ranges
-    /// that carry a reference origin (BaseRow &gt; 0) can be probed — the
-    /// cell-formula lookup (FindCell, as used by ISFORMULA) is current-sheet
-    /// only; anything else passes through unchanged.
+    /// Blank out cells the enclosing SUBTOTAL must skip: cells whose own formula
+    /// contains a nested SUBTOTAL/AGGREGATE call (Excel's nested-subtotal exclusion,
+    /// all codes), and — when <paramref name="subtotalCode"/> asks for it — cells on
+    /// hidden rows (codes 101-111 always; codes 1-11 when the sheet has an AutoFilter,
+    /// since OOXML can't distinguish a filter-hidden row from a manually-hidden one).
+    /// Only same-sheet ranges with a reference origin (BaseRow &gt; 0) can be probed —
+    /// FindCell (as used by ISFORMULA) is current-sheet only; anything else passes
+    /// through unchanged. Pass <paramref name="subtotalCode"/> 0 (e.g. from AGGREGATE)
+    /// to skip the hidden-row rule.
     /// </summary>
-    private object ExcludeNestedSubtotalCells(object arg)
+    private object ExcludeNestedSubtotalCells(object arg, int subtotalCode = 0)
     {
         // Range args reach SUBTOTAL either as a bare RangeData or wrapped in
         // a FormulaResult area; scalars (e.g. AGGREGATE's k) pass through.
@@ -545,11 +551,19 @@ internal partial class FormulaEvaluator
         };
         if (rd == null || rd.BaseRow <= 0 || !string.IsNullOrEmpty(rd.BaseSheet)) return arg;
 
+        var dropHidden = subtotalCode >= 101 || (subtotalCode is >= 1 and <= 11 && HasAutoFilter);
         FormulaResult?[,]? filtered = null;
         for (int r = 0; r < rd.Rows; r++)
         {
+            var rowHidden = dropHidden && IsRowHidden(rd.BaseRow + r);
             for (int c = 0; c < rd.Cols; c++)
             {
+                if (rowHidden)
+                {
+                    filtered ??= (FormulaResult?[,])rd.Cells.Clone();
+                    filtered[r, c] = null; // hidden row — excluded per SUBTOTAL's ignore-hidden rule
+                    continue;
+                }
                 var formula = FindCell($"{IndexToCol(rd.BaseCol + c)}{rd.BaseRow + r}")?.CellFormula?.Text;
                 if (formula == null) continue;
                 if (formula.IndexOf("SUBTOTAL", StringComparison.OrdinalIgnoreCase) < 0
@@ -591,7 +605,7 @@ internal partial class FormulaEvaluator
         // range, regardless of the options value (same rule as SUBTOTAL).
         // LARGE/SMALL (14/15) take a scalar k as the trailing arg — the
         // exclusion helper passes non-range args through untouched.
-        rest = rest.Select(ExcludeNestedSubtotalCells).ToList();
+        rest = rest.Select(a => ExcludeNestedSubtotalCells(a)).ToList();
         return EvalFunction(name, rest);
     }
 

--- a/src/officecli/Core/Formula/FormulaEvaluator.cs
+++ b/src/officecli/Core/Formula/FormulaEvaluator.cs
@@ -1431,6 +1431,24 @@ internal partial class FormulaEvaluator
         return _cellIndex.TryGetValue(cellRef, out var found) ? found : null;
     }
 
+    // Row-visibility index for SUBTOTAL's ignore-hidden semantics, built lazily like _cellIndex.
+    private Dictionary<int, bool>? _rowHiddenIndex;
+    internal bool IsRowHidden(int rowNumber)
+    {
+        if (_rowHiddenIndex == null)
+        {
+            _rowHiddenIndex = new Dictionary<int, bool>();
+            foreach (var row in _sheetData.Elements<Row>())
+                if (row.RowIndex?.Value is uint idx && row.Hidden?.Value == true)
+                    _rowHiddenIndex[(int)idx] = true;
+        }
+        return _rowHiddenIndex.TryGetValue(rowNumber, out var h) && h;
+    }
+
+    // True when this evaluator's sheet carries an AutoFilter — under a filter, hidden rows are the
+    // filtered-out ones, which SUBTOTAL codes 1-11 must exclude.
+    internal bool HasAutoFilter => (_sheetData.Parent as Worksheet)?.GetFirstChild<AutoFilter>() != null;
+
     private RangeData Expand2DRange(string rangeExpr)
     {
         // Handle cross-sheet ranges like "SheetName!A1:B3"


### PR DESCRIPTION
Follow-on to the nested-subtotal exclusion (bd5d39bf): SUBTOTAL should also ignore rows Excel hides. Codes 101–111 always drop hidden rows; codes 1–11 drop them when the sheet has an AutoFilter (OOXML can't distinguish a filter-hidden row from a manually-hidden one, and under a filter the hidden rows are the filtered-out ones Excel excludes). Previously 101–111 collapsed to 1–11 and hidden rows were summed, over-counting filtered sheets.

Threads the raw code into ExcludeNestedSubtotalCells (default 0 leaves AGGREGATE unchanged) and blanks hidden-row cells via a lazy row-hidden index; same-sheet only, like the nested-exclusion probe.

Validation (before → after): AutoFilter on A1:A6, values 10..50 in A2:A6, rows for 20 and 40 hidden:
A7 = SUBTOTAL(9,A2:A6) → 150 before, 90 after (Excel counts visible only: 10+30+50). Also verified against a real filtered stock sheet — a running total that was ~6% high now matches Excel.