### PR TITLE
fix(mcp): avoid probing JSON-RPC stdin for explicit batch input

### DIFF
--- a/src/officecli/CommandBuilder.Batch.cs
+++ b/src/officecli/CommandBuilder.Batch.cs
@@ -172,6 +172,13 @@ static partial class CommandBuilder
             var bestEffort = result.GetValue(batchBestEffortOpt);
 
             string jsonText;
+            if (inlineCommands != null && inputFile != null)
+                throw new ArgumentException(
+                    "batch: --commands and --input are mutually exclusive. Pick one source.");
+            // '--input -' explicitly opts INTO stdin — don't emit the
+            // "stdin will be ignored" warning in that case, since stdin
+            // is exactly what will be read.
+            var inputIsStdinAlias = inputFile != null && inputFile.Name == "-";
             // BUG-R7-09 (F-6): previously --commands/--input/stdin were
             // silently prioritized in that order — passing two of them at
             // once dropped the lower-priority source with no warning, so
@@ -179,28 +186,35 @@ static partial class CommandBuilder
             // command that already had --commands set. Reject the
             // combination loudly. (Detect stdin via Console.IsInputRedirected
             // to avoid spurious failures from interactive terminals.)
+            //
+            // Only probe stdin when all of these are true: an explicit
+            // non-stdin source will make us ignore stdin, the warning has not
+            // been disabled, and stdin is redirected. This is a correctness
+            // boundary for MCP: its stdin is the JSON-RPC transport.
+            // OFFICECLI_BATCH_ALLOW_STDIN_REDIRECT is enabled by McpServer, so
+            // MCP calls with --commands/--input must never touch stdin here.
             // IsInputRedirected alone is true for every non-interactive
             // invocation (cron, CI, `< /dev/null`, systemd), so the warning
             // below fired on effectively all scripted batch runs with only
             // one source supplied. Refine: a seekable stdin (regular file or
             // /dev/null redirect) with zero length carries no second payload
-            // — skip the warning. Pipes (CanSeek=false) still warn: someone
-            // is actively piping data that will be ignored.
-            // #340/#339: the warning below only needs to know whether a SECOND
-            // payload is sitting on stdin while --commands/--input is also given.
-            // The old refinement peeked a byte off stdin — but under `officecli
-            // mcp` stdin IS the JSON-RPC channel, and that consuming read (on an
-            // abandoned thread) swallowed the next request frame, so the client
-            // hung with no response. Determine it WITHOUT consuming: only a
-            // seekable stdin can be sized without reading. This makes the warning
-            // best-effort — most hosts expose redirected stdin as a non-seekable
-            // stream (Console.OpenStandardInput().CanSeek == false for pipes AND,
-            // on several platforms, for `< file` too), and those are deliberately
+            // — skip the warning.
+            // #340/#339: when the warning path does probe, determine whether a
+            // SECOND payload is sitting on stdin WITHOUT consuming — only a
+            // seekable stdin can be sized without reading. An earlier Peek-based
+            // probe swallowed JSON-RPC frames under `officecli mcp`. Most hosts
+            // expose redirected stdin as a non-seekable stream
+            // (Console.OpenStandardInput().CanSeek == false for pipes AND, on
+            // several platforms, for `< file` too), and those are deliberately
             // left unconfirmed rather than consumed. Never swallowing a frame
             // matters more than the warning. The actual stdin payload path below
             // still reads stdin in full when batch has no explicit source.
+            var hasExplicitNonStdinSource = inlineCommands != null
+                || (inputFile != null && !inputIsStdinAlias);
+            var shouldWarnAboutIgnoredStdin = hasExplicitNonStdinSource
+                && Environment.GetEnvironmentVariable("OFFICECLI_BATCH_ALLOW_STDIN_REDIRECT") == null;
             bool stdinHasInput = false;
-            if (Console.IsInputRedirected)
+            if (shouldWarnAboutIgnoredStdin && Console.IsInputRedirected)
             {
                 try
                 {
@@ -209,15 +223,7 @@ static partial class CommandBuilder
                 }
                 catch { /* treat as no confirmed payload */ }
             }
