### PR TITLE
fix(help): pptx shape spacing is documented in the wrong unit

### DIFF
--- a/schemas/help/pptx/shape.json
+++ b/schemas/help/pptx/shape.json
@@ -316,7 +316,7 @@
     },
     "spacing": {
       "type": "number",
-      "description": "character spacing in 1/100 pt (drawingML rPr/@spc).",
+      "description": "character spacing in points. Stored as 1/100 pt in OOXML (drawingML rPr/@spc). Negative values tighten.",
       "aliases": [
         "spc",
         "charspacing",
@@ -326,7 +326,8 @@
       "set": true,
       "get": true,
       "examples": [
-        "--prop spacing=200"
+        "--prop spacing=2",
+        "--prop spacing=-0.5"
       ],
       "readback": "integer",
       "enforcement": "report"


### PR DESCRIPTION
Fixes #291. Help text only, 3 lines, no code change.

`schemas/help/pptx/shape.json` described `spacing` as **1/100 pt** and offered `--prop spacing=200` as the example. The setter parses **points** and multiplies by 100, so following the printed example writes `spc="20000"`, which is 200pt of letter spacing.

## Validation: authoritative reference (CONTRIBUTING rule 2, option 3)

The code is the reference here, since the defect is that the docs disagree with it.

`src/officecli/Handlers/Pptx/PowerPointHandler.ShapeProperties.cs:1502`:

```csharp
case "spacing" or "charspacing" or "letterspacing" or "spc":
{
    // Character spacing in points (e.g. "2" = +2pt, "-1" = -1pt)
    // Stored as 1/100th of a point in OOXML
    ...
    var spcVal = (int)(spcDbl * 100);
```

Its own error message says `Expected a finite number in points (e.g. 2, -1, 0.5)`.

`schemas/help/pptx/run.json` already documents the same OOXML attribute correctly ("character spacing in points. Stored as 1/100 pt in OOXML"), so the two help files contradicted each other for one attribute. This aligns `shape.json` with both the code and `run.json`.

The new examples are `spacing=2` and `spacing=-0.5`, the latter because the setter accepts fractional points and negatives tighten.

## Not changed

`"readback": "integer"` on this property looks questionable too, since readback is described elsewhere as the point value and points can be fractional. I did not trace the readback path, so I left it rather than guess. Happy to open a separate issue if that is worth checking.