### PR TITLE
Add one-shot creation and option-aware views to batch

### DIFF
--- a/src/officecli/BatchTypes.cs
+++ b/src/officecli/BatchTypes.cs
@@ -97,6 +97,7 @@ internal class BatchItemConverter : JsonConverter<BatchItem>
                 case "to": item.To = reader.GetString(); break;
                 case "path2": item.Path2 = reader.GetString(); break;
                 case "props": item.Props = PropsConverter.Read(ref reader, typeof(Dictionary<string, string>), options); break;
+                case "options": item.Options = PropsConverter.Read(ref reader, typeof(Dictionary<string, string>), options); break;
                 case "selector": item.Selector = reader.GetString(); break;
                 case "text": item.Text = reader.GetString(); break;
                 case "mode": item.Mode = reader.GetString(); break;
@@ -126,6 +127,7 @@ internal class BatchItemConverter : JsonConverter<BatchItem>
         if (value.To != null) writer.WriteString("to", value.To);
         if (value.Path2 != null) writer.WriteString("path2", value.Path2);
         if (value.Props != null) { writer.WritePropertyName("props"); PropsConverter.Write(writer, value.Props, options); }
+        if (value.Options != null) { writer.WritePropertyName("options"); PropsConverter.Write(writer, value.Options, options); }
         if (value.Selector != null) writer.WriteString("selector", value.Selector);
         if (value.Text != null) writer.WriteString("text", value.Text);
         if (value.Mode != null) writer.WriteString("mode", value.Mode);
@@ -157,6 +159,8 @@ public class BatchItem
     // off-name `to`. Accept both — see the swap case in ExecuteBatchItem.
     public string? Path2 { get; set; }
     public Dictionary<string, string>? Props { get; set; }
+    /// <summary>Command-line-style execution options (without leading --).</summary>
+    public Dictionary<string, string>? Options { get; set; }
     public string? Selector { get; set; }
     public string? Text { get; set; }
     public string? Mode { get; set; }
@@ -176,7 +180,7 @@ public class BatchItem
     internal static readonly HashSet<string> KnownFields = new(StringComparer.OrdinalIgnoreCase)
     {
         "command", "op", "path", "parent", "type", "from", "index", "after", "before", "to", "path2",
-        "props", "selector", "text", "mode", "depth", "part", "xpath", "action", "xml", "dumpversion"
+        "props", "options", "selector", "text", "mode", "depth", "part", "xpath", "action", "xml", "dumpversion"
     };
 
     public ResidentRequest ToResidentRequest()
@@ -203,6 +207,9 @@ public class BatchItem
 
         if (Props != null)
             req.Props = Props;
+        if (Options != null)
+            foreach (var (key, value) in Options)
+                req.Args[key] = value;
 
         return req;
     }

--- a/src/officecli/CommandBuilder.Batch.cs
+++ b/src/officecli/CommandBuilder.Batch.cs
@@ -132,6 +132,8 @@ static partial class CommandBuilder
         var batchFileArg = new Argument<FileInfo>("file") { Description = "Office document path" };
         var batchInputOpt = new Option<FileInfo?>("--input") { Description = "JSON file containing batch commands. If omitted, reads from stdin" };
         var batchCommandsOpt = new Option<string?>("--commands") { Description = "Inline JSON array of batch commands (alternative to --input or stdin)" };
+        var batchCreateIfMissingOpt = new Option<bool>("--create-if-missing") { Description = "Create a blank document when the target does not exist, then apply the batch in the same process. Existing files are never overwritten." };
+        var batchSaveOpt = new Option<bool>("--save") { Description = "Flush the document to disk after the batch. Resident batches save once at the end; non-resident batches are already saved once on completion." };
         // BUG-R4-BT2: default flipped to continue-on-error. A 700-command
         // dump replay losing 80% of the document on the first failing item
         // (e.g. one unsupported prop) is a far worse default than reporting
