### PR TITLE
fix(update): honor OFFICECLI_SKIP_UPDATE in MCP paths

### DIFF
--- a/src/officecli/Core/UpdateChecker.cs
+++ b/src/officecli/Core/UpdateChecker.cs
@@ -45,6 +45,9 @@ internal static class UpdateChecker
     /// </summary>
     internal static void CheckInBackground()
     {
+        if (Environment.GetEnvironmentVariable("OFFICECLI_SKIP_UPDATE") == "1")
+            return;
+
         // Best-effort: SaveConfig falls back to $TMPDIR inside containers when
         // home is read-only, so a CreateDirectory failure here is not fatal.
         try { Directory.CreateDirectory(ConfigDir); } catch { /* continue */ }
@@ -102,6 +105,9 @@ internal static class UpdateChecker
     /// </summary>
     internal static void RunRefresh()
     {
+        if (Environment.GetEnvironmentVariable("OFFICECLI_SKIP_UPDATE") == "1")
+            return;
+
         try
         {
             var config = LoadConfig();


### PR DESCRIPTION
## Summary

- honor `OFFICECLI_SKIP_UPDATE=1` inside `UpdateChecker.CheckInBackground()`
- apply the same guard to the internal `__update-check__` / `RunRefresh()` path
- return before config writes, pending-update swaps, network checks, or downloads

## Root cause

`Program.cs` dispatches `mcp`, `mcp-serve`, and the internal `__update-check__`
command before the existing per-invocation `OFFICECLI_SKIP_UPDATE` guard. The
MCP server then calls `CheckInBackground()` at startup and every hour, so an MCP
process could still stage and apply a self-update even when its parent explicitly
disabled updates.

Keeping the guard in `UpdateChecker` makes the environment variable an invariant
for every automatic-update entry point while preserving the default auto-update
behavior when the variable is unset.

## Validation

Black-box reproduction with an isolated home and `autoUpdate=false`:

```bash
tmp_home=$(mktemp -d)
HOME="$tmp_home" officecli config autoUpdate false
before=$(shasum -a 256 "$tmp_home/.officecli/config.json")
HOME="$tmp_home" USERPROFILE="$tmp_home" OFFICECLI_SKIP_UPDATE=1 officecli mcp </dev/null
after=$(shasum -a 256 "$tmp_home/.officecli/config.json")
test "$before" = "$after"
```

- Before this change: the hashes differ because MCP still runs
  `CheckInBackground()` and writes `lastSkillRefreshVersion`.
- After this change: the hashes are identical.
- Control run without `OFFICECLI_SKIP_UPDATE`: the hashes still differ, confirming
  the normal update path remains enabled.
- `dotnet build src/officecli/officecli.csproj -c Release --no-restore --nologo`
  succeeds (one pre-existing nullable warning in `ExcelHandler.SheetShift.cs`).
- `dotnet publish src/officecli/officecli.csproj -c Release -r win-x64`
  succeeds and produces an x86-64 Windows PE executable.
