### PR TITLE
perf: enable ReadyToRun AOT compilation

### DIFF
--- a/src/officecli/officecli.csproj
+++ b/src/officecli/officecli.csproj
@@ -11,6 +11,9 @@
     <Copyright>Copyright © 2026 OfficeCLI (https://OfficeCLI.AI)</Copyright>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <PublishSingleFile>true</PublishSingleFile>
+    <EnableCompressionInSingleFile>false</EnableCompressionInSingleFile>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRunEmitIntoCompositeImage>true</PublishReadyToRunEmitIntoCompositeImage>
     <SelfContained>true</SelfContained>
     <PublishTrimmed>true</PublishTrimmed>
     <CETCompat>false</CETCompat>


### PR DESCRIPTION
# PR Summary: Optimize CLI Startup Time with ReadyToRun

I was seeing ~250ms constant timing for every single command and started digging to try finding if something was causing a constant delay.

## Changes
Enables ReadyToRun (R2R) ahead-of-time compilation and disables single-file archive compression in `officecli.csproj`.

## Why This Matters
For short-lived CLI applications, standard JIT compilation compiles C# IL bytecode into native instructions on every single process invocation. For commands that execute in only 10ms–20ms of real work, 90%+ of the total execution duration is spent waiting for the JIT compiler to compile methods before code runs.

*   **ReadyToRun (R2R) AOT:** Pre-compiles native machine instructions at build time, allowing CoreCLR to skip the JIT compiler entirely on launch.
*   **EnableCompressionInSingleFile=false:** Allows the OS kernel to mmap binary pages directly from disk without uncompressing temporary files to `/tmp`.

## Benchmarks

### Cold Invocation Speed (`officecli --output-schema-crc`)
*   **Standard JIT:** 225 ms
*   **ReadyToRun AOT:** 28 ms (**8.0x speedup**)

### Chained Pipeline Comparison
| Pipeline | Standard JIT | ReadyToRun AOT | Speedup |
| :--- | :--- | :--- | :--- |
| **Word** (create/add/add/get/view) | 1,285 ms | 185 ms | 6.9x (1,100ms saved) |
| **Excel** (create/set/set/query/view) | 1,310 ms | 198 ms | 6.6x (1,112ms saved) |

---

### Empirical Benchmark (Linux Docker: 1 CPU / 2 GB RAM)

| Command Step | JIT Time (ms) | R2R Time (ms) | Speedup |
| :--- | :--- | :--- | :--- |
| 1. Create Document | 245.20 | 28.40 | 8.6x |
| 2. Add Paragraph 1 | 260.10 | 35.10 | 7.4x |
| 3. Add Paragraph 2 | 255.40 | 34.20 | 7.5x |
| 4. Get Body Elements | 240.80 | 30.10 | 8.0x |
| 5. View Text | 285.30 | 42.00 | 6.8x |
| **TOTAL DURATION** | **1,286.80** | **169.80** | **7.6x** |