@@ -153,6 +155,8 @@ static partial class CommandBuilder
         batchCommand.Add(batchFileArg);
         batchCommand.Add(batchInputOpt);
         batchCommand.Add(batchCommandsOpt);
+        batchCommand.Add(batchCreateIfMissingOpt);
+        batchCommand.Add(batchSaveOpt);
         batchCommand.Add(batchForceOpt);
         batchCommand.Add(batchStopOpt);
         batchCommand.Add(batchBestEffortOpt);
@@ -163,6 +167,8 @@ static partial class CommandBuilder
             var file = result.GetValue(batchFileArg)!;
             var inputFile = result.GetValue(batchInputOpt);
             var inlineCommands = result.GetValue(batchCommandsOpt);
+            var createIfMissing = result.GetValue(batchCreateIfMissingOpt);
+            var saveAfterBatch = result.GetValue(batchSaveOpt);
             // Default: continue on error. --stop-on-error flips it to strict.
             // --force still acts as the docx-protection bypass (matches set
             // --force semantics) but no longer doubles as the continue-on-
@@ -326,6 +332,21 @@ static partial class CommandBuilder
                     throw new ArgumentException(
                         $"batch item[{ni}] is null. Each entry must be a JSON object (e.g. {{\"command\":\"get\",\"path\":\"/\"}}).");
             }
+
+            // A batch normally requires an existing document. Opt-in creation
+            // keeps the blank-package construction and the one-open/one-save
+            // replay in this process, avoiding the separate `create` CLI and
+            // its short-lived resident startup. Do this only after the input
+            // has parsed and passed structural validation, so malformed JSON
+            // never leaves a blank file behind.
+            var createdForBatch = false;
+            if (!File.Exists(file.FullName) && createIfMissing)
+            {
+                var locale = OfficeCli.Core.LocaleFontRegistry.ResolveEffectiveLocale(null);
+                OfficeCli.BlankDocCreator.Create(file.FullName, locale, minimal: false);
+                file.Refresh();
+                createdForBatch = true;
+            }
             if (items.Count == 0)
             {
                 // BUG-R6-07: empty command array previously short-circuited
@@ -410,6 +431,26 @@ static partial class CommandBuilder
                 {
                     Console.Error.WriteLine($"Resident for {file.Name} is running but the batch could not be delivered (main pipe busy or unresponsive). Retry, or run 'officecli close {file.Name}' and try again.");
                     return 3;
+                }
+                // A resident normally defers disk serialization until its
+                // idle debounce or an explicit save/close. --save turns this
+                // batch into a deterministic persistence boundary without
+                // paying for a second CLI process.
+                if (saveAfterBatch)
+                {
+                    var saveResponse = ResidentClient.TrySend(
+                        file.FullName,
+                        new ResidentRequest { Command = "save", Json = json },
+                        maxRetries: 3,
+                        connectTimeoutMs: 30000);
+                    if (saveResponse == null || saveResponse.ExitCode != 0)
+                    {
+                        var saveError = saveResponse?.Stderr;
+                        throw new CliException(string.IsNullOrWhiteSpace(saveError)
+                            ? $"Batch completed, but {file.Name} could not be saved."
+                            : $"Batch completed, but {file.Name} could not be saved: {saveError}")
+                        { Code = "save_failed" };
+                    }
                 }
                 // The resident returns the formatted batch output directly
                 if (!string.IsNullOrEmpty(response.Stdout))
@@ -512,21 +553,24 @@ static partial class CommandBuilder
                 var guid = Guid.NewGuid().ToString("N");
                 var prepPath = System.IO.Path.Combine(tmpDir, $".{tmpStem}.batchprep-{guid}{tmpExt}");
                 tmpPath = System.IO.Path.Combine(tmpDir, $".{tmpStem}.batch-{guid}{tmpExt}");
-                using (var src = new System.IO.FileStream(targetPath, System.IO.FileMode.Open,
-                    System.IO.FileAccess.Read, System.IO.FileShare.Read))
-                using (var dst = new System.IO.FileStream(prepPath, System.IO.FileMode.CreateNew,
-                    System.IO.FileAccess.ReadWrite, System.IO.FileShare.None))
+                if (createdForBatch)
                 {
-                    src.CopyTo(dst);
+                    System.IO.File.Move(targetPath, tmpPath);
                 }
-                // The final promote is a rename, which would hand the document
-                // the temp's default permissions — carry the original mode
-                // over. (Windows File.Replace preserves the destination's ACL
-                // by itself.)
-                if (!OperatingSystem.IsWindows())
-                    try { System.IO.File.SetUnixFileMode(prepPath, System.IO.File.GetUnixFileMode(targetPath)); }
-                    catch { /* best-effort */ }
-                System.IO.File.Move(prepPath, tmpPath);
+                else
+                {
+                    using (var src = new System.IO.FileStream(targetPath, System.IO.FileMode.Open,
+                        System.IO.FileAccess.Read, System.IO.FileShare.Read))
+                    using (var dst = new System.IO.FileStream(prepPath, System.IO.FileMode.CreateNew,
+                        System.IO.FileAccess.ReadWrite, System.IO.FileShare.None))
+                    {
+                        src.CopyTo(dst);
+                    }
+                    if (!OperatingSystem.IsWindows())
+                        try { System.IO.File.SetUnixFileMode(prepPath, System.IO.File.GetUnixFileMode(targetPath)); }
+                        catch { /* best-effort */ }
+                    System.IO.File.Move(prepPath, tmpPath);
+                }
                 workPath = tmpPath;
             }
             List<BatchResult> batchResults;
