### PR TITLE
fix(docx): recognize character-relative first-line indents

### DIFF
--- a/src/officecli/Handlers/Word/WordHandler.View.cs
+++ b/src/officecli/Handlers/Word/WordHandler.View.cs
@@ -1321,7 +1321,9 @@ public partial class WordHandler
             if (pProps != null && IsNormalStyle(styleName))
             {
                 var indent = pProps.Indentation;
-                if (indent?.FirstLine == null || indent.FirstLine.Value == "0")
+                var hasFirstLine = indent?.FirstLine != null && indent.FirstLine.Value != "0";
+                var hasFirstLineChars = indent?.FirstLineChars != null && indent.FirstLineChars.Value > 0;
+                if (!hasFirstLine && !hasFirstLineChars)
                 {
                     // Skip paragraphs where first-line indent is not expected:
                     // - hanging indent (e.g. bibliography entries)


### PR DESCRIPTION
## Problem

`view issues` reports that a Normal-style body paragraph is missing a first-line indent even when its OOXML indentation has a positive `firstLineChars` value.

## Fix

Treat either a non-zero absolute `FirstLine` value or a positive character-relative `FirstLineChars` value as satisfying the existing first-line-indent check. The current hanging-indent, alignment, list, and text exemptions are unchanged.

## Validation

- Built `src/officecli/officecli.csproj` in Release with .NET 10.
- Reproduced the false warning with `firstLineChars=200` before the change and confirmed it is absent afterward.
- Confirmed `firstLineChars=0` still reports the warning.
- Confirmed `firstLineIndent=2cm` remains accepted.
- Confirmed all generated DOCX fixtures pass `officecli validate --json`.

Closes #283.
