### PR TITLE
feat(pptx): add slide-number visibility option for HTML previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ officecli view deck.pptx outline
 
 # View as HTML — opens a rendered preview in your browser, no server needed
 officecli view deck.pptx html
+officecli view deck.pptx html --slide-numbers false  # hide slide-number fields inside slides
 
 # Get structured JSON for any element
 officecli get deck.pptx '/slide[1]/shape[1]' --json

--- a/SKILL.md
+++ b/SKILL.md
@@ -108,7 +108,7 @@ officecli validate <file>             # Validate against OpenXML schema
 | `issues` | Formatting/content/structure problems | `--type format\|content\|structure`, `--limit N` |
 | `text` | Plain text extraction | `--start N --end N`, `--max-lines N` |
 | `annotated` | Text with formatting annotations | |
-| `html` | Static HTML snapshot — same renderer as `watch`, no server needed | `--browser`, `--page N` (docx), `--start N --end N` (pptx) |
+| `html` | Static HTML snapshot — same renderer as `watch`, no server needed | `--browser`, `--page N` (docx), `--start N --end N` / `--slide-numbers true\|false` (pptx) |
 | `screenshot` / `svg` / `pdf` / `forms` | PNG via headless browser / SVG (pptx slide) / PDF via exporter plugin / form-fields JSON via format-handler plugin | `-o`, `--screenshot-width/-height`, pptx `--grid N` |
 
 Use `view html` for one-shot snapshots (CI artifacts, archival, diffing); use `watch` when you need live refresh or browser-side click-to-select.

--- a/src/officecli/CommandBuilder.View.cs
+++ b/src/officecli/CommandBuilder.View.cs
@@ -33,6 +33,11 @@ static partial class CommandBuilder
         };
         var renderOpt = new Option<string>("--render") { Description = "Screenshot rendering path (docx/pptx): auto (default; native on Windows w/ Word/PowerPoint, html elsewhere), native (force OS-native, error if unavailable), html", DefaultValueFactory = _ => "auto" };
         var withPagesOpt = new Option<bool>("--page-count") { Description = "stats mode (docx only): also report total page count via Word repagination (Win + Word required; slow on long docs)" };
+        var slideNumbersOpt = new Option<string>("--slide-numbers")
+        {
+            Description = "PPTX HTML mode: render slide-number placeholders and slidenum fields (true by default; pass false to hide page-internal slide numbers)",
+            DefaultValueFactory = _ => "true",
+        };
 
         var viewCommand = new Command("view", "View document in different modes");
         viewCommand.Add(viewFileArg);
@@ -52,6 +57,7 @@ static partial class CommandBuilder
         viewCommand.Add(gridOpt);
         viewCommand.Add(renderOpt);
         viewCommand.Add(withPagesOpt);
+        viewCommand.Add(slideNumbersOpt);
         viewCommand.Add(jsonOption);
 
         viewCommand.SetAction(result => { var json = result.GetValue(jsonOption); return SafeRun(() =>
@@ -80,6 +86,11 @@ static partial class CommandBuilder
             if (renderMode is not ("auto" or "native" or "html"))
                 throw new OfficeCli.Core.CliException($"Invalid --render value: {renderMode}. Valid: auto, native, html") { Code = "invalid_render", ValidValues = ["auto", "native", "html"] };
             var withPages = result.GetValue(withPagesOpt);
+            var slideNumbersValue = result.GetValue(slideNumbersOpt) ?? "true";
+            if (!bool.TryParse(slideNumbersValue, out var includeSlideNumbers))
+                throw new OfficeCli.Core.CliException(
+                    $"Invalid --slide-numbers value: {slideNumbersValue}. Valid: true, false")
+                { Code = "invalid_value", ValidValues = ["true", "false"] };
 
             // pdf mode runs entirely through an exporter plugin (no handler
             // open, no resident hop — the plugin gets a snapshot of the
@@ -133,6 +144,7 @@ static partial class CommandBuilder
                 if (gridCols != 0) req.Args["grid"] = gridCols.ToString(); // -1 = auto
                 if (renderMode != "auto") req.Args["render"] = renderMode;
                 if (withPages) req.Args["page-count"] = "true";
+                if (!includeSlideNumbers) req.Args["slide-numbers"] = "false";
             }, json) is {} rc) return rc;
 
             var format = json ? OutputFormat.Json : OutputFormat.Text;