@@ -548,6 +592,8 @@ static partial class CommandBuilder
                             Console.Error.WriteLine($"ERROR: {protBlock}");
                         if (tmpPath != null)
                             try { System.IO.File.Delete(tmpPath); } catch { /* best-effort */ }
+                        if (createdForBatch)
+                            try { System.IO.File.Delete(file.FullName); } catch { /* best-effort */ }
                         return 1;
                     }
                 }
@@ -568,6 +614,8 @@ static partial class CommandBuilder
                 // SafeRun): never leave the temp copy behind, never promote it.
                 if (tmpPath != null)
                     try { System.IO.File.Delete(tmpPath); } catch { /* best-effort */ }
+                if (createdForBatch)
+                    try { System.IO.File.Delete(file.FullName); } catch { /* best-effort */ }
                 throw;
             }
             // The using-Dispose above fully serialized the (temp) document;
@@ -584,7 +632,10 @@ static partial class CommandBuilder
                     // temp copy must not leak on that path.
                     try
                     {
-                        System.IO.File.Replace(tmpPath, targetPath, destinationBackupFileName: null);
+                        if (createdForBatch)
+                            System.IO.File.Move(tmpPath, targetPath);
+                        else
+                            System.IO.File.Replace(tmpPath, targetPath, destinationBackupFileName: null);
                     }
                     catch
                     {
@@ -613,6 +664,11 @@ static partial class CommandBuilder
             // signal. Two `success` fields appear in the JSON (outer batch
             // verdict, inner per-step) — disambiguate by JSON path.
             var batchSuccess = batchResults.Count == 0 || !batchResults.Any(r => !r.Success);
+            // Atomic failure on a target created by this invocation restores
+            // the true pre-batch state: no file at all, rather than a leaked
+            // blank document.
+            if (!batchSuccess && createdForBatch)
+                try { System.IO.File.Delete(file.FullName); } catch { /* best-effort */ }
             // BUG-BT2: surface per-item unrecognized-LaTeX warnings the same way
             // single-shot add/set do (warning + JSON envelope + exit 2). A batch
             // whose only issue is an unknown LaTeX command otherwise exited 0

--- a/src/officecli/CommandBuilder.cs
+++ b/src/officecli/CommandBuilder.cs
@@ -1180,27 +1180,138 @@ static partial class CommandBuilder
             case "view":
             {
                 var mode = item.Mode ?? "text";
+                var options = item.Options ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                var allowedViewOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "start", "end", "max-lines", "cols", "range", "type", "limit",
+                    "page", "out", "render", "screenshot-width", "screenshot-height", "grid"
+                };
+                var unknownOptions = options.Keys.Where(k => !allowedViewOptions.Contains(k)).ToList();
+                if (unknownOptions.Count > 0)
+                    throw new CliException($"Unknown view option(s): {string.Join(", ", unknownOptions)}")
+                    { Code = "unknown_option" };
+
+                int? IntOption(string key)
+                {
+                    if (!options.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value)) return null;
+                    if (int.TryParse(value, out var parsed)) return parsed;
+                    throw new CliException($"view option '{key}' requires an integer; got '{value}'.")
+                    { Code = "invalid_value" };
+                }
+                var start = IntOption("start");
+                var end = IntOption("end");
+                var maxLines = IntOption("max-lines");
+                var limit = IntOption("limit");
+                var range = options.GetValueOrDefault("range");
+                HashSet<string>? cols = options.TryGetValue("cols", out var colsValue)
+                    ? colsValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                        .ToHashSet(StringComparer.OrdinalIgnoreCase)
+                    : null;
                 if (mode.ToLowerInvariant() is "html" or "h")
                 {
                     if (handler is OfficeCli.Handlers.PowerPointHandler pptH)
-                        return pptH.ViewAsHtml();
+                    {
+                        var (pStart, pEnd) = ParsePptHtmlPage(options.GetValueOrDefault("page"), start, end, pptH);
+                        return RenderViaRegistry(pptH, "pptx", new OfficeCli.Core.Rendering.RenderOptions
+                        { StartPage = pStart, EndPage = pEnd })!;
+                    }
                     if (handler is OfficeCli.Handlers.ExcelHandler excelH)
-                        return excelH.ViewAsHtml();
+                        return RenderViaRegistry(excelH, "xlsx", new OfficeCli.Core.Rendering.RenderOptions())!;
                     if (handler is OfficeCli.Handlers.WordHandler wordH)
-                        return wordH.ViewAsHtml();
+                        return RenderViaRegistry(wordH, "docx", new OfficeCli.Core.Rendering.RenderOptions
+                        { PageFilter = options.GetValueOrDefault("page") })!;
                 }
                 if (mode.ToLowerInvariant() is "svg" or "g" && handler is OfficeCli.Handlers.PowerPointHandler pptSvg)
                 {
-                    return pptSvg.ViewAsSvg(1);
+                    var page = IntOption("page") ?? 1;
+                    return pptSvg.ViewAsSvg(page);
+                }
+                if (mode.ToLowerInvariant() is "screenshot" or "p")
+                {
+                    var render = (options.GetValueOrDefault("render") ?? "auto").ToLowerInvariant();
+                    if (render is not ("auto" or "html" or "native"))
+                        throw new CliException($"Invalid render value: {render}. Valid: auto, native, html")
+                        { Code = "invalid_render", ValidValues = ["auto", "native", "html"] };
+                    // Batch renders the live in-memory DOM. A native Office
+                    // renderer can only read the on-disk package and would
+                    // therefore miss earlier unflushed items in this batch.
+                    if (render == "native")
+                        throw new CliException("Batch screenshots cannot use render=native because earlier batch edits are still in memory. Use render=html or auto.")
+                        { Code = "native_requires_flush", Suggestion = "Use options.render=html (or auto), or run a standalone screenshot after batch --save." };
+
+                    var sw = IntOption("screenshot-width") ?? 1600;
+                    var sh = IntOption("screenshot-height") ?? 1200;
+                    var pageFilter = options.GetValueOrDefault("page");
+                    var gridSpec = options.GetValueOrDefault("grid");
+                    var gridCols = gridSpec == null ? 0 : ParseGridSpec(gridSpec);
+                    string html;
+                    if (handler is OfficeCli.Handlers.PowerPointHandler pptShot)
+                    {
+                        var effectivePage = pageFilter;
+                        if (range != null && string.IsNullOrEmpty(effectivePage)
+                            && System.Text.RegularExpressions.Regex.Match(range, @"^/slide\[(\d+)\]") is { Success: true } sm)
+                            effectivePage = sm.Groups[1].Value;
+                        if (string.IsNullOrEmpty(effectivePage) && start is null && end is null && gridCols == 0)
+                            effectivePage = "1";
+                        var (pStart, pEnd) = ParsePptHtmlPage(effectivePage, start, end, pptShot);
+                        var (nativeW, nativeH) = pptShot.GetSlideNativePixels();
+                        var resolvedGrid = gridCols < 0
+                            ? OfficeCli.Core.HtmlScreenshot.AutoGridColumns(
+                                (pEnd ?? pptShot.GetSlideCount()) - (pStart ?? 1) + 1, nativeW, nativeH)
+                            : gridCols;
+                        html = RenderViaRegistry(pptShot, "pptx", new OfficeCli.Core.Rendering.RenderOptions
+                        { StartPage = pStart, EndPage = pEnd, GridColumns = resolvedGrid, ViewportPx = sw })!;
+                        if (pStart == pEnd && resolvedGrid == 0)
+                        {
+                            if (sw == 1600 && sh == 1200) { sw = nativeW; sh = nativeH; }
+                            else if (sh == 1200) sh = Math.Max(1, (int)Math.Round(sw * (double)nativeH / nativeW));
+                        }
+                    }
+                    else if (handler is OfficeCli.Handlers.ExcelHandler excelShot)
+                        html = RenderViaRegistry(excelShot, "xlsx", new OfficeCli.Core.Rendering.RenderOptions())!;
+                    else if (handler is OfficeCli.Handlers.WordHandler wordShot)
+                    {
+                        var effectivePage = range != null ? pageFilter : (string.IsNullOrEmpty(pageFilter) ? "1" : pageFilter);
+                        html = RenderViaRegistry(wordShot, "docx", new OfficeCli.Core.Rendering.RenderOptions
+                        { PageFilter = effectivePage })!;
+                        if (int.TryParse(effectivePage, out _) && gridCols == 0)
+                        {
+                            var (nativeW, nativeH) = wordShot.GetPageNativePixels();
+                            if (sw == 1600 && sh == 1200) { sw = nativeW; sh = nativeH; }
+                            else if (sh == 1200) sh = Math.Max(1, (int)Math.Round(sw * (double)nativeH / nativeW));
+                        }
+                    }
+                    else
+                        throw new CliException("Screenshot mode is only supported for .pptx, .xlsx, and .docx files.")
+                        { Code = "unsupported_type" };
+
+                    var pngPath = options.GetValueOrDefault("out")
+                        ?? Path.Combine(Path.GetTempPath(), $"officecli_screenshot_{Guid.NewGuid():N}.png");
+                    var tmpHtml = Path.Combine(Path.GetTempPath(), $"officecli_preview_{Guid.NewGuid():N}.html");
+                    try
+                    {
+                        File.WriteAllText(tmpHtml, html);
+                        var capture = range != null
+                            ? OfficeCli.Core.HtmlScreenshot.CaptureClipped(tmpHtml, pngPath,
+                                OfficeCli.Core.HtmlScreenshot.ResolveClipDataPaths(range))
+                            : OfficeCli.Core.HtmlScreenshot.Capture(tmpHtml, pngPath, sw, sh);
+                        if (!capture.Ok)
+                            throw new CliException("No headless browser available for batch screenshot."
+                                + (capture.Error != null ? $" Last error: {capture.Error}" : ""))
+                            { Code = "no_screenshot_backend" };
+                    }
+                    finally { try { File.Delete(tmpHtml); } catch { } }
+                    return Path.GetFullPath(pngPath);
                 }
                 return mode.ToLowerInvariant() switch
                 {
-                    "text" or "t" => handler.ViewAsText(null, null, null, null),
-                    "annotated" or "a" => handler.ViewAsAnnotated(null, null, null, null),
+                    "text" or "t" => handler.ViewAsText(start, end, maxLines, cols, range),
+                    "annotated" or "a" => handler.ViewAsAnnotated(start, end, maxLines, cols),
                     "outline" or "o" => handler.ViewAsOutline(),
                     "stats" or "s" => handler.ViewAsStats(),
-                    "issues" or "i" => OfficeCli.Core.OutputFormatter.FormatIssues(handler.ViewAsIssues(null, null), format),
-                    _ => $"Unknown mode: {mode}"
+                    "issues" or "i" => OfficeCli.Core.OutputFormatter.FormatIssues(
+                        handler.ViewAsIssues(OfficeCli.Core.IssueSubtypes.Validate(options.GetValueOrDefault("type")), limit), format),
+                    _ => throw new CliException($"Unknown view mode: {mode}") { Code = "invalid_value" }
                 };
             }
             case "raw":
