### PR TITLE
fix(xlsx): make import mark document modified to save xlsx properly

### DIFF
--- a/src/officecli/Handlers/Excel/ExcelHandler.Import.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Import.cs
@@ -237,6 +237,9 @@ public partial class ExcelHandler
             sheetView.InsertAt(pane, 0);
         }
 
+        // Mark modified so Dispose flushes the import (the !Modified
+        // byte-preserving discard path would otherwise drop it).
+        Modified = true;
         SaveWorksheet(worksheet);
         return $"Imported {rows.Count} rows x {maxCols} cols into /{sheetName} starting at {startCell.ToUpperInvariant()}";
     }


### PR DESCRIPTION
`Import` changes cells in memory, but it never sets `Modified = true`. 

In v1.0.143 (cd4befc) `Dispose()` learned to throw away all in-memory changes when `Modified` is false. So `officecli import` prints a success message like `Imported 3 rows x 2 cols`, but nothing is saved to the file. The same bug was already fixed for Move/Swap/CopyFrom in c84340d. But `Import` was missed.

Fix: set `Modified = true` right before `SaveWorksheet(worksheet)`, so `Dispose()` saves the imported cells. An empty import returns before this line, so it stays a no-op.

### Validation (before → after):

```bash
officecli create book.xlsx
printf 'name,value\nalpha,10\nbeta,20\n' > data.csv
officecli import book.xlsx /Sheet1 data.csv --header
officecli close book.xlsx
officecli get book.xlsx /Sheet1/A1
```

- Before (v1.0.143): import prints success, but `/Sheet1/A1` is `(empty)` ✗ — nothing on disk
- After: `/Sheet1/A1 (cell) "name" type=String` ✓ and `/Sheet1/B3 (cell) "20" type=Number` ✓

Also checked the batch path — an `import` item with no `set` after it, which was broken the same way:

```bash
officecli create book2.xlsx
printf '[{"command":"import","parent":"/Sheet1","text":"x,y\n1,2\n3,4"}]' | officecli batch book2.xlsx
officecli close book2.xlsx
# the imported values are now in xl/worksheets/sheet1.xml on disk
```