@@ -151,7 +163,12 @@ static partial class CommandBuilder
                     // range checking, matching SVG mode's CONSISTENCY(strict-page).
                     var (pStart, pEnd) = ParsePptHtmlPage(pageFilter, start, end, pptHandler);
                     html = RenderViaRegistry(handler, "pptx",
-                        new OfficeCli.Core.Rendering.RenderOptions { StartPage = pStart, EndPage = pEnd });
+                        new OfficeCli.Core.Rendering.RenderOptions
+                        {
+                            StartPage = pStart,
+                            EndPage = pEnd,
+                            IncludeSlideNumbers = includeSlideNumbers,
+                        });
                 }
                 else if (handler is OfficeCli.Handlers.ExcelHandler)
                     html = RenderViaRegistry(handler, "xlsx", new OfficeCli.Core.Rendering.RenderOptions());

--- a/src/officecli/Core/Rendering/RenderOptions.cs
+++ b/src/officecli/Core/Rendering/RenderOptions.cs
@@ -6,7 +6,7 @@ namespace OfficeCli.Core.Rendering;
 /// <summary>
 /// A render request. Unifies the per-handler entry points that exist today
 /// (WordHandler.ViewAsHtml(pageFilter, gridCols, gridCellWpx),
-/// PowerPointHandler.ViewAsHtml(start, end, gridCols, viewportPx),
+/// PowerPointHandler.ViewAsHtml(start, end, gridCols, viewportPx, includeSlideNumbers),
 /// ExcelHandler.ViewAsHtml(), FormatHandlerProxy.ViewAsHtml(page)) into a single
 /// options object so dispatch no longer branches on the concrete handler type.
 /// <para>
@@ -40,6 +40,9 @@ public sealed class RenderOptions
 
     /// <summary>Viewport width in px for slide-style scaling (pptx). 0 = renderer default.</summary>
     public int ViewportPx { get; init; }
+
+    /// <summary>Whether PPTX HTML renders slide-number placeholders and slidenum fields.</summary>
+    public bool IncludeSlideNumbers { get; init; } = true;
 
     /// <summary>Target raster width in px for Png/Pdf output. 0 = renderer default.</summary>
     public int RasterWidthPx { get; init; }

--- a/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.Shapes.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.Shapes.cs
@@ -20,7 +20,8 @@ public partial class PowerPointHandler
     /// </summary>
     private static void RenderShape(StringBuilder sb, Shape shape, OpenXmlPart part,
         Dictionary<string, string> themeColors, (long x, long y, long cx, long cy)? overridePos = null,
-        string? dataPath = null, bool suppressText = false, int? slideNumber = null)
+        string? dataPath = null, bool suppressText = false, int? slideNumber = null,
+        bool includeSlideNumbers = true)
     {
         // prst="line" auto-shapes are line-segment geometry; render as SVG
         // through the connector pipeline so they don't degrade to a div with
@@ -785,7 +786,8 @@ public partial class PowerPointHandler
             // R11-3: pass the shape's <p:style>/<a:fontRef> schemeClr down as the
             // final fallback run color (used only when no explicit/inherited color).
             var fontRefDefaultColor = ResolveStyleRefSchemeColor(shape.ShapeStyle?.FontReference, themeColors);
-            RenderTextBody(sb, shape.TextBody, themeColors, shape, part, fontRefDefaultColor, slideNumber);
+            RenderTextBody(sb, shape.TextBody, themeColors, shape, part, fontRefDefaultColor,
+                slideNumber, includeSlideNumbers);
 
             if (!string.IsNullOrEmpty(columnStyle))
                 sb.Append("</div>");

--- a/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.Text.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.Text.cs
@@ -16,7 +16,7 @@ public partial class PowerPointHandler
 
     private static void RenderTextBody(StringBuilder sb, OpenXmlElement textBody, Dictionary<string, string> themeColors,
         Shape? placeholderShape = null, OpenXmlPart? placeholderPart = null, string? fontRefDefaultColor = null,
-        int? slideNumber = null)
+        int? slideNumber = null, bool includeSlideNumbers = true)
     {
         // Per-textbody auto-number counters, keyed by scheme type + paragraph level.
         // Resets when switching type/level. Paragraphs aren't wrapped in <ol>, so
@@ -377,7 +377,7 @@ public partial class PowerPointHandler
             var hasMath = para.OuterXml.Contains("oMath");
             var runs = para.Elements<Drawing.Run>().ToList();
             bool hasVisibleField = para.Elements<Drawing.Field>()
-                .Any(f => !string.IsNullOrEmpty(ResolveFieldText(f, slideNumber)));
+                .Any(f => !string.IsNullOrEmpty(ResolveFieldText(f, slideNumber, includeSlideNumbers)));
             bool hasVisibleText = runs.Any(r => !string.IsNullOrEmpty(r.Text?.Text)) || hasVisibleField;
             bool isEmptyPara = !hasVisibleText && !hasMath;
 
@@ -647,7 +647,7 @@ public partial class PowerPointHandler
                         // size / color exactly like a real run. slidenum is
                         // recomputed to the actual 1-based slide position when known
                         // (matching PowerPoint); other fields emit their cached <a:t>.
-                        var fldText = ResolveFieldText(fld, slideNumber);
+                        var fldText = ResolveFieldText(fld, slideNumber, includeSlideNumbers);
                         if (string.IsNullOrEmpty(fldText)) continue;
                         var fldRun = new Drawing.Run();
                         var fldRpr = fld.GetFirstChild<Drawing.RunProperties>();
@@ -664,16 +664,20 @@ public partial class PowerPointHandler
         }
     }
 