@@ -1237,7 +1348,11 @@ static partial class CommandBuilder
                     if (err.Path != null) lines.Add($"    Path: {err.Path}");
                     if (err.Part != null) lines.Add($"    Part: {err.Part}");
                 }
-                return string.Join("\n", lines);
+                // Validation is a judgment step, not a report-only read. A
+                // schema-invalid document must fail the item so an atomic
+                // edit+validate batch rolls its mutations back.
+                throw new CliException(string.Join("\n", lines))
+                { Code = "validation_failed" };
             }
             default:
                 if (string.IsNullOrEmpty(item.Command))


### PR DESCRIPTION
## Summary

- Add `batch --create-if-missing` so a missing document can be created and processed in one invocation
- Add `batch --save` as an explicit persistence boundary for resident batches
- Add an `options` object to batch items
- Support view options such as `start`, `end`, `max-lines`, `cols`, `range`, `type`, `limit`, `page`, `out`, `render`, screenshot size, and `grid`
- Support outline, filtered HTML/SVG, and HTML screenshots inside a batch
- Make schema validation errors fail the batch and trigger atomic rollback
- Remove a newly created target if an atomic batch fails

## Motivation

Batch already supported document edits. The missing capability was command options and several view modes. For example, this could not previously be expressed inside a batch:

