### PR TITLE
fix(xlsx): arithmetic coerces date/time-formatted text to its serial like Excel

### DIFF
--- a/src/officecli/Core/Formula/FormulaEvaluator.cs
+++ b/src/officecli/Core/Formula/FormulaEvaluator.cs
@@ -872,7 +872,16 @@ internal partial class FormulaEvaluator
     {
         if (r.IsBlank) { val = 0; return true; }
         if (r.IsString)
-            return double.TryParse(r.StringValue, NumberStyles.Any, CultureInfo.InvariantCulture, out val);
+        {
+            if (double.TryParse(r.StringValue, NumberStyles.Any, CultureInfo.InvariantCulture, out val))
+                return true;
+            // Excel coerces date/time-formatted text to its serial in arithmetic
+            // (e.g. "2024-08-01" - "2024-08-01" = 0), so fall back to date parsing
+            // when the text isn't a plain number.
+            if (DateTime.TryParse(r.StringValue, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
+            { val = dt.ToOADate(); return true; }
+            return false;
+        }
         val = r.AsNumber();
         return true;
     }


### PR DESCRIPTION
TryCoerceArithmetic rejected date-formatted text as #VALUE!, so =G6-I6 where the cells hold "2024-08-01" errored instead of Excel's 0. Excel coerces such text to its date serial in arithmetic. Adds a DateTime.TryParse fallback after the numeric parse — numeric-looking text is still tried first, and genuine non-numeric text still yields #VALUE!.

Validation (before → after): two cells holding "2024-08-01", =A1-A2 → #VALUE! before, 0 after (matches Excel). Regression-checked: 10-3 → 7, "hello"-3 → #VALUE!.