-    // Effective display text for an <a:fld> in the HTML preview. For
-    // type="slidenum" we prefer the ACTUAL 1-based slide number when the
-    // renderer threaded it (PowerPoint recomputes slidenum to the real slide
-    // position), falling back to the cached <a:t> when unknown. All other field
-    // types (datetime*, etc.) emit their cached <a:t> verbatim. Mirrors
-    // GetShapeText's field handling for the non-render extractor.
-    private static string ResolveFieldText(Drawing.Field fld, int? slideNumber)
+    // Effective display text for an <a:fld> in the HTML preview. A disabled
+    // slide-number option suppresses type="slidenum" entirely. Otherwise we
+    // prefer the ACTUAL 1-based slide number when the renderer threaded it
+    // (PowerPoint recomputes slidenum to the real slide position), falling back
+    // to the cached <a:t> when unknown. All other field types (datetime*, etc.)
+    // emit their cached <a:t> verbatim. Mirrors GetShapeText's field handling
+    // for the non-render extractor.
+    private static string ResolveFieldText(Drawing.Field fld, int? slideNumber,
+        bool includeSlideNumbers = true)
     {
         var cached = string.Concat(fld.Elements<Drawing.Text>().Select(t => t.Text));
         var fldType = fld.Type?.Value ?? "";
+        if (fldType == "slidenum" && !includeSlideNumbers)
+            return "";
         if (fldType == "slidenum" && slideNumber.HasValue)
             return slideNumber.Value.ToString();
         return cached;

--- a/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.cs
@@ -69,7 +69,8 @@ public partial class PowerPointHandler
     /// Each slide is rendered as an absolutely-positioned div with CSS styling.
     /// Images are embedded as base64 data URIs.
     /// </summary>
-    public string ViewAsHtml(int? startSlide = null, int? endSlide = null, int gridCols = 0, int viewportPx = 1600)
+    public string ViewAsHtml(int? startSlide = null, int? endSlide = null, int gridCols = 0,
+        int viewportPx = 1600, bool includeSlideNumbers = true)
     {
         // CSS demands '.' as the decimal separator; under comma-decimal locales
         // (de-DE, fr-FR, …) every `$"{double}pt"` interpolation deep in the
@@ -213,8 +214,9 @@ public partial class PowerPointHandler
             sb.AppendLine(">");
 
             // Render slide elements + inherited layout placeholders
-            RenderLayoutPlaceholders(sb, slidePart, slideColors, slideNum);
-            RenderSlideElements(sb, slidePart, slideNum, slideWidthEmu, slideHeightEmu, slideColors);
+            RenderLayoutPlaceholders(sb, slidePart, slideColors, slideNum, includeSlideNumbers);
+            RenderSlideElements(sb, slidePart, slideNum, slideWidthEmu, slideHeightEmu, slideColors,
+                includeSlideNumbers);
 
             sb.AppendLine("    </div>");
             sb.AppendLine("  </div>");
@@ -297,7 +299,7 @@ public partial class PowerPointHandler
     /// Render a single slide's HTML fragment (slide-container div) for incremental updates.
     /// Returns null if the slide number is out of range.
     /// </summary>
-    public string? RenderSlideHtml(int slideNum)
+    public string? RenderSlideHtml(int slideNum, bool includeSlideNumbers = true)
     {
         // Each slide-render call must be self-contained: the receiver (watch
         // SSE replace) has no other source for the GLB data scripts.
@@ -328,8 +330,9 @@ public partial class PowerPointHandler
             sb.Append($" style=\"{string.Join("", slideStyles)}\"");
         sb.AppendLine(">");
 
-        RenderLayoutPlaceholders(sb, slidePart, slideColors, slideNum);
-        RenderSlideElements(sb, slidePart, slideNum, slideWidthEmu, slideHeightEmu, slideColors);
+        RenderLayoutPlaceholders(sb, slidePart, slideColors, slideNum, includeSlideNumbers);
+        RenderSlideElements(sb, slidePart, slideNum, slideWidthEmu, slideHeightEmu, slideColors,
+            includeSlideNumbers);
 
         sb.AppendLine("    </div>");
         sb.AppendLine("  </div>");
@@ -666,7 +669,8 @@ public partial class PowerPointHandler
     // ==================== Render Slide Elements ====================
 
     private void RenderSlideElements(StringBuilder sb, SlidePart slidePart, int slideNum,
-        long slideWidthEmu, long slideHeightEmu, Dictionary<string, string> themeColors)
+        long slideWidthEmu, long slideHeightEmu, Dictionary<string, string> themeColors,
+        bool includeSlideNumbers = true)
     {
         var shapeTree = GetSlide(slidePart).CommonSlideData?.ShapeTree;
         if (shapeTree == null) return;
@@ -685,7 +689,11 @@ public partial class PowerPointHandler
             {
                 case Shape shape:
                     shapeIdx++;
-                    RenderShape(sb, shape, slidePart, themeColors, dataPath: PathFor("shape", shape, shapeIdx), slideNumber: slideNum);
+                    if (!includeSlideNumbers && IsSlideNumberPlaceholder(shape))
+                        break;
+                    RenderShape(sb, shape, slidePart, themeColors,
+                        dataPath: PathFor("shape", shape, shapeIdx), slideNumber: slideNum,
+                        includeSlideNumbers: includeSlideNumbers);
                     break;
                 case Picture pic:
                     picIdx++;
@@ -747,7 +755,8 @@ public partial class PowerPointHandler
     /// overridden by the slide itself. This includes footers, slide numbers,
     /// date/time, logos, and decorative shapes from the layout/master.
     /// </summary>
-    private void RenderLayoutPlaceholders(StringBuilder sb, SlidePart slidePart, Dictionary<string, string> themeColors, int slideNum = 1)
+    private void RenderLayoutPlaceholders(StringBuilder sb, SlidePart slidePart,
+        Dictionary<string, string> themeColors, int slideNum = 1, bool includeSlideNumbers = true)
     {
         // Collect placeholder identifiers already present on the slide
         var slidePlaceholders = new HashSet<string>();
@@ -766,7 +775,8 @@ public partial class PowerPointHandler
         // Render shapes from SlideLayout (higher priority)
         var layoutPart = slidePart.SlideLayoutPart;
         if (layoutPart != null)
-            RenderInheritedShapes(sb, layoutPart.SlideLayout?.CommonSlideData?.ShapeTree, layoutPart, slidePlaceholders, themeColors, slideNum);
+            RenderInheritedShapes(sb, layoutPart.SlideLayout?.CommonSlideData?.ShapeTree,
+                layoutPart, slidePlaceholders, themeColors, slideNum, includeSlideNumbers);
 
         // Render shapes from SlideMaster (lower priority, only if not in layout).
         // R12-2: <p:sld showMasterSp="0"> suppresses master-level decoration.
@@ -775,7 +785,8 @@ public partial class PowerPointHandler
         var showMasterSp = GetSlide(slidePart).ShowMasterShapes?.Value ?? true;
         var masterPart = layoutPart?.SlideMasterPart;
         if (masterPart != null && showMasterSp)
-            RenderInheritedShapes(sb, masterPart.SlideMaster?.CommonSlideData?.ShapeTree, masterPart, slidePlaceholders, themeColors, slideNum);
+            RenderInheritedShapes(sb, masterPart.SlideMaster?.CommonSlideData?.ShapeTree,
+                masterPart, slidePlaceholders, themeColors, slideNum, includeSlideNumbers);
     }
 
     // RenderInheritedShapes — render the layout/master shapes that the slide
@@ -795,7 +806,8 @@ public partial class PowerPointHandler
     //      placeholder authored without an explicit type leaked its prompt
     //      text onto the slide.
     private void RenderInheritedShapes(StringBuilder sb, ShapeTree? shapeTree, OpenXmlPart part,
-        HashSet<string> skipIndices, Dictionary<string, string> themeColors, int slideNum = 1)
+        HashSet<string> skipIndices, Dictionary<string, string> themeColors, int slideNum = 1,
+        bool includeSlideNumbers = true)
     {
         if (shapeTree == null) return;
 
@@ -804,7 +816,8 @@ public partial class PowerPointHandler
             switch (element)
             {
                 case Shape shape:
-                    RenderInheritedShape(sb, shape, part, skipIndices, themeColors, slideNum);
+                    RenderInheritedShape(sb, shape, part, skipIndices, themeColors, slideNum,
+                        includeSlideNumbers);
                     break;
                 // R12-1: PowerPoint renders group/connector/graphic-frame
                 // decoration from the layout/master tree too. The old code
@@ -835,10 +848,14 @@ public partial class PowerPointHandler
     }
 
     private void RenderInheritedShape(StringBuilder sb, Shape shape, OpenXmlPart part,
-        HashSet<string> skipIndices, Dictionary<string, string> themeColors, int slideNum = 1)
+        HashSet<string> skipIndices, Dictionary<string, string> themeColors, int slideNum = 1,
+        bool includeSlideNumbers = true)
     {
         var ph = shape.NonVisualShapeProperties?.ApplicationNonVisualDrawingProperties
             ?.GetFirstChild<PlaceholderShape>();
+
+        if (!includeSlideNumbers && IsSlideNumberPlaceholder(shape))
+            return;
 
         bool suppressText = false;
         if (ph != null)
@@ -888,8 +905,13 @@ public partial class PowerPointHandler
         if (string.IsNullOrWhiteSpace(text) && !hasFill && !hasLine)
             return;
 
-        RenderShape(sb, shape, part, themeColors, suppressText: suppressText, slideNumber: slideNum);
+        RenderShape(sb, shape, part, themeColors, suppressText: suppressText,
+            slideNumber: slideNum, includeSlideNumbers: includeSlideNumbers);
     }
+
+    private static bool IsSlideNumberPlaceholder(Shape shape) =>
+        shape.NonVisualShapeProperties?.ApplicationNonVisualDrawingProperties
+            ?.GetFirstChild<PlaceholderShape>()?.Type?.Value == PlaceholderValues.SlideNumber;
 
     private static bool IsLayoutSuppliedTextPlaceholder(PlaceholderValues type) =>
         type == PlaceholderValues.DateAndTime

--- a/src/officecli/Handlers/Rendering/BasicRenderers.cs
+++ b/src/officecli/Handlers/Rendering/BasicRenderers.cs
@@ -87,7 +87,8 @@ public sealed class PptBasicRenderer : IRenderer
             return RenderResult.Svg(h.ViewAsSvg(options.StartPage ?? 1));
 
         var viewport = options.ViewportPx > 0 ? options.ViewportPx : DefaultViewportPx;
-        var html = h.ViewAsHtml(options.StartPage, options.EndPage, options.GridColumns, viewport);
+        var html = h.ViewAsHtml(options.StartPage, options.EndPage, options.GridColumns, viewport,
+            options.IncludeSlideNumbers);
         return RenderResult.Html(html);
     }
 }

--- a/src/officecli/ResidentServer.cs
+++ b/src/officecli/ResidentServer.cs
@@ -1490,6 +1490,8 @@ public class ResidentServer : IDisposable
         var limit = req.GetIntArg("limit");
         var cols = req.GetCols("cols");
         var pageFilter = req.GetArgOrNull("page");
+        var includeSlideNumbers = !req.GetArg("slide-numbers", "true")
+            .Equals("false", StringComparison.OrdinalIgnoreCase);
 
         if (mode!.ToLowerInvariant() is "html" or "h")
         {
@@ -1499,7 +1501,12 @@ public class ResidentServer : IDisposable
                 // BUG-R36-B7: honor --page on pptx html with strict bounds.
                 var (pStart, pEnd) = ResolvePptHtmlPage(pageFilter, start, end, pptHandler);
                 html = CommandBuilder.RenderViaRegistry(_handler, "pptx",
-                    new OfficeCli.Core.Rendering.RenderOptions { StartPage = pStart, EndPage = pEnd });
+                    new OfficeCli.Core.Rendering.RenderOptions
+                    {
+                        StartPage = pStart,
+                        EndPage = pEnd,
+                        IncludeSlideNumbers = includeSlideNumbers,
+                    });
             }
             else if (_handler is OfficeCli.Handlers.ExcelHandler)
                 html = CommandBuilder.RenderViaRegistry(_handler, "xlsx", new OfficeCli.Core.Rendering.RenderOptions());


### PR DESCRIPTION
Add --slide-numbers true|false support while preserving the existing default behavior.

Suppress slide-number placeholders and slidenum fields when disabled.

Propagate the option through direct and resident rendering paths and document its usage.