### PR TITLE
fix(excel): flush import data to disk and surface write failures

### DIFF
--- a/src/officecli/CommandBuilder.Import.cs
+++ b/src/officecli/CommandBuilder.Import.cs
@@ -113,6 +113,10 @@ static partial class CommandBuilder
             ResidentClient.SendClose(file.FullName);
             using var handler = new OfficeCli.Handlers.ExcelHandler(file.FullName, editable: true);
             var msg = handler.Import(parentPath, csvContent, delimiter, header, startCell);
+            // Import works against ExcelHandler's crash-atomic in-memory package.
+            // Flush before reporting success so write-back failures are surfaced
+            // as command errors instead of being swallowed by best-effort Dispose.
+            handler.Save();
             if (json)
                 Console.WriteLine(OutputFormatter.WrapEnvelopeText(msg));
             else

--- a/src/officecli/Handlers/Excel/ExcelHandler.Helpers.Sheet.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Helpers.Sheet.cs
@@ -197,6 +197,12 @@ public partial class ExcelHandler
     /// </summary>
     private void SaveWorksheet(WorksheetPart part)
     {
+        // A dirty worksheet is itself proof that the editable package was
+        // modified.  Keep this invariant here instead of relying on every
+        // caller to set Modified separately: Import writes rows directly and
+        // used to enqueue the part without setting Modified, so Dispose()
+        // treated the session as read-only and discarded the in-memory copy.
+        Modified = true;
         _dirtyWorksheets.Add(part);
     }
 


### PR DESCRIPTION
## Summary

`officecli import <xlsx> /SheetN <file.csv>` reports success (`Imported N rows x M cols into /Sheet1 ...`) but **writes nothing** to the sheet. The xlsx on disk stays empty, so the imported data is silently lost — CSV and TSV both reproduce this.

### Root cause

`ExcelHandler.Import` writes rows/cells into `ExcelHandler`'s in-memory package, but:

1. **`SaveWorksheet`** enqueued the part into `_dirtyWorksheets` without setting the `Modified` flag. `ExcelHandler.Dispose()` therefore treated the whole session as **read-only** and discarded the in-memory copy (reverted to the on-disk bytes) — the `_dirtyWorksheets` entries were never flushed.
2. The `import` command layer (`CommandBuilder.Import`) never explicitly saved; it relied on `Dispose()`, which did nothing because of (1), and reported the returned message string as success regardless.

The `set` path worked because it goes through the resident/save machinery that does set `Modified`.

### Fix

- `ExcelHandler.Helpers.Sheet.cs`: `SaveWorksheet` now sets `Modified = true` — a dirty worksheet is itself proof the package was modified, regardless of which caller enqueues it. This is the root-cause fix.
- `CommandBuilder.Import.cs`: after `handler.Import(...)`, call `handler.Save()` explicitly so write-back happens before the success message is printed. Any write-back failure now surfaces as a command error instead of being swallowed on `Dispose()`.

### Validation method (per CONTRIBUTING Rule 2)

**Before my fix (v1.0.143 baseline):**

```bash
officecli create t.xlsx
officecli import t.xlsx /Sheet1 data.csv   # → "Imported 3 rows x 2 cols into /Sheet1 starting at A1"
officecli view t.xlsx text                 # → (empty)  ❌ data not present
unzip -p t.xlsx xl/worksheets/sheet1.xml | grep alice   # → (empty)  ❌ on-disk XML has no data
```

**After my fix:**

```bash
officecli create t.xlsx
officecli import t.xlsx /Sheet1 data.csv   # → "Imported 3 rows x 2 cols into /Sheet1 starting at A1"
officecli view t.xlsx text
# → [/Sheet1/row[1]] A1=name B1=score
# → [/Sheet1/row[2]] A2=alice B2=88      ✓ data present
unzip -p t.xlsx xl/worksheets/sheet1.xml | grep alice   # → present   ✓ on-disk XML has data
```

Also cross-verified with **openpyxl** (independent of officecli's own readers): the workbook loaded by a third-party library contains the imported rows after the fix, confirming the bytes were really persisted to disk.

Note: I validated by building the patched source with `dotnet build` and running the CLI against the compiled `officecli.dll` (macOS arm64, net10.0.302). CI's multi-platform `dotnet build` matrix should confirm the same for the other RIDs.

## Checklist

- [x] One atomic change (import data persistence)
- [x] Compiles clean (dotnet build, 0 errors)
- [x] Verified data persists to disk (officecli view + unzip XML + openpyxl cross-check)