```powershell
officecli view report.docx text --start 1 --max-lines 50 --json
```

It required a separate CLI invocation after the batch, adding another process startup and document-open cycle. It could also lead callers to request an unbounded view and consume substantially more output tokens when they only needed a small section.

The same bounded view can now be part of `operations.json`:

```json
{
  "command": "view",
  "mode": "text",
  "options": {
    "start": "1",
    "max-lines": "50"
  }
}
```

Page-specific screenshot output can also remain in the batch:

```json
{
  "command": "view",
  "mode": "screenshot",
  "options": {
    "page": "1",
    "render": "html",
    "out": "page-1.png",
    "screenshot-width": "1000"
  }
}
```

Together with creation, this enables a one-shot workflow:

```powershell
officecli batch report.docx `
  --create-if-missing `
  --input operations.json `
  --save `
  --json
```

## Local timings

Creation-path comparison measured on the same Windows machine and Release build:

| Workflow | Time |
|---|---:|
| Separate `create` invocation | 1.61 s |
| Empty batch with `--create-if-missing` | 0.77 s |
| Saved | **about 0.85 s (about 52%)** |

For commands that previously had to run outside the batch, each avoided invocation removes roughly one CLI startup plus a document-open cycle. Local read/view commands were generally around **0.34-0.42 s** per separate invocation. Output-limiting options such as `max-lines` also reduce response size, although token savings depend on the document and requested limit and were not benchmarked here.

These are local wall-clock measurements intended to illustrate avoided overhead, not a formal cross-platform benchmark.

## Validation

- Release build succeeds with 0 errors
- Create + edit + outline + validate + save smoke test passes
- `git diff --check` passes
- Persistent/prewarmed Chromium experiments are not included