-            if (inlineCommands != null && inputFile != null)
-                throw new ArgumentException(
-                    "batch: --commands and --input are mutually exclusive. Pick one source.");
-            // '--input -' explicitly opts INTO stdin — don't emit the
-            // "stdin will be ignored" warning in that case, since stdin
-            // is exactly what will be read.
-            var inputIsStdinAlias = inputFile != null && inputFile.Name == "-";
-            if ((inlineCommands != null || (inputFile != null && !inputIsStdinAlias)) && stdinHasInput
-                && Environment.GetEnvironmentVariable("OFFICECLI_BATCH_ALLOW_STDIN_REDIRECT") == null)
+            if (stdinHasInput)
             {
                 Console.Error.WriteLine(
                     "Warning: batch is reading from --commands/--input but stdin is also redirected; "


### PR DESCRIPTION
## Summary

- skip the redirected-stdin probe when `batch` already has an explicit non-stdin input and the warning is disabled
- ensure MCP `batch --commands` / `batch --input` calls never read from the JSON-RPC transport
- preserve stdin fallback, explicit `--input -`, and the existing ignored-stdin warning for normal CLI use

## Root cause

The MCP server sets `OFFICECLI_BATCH_ALLOW_STDIN_REDIRECT=1` because its stdin is the JSON-RPC transport. However, the old batch handler checked that flag only when deciding whether to print a warning, after it had already started a background `StdIn.Peek()`.

When the 50 ms wait expired, the blocked task was abandoned but remained alive. Once the client sent its next JSON-RPC request, that task could buffer the request from stdin, leaving the MCP read loop without the expected message. The caller then waited until its tool timeout.

The fix decides whether the ignored-stdin warning is needed before starting the probe. MCP disables that warning, so it no longer creates a competing stdin reader. The mutual-exclusion check also runs before any possible probe.

## Validation

Both the baseline (`459b1a47`) and patched source were published for `linux-arm64` with:

```bash
dotnet publish src/officecli/officecli.csproj \
  -c Release -r linux-arm64 -o publish --nologo
```

I then ran the same MCP sequence against each binary: initialize, send a malformed string-form batch (which returns an error), then immediately send a valid argv-form batch.

| Version | Malformed call returned | Next valid call |
| --- | --- | --- |
| Baseline | error as expected | no response within 3 seconds |
| Patched | error as expected | success in 559 ms |

Portable reproducer (set `OFFICECLI` to the binary under test):

```python
import json
import os
import select
import subprocess
import tempfile
import time

cli = os.environ.get("OFFICECLI", "officecli")


def send(proc, message):
    proc.stdin.write(json.dumps(message, separators=(",", ":")) + "\n")
    proc.stdin.flush()


def receive(proc, expected_id, timeout):
    deadline = time.monotonic() + timeout
    while time.monotonic() < deadline:
        ready, _, _ = select.select(
            [proc.stdout], [], [], max(0, deadline - time.monotonic())
        )
        if not ready:
            break
        message = json.loads(proc.stdout.readline())
        if message.get("id") == expected_id:
            return message
    raise TimeoutError(f"no response for id={expected_id}")


with tempfile.TemporaryDirectory() as work:
    document = os.path.join(work, "probe.docx")
    subprocess.run([cli, "create", document], check=True)
    proc = subprocess.Popen(
        [cli, "mcp"],
        stdin=subprocess.PIPE,
        stdout=subprocess.PIPE,
        stderr=subprocess.DEVNULL,
        text=True,
        bufsize=1,
    )
    try:
        send(proc, {
            "jsonrpc": "2.0", "id": 1, "method": "initialize",
            "params": {
                "protocolVersion": "2024-11-05",
                "capabilities": {},
                "clientInfo": {"name": "stdin-regression", "version": "1.0"},
            },
        })
        receive(proc, 1, 10)
        send(proc, {
            "jsonrpc": "2.0",
            "method": "notifications/initialized",
            "params": {},
        })

        malformed = (
            f'batch {document} --commands '
            '[{"op":"add","path":"/body","type":"paragraph",'
            '"props":{"text":"malformed"}}]'
        )
        send(proc, {
            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
            "params": {
                "name": "officecli",
                "arguments": {"command": malformed},
            },
        })
        print("malformed isError:", receive(proc, 2, 5)["result"]["isError"])

        commands = json.dumps([{
            "op": "add", "path": "/body", "type": "paragraph",
            "props": {"text": "request after malformed batch"},
        }], separators=(",", ":"))
        send(proc, {
            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
            "params": {
                "name": "officecli",
                "arguments": {
                    "command": ["batch", document, "--commands", commands],
                },
            },
        })
        print("next request isError:", receive(proc, 3, 3)["result"]["isError"])
    finally:
        proc.terminate()
        proc.wait(timeout=3)
```

The patched output is:

```text
malformed isError: True
next request isError: False
```
