### PR TITLE
fix(word): classify SDT checkboxes in view forms

### DIFF
--- a/src/officecli/Handlers/Word/WordHandler.View.cs
+++ b/src/officecli/Handlers/Word/WordHandler.View.cs
@@ -1651,12 +1651,19 @@ public partial class WordHandler
             var lockVal = lockEl?.Val?.InnerText;
 
             // Determine SDT type
+            var checkBox = sdtProps.GetFirstChild<DocumentFormat.OpenXml.Office2010.Word.SdtContentCheckBox>();
             string sdtType;
-            if (sdtProps.GetFirstChild<SdtContentDropDownList>() != null) sdtType = "dropdown";
+            if (checkBox != null) sdtType = "checkbox";
+            else if (sdtProps.GetFirstChild<SdtContentDropDownList>() != null) sdtType = "dropdown";
             else if (sdtProps.GetFirstChild<SdtContentComboBox>() != null) sdtType = "combobox";
             else if (sdtProps.GetFirstChild<SdtContentDate>() != null) sdtType = "date";
             else if (sdtProps.GetFirstChild<SdtContentText>() != null) sdtType = "text";
             else sdtType = "richtext";
+
+            bool? checkedState = checkBox == null
+                ? null
+                : checkBox.Checked?.Val?.InnerText == "1"
+                    || string.Equals(checkBox.Checked?.Val?.InnerText, "true", StringComparison.OrdinalIgnoreCase);
 
             // Items for dropdown/combobox
             string? items = null;
@@ -1678,9 +1685,10 @@ public partial class WordHandler
                 FieldType: sdtType,
                 Editable: editable,
                 Alias: alias ?? tag,
-                Value: displayValue,
+                Value: checkBox == null ? displayValue : null,
                 Items: items,
-                Lock: lockVal));
+                Lock: lockVal,
+                Checked: checkedState));
         }
 
         // 2. Collect legacy form fields


### PR DESCRIPTION
## Summary

- classify Word SDT checkbox controls as `checkbox` in `view forms`
- expose their checked state through the existing `checked` field
- avoid returning the glyph as a generic text value

Closes #310.

## Root cause

`CollectFormFieldEntries` handled dropdown, combo box, date, and text SDTs, but omitted `SdtContentCheckBox`. The same checkbox was already recognized correctly by the Word navigation path.

## Validation

Reproduced with the released OfficeCLI 1.0.143:

```bash
officecli create /tmp/checkbox.docx
officecli add /tmp/checkbox.docx /body --type sdt --prop type=checkbox --prop alias=approval --prop checked=true
officecli close /tmp/checkbox.docx
officecli view /tmp/checkbox.docx forms --json
```

Before: `type` was `richtext` and `value` was the checkbox glyph.

Built the modified source with .NET SDK 10.0.400, then ran the same fixture through that build. After: `type` is `checkbox` and `checked` is `true`.

- `dotnet build src/officecli/officecli.csproj -c Release` (0 errors; one pre-existing nullable warning in `ExcelHandler.SheetShift.cs`)
- exact CLI JSON assertion for `type == checkbox` and `checked == true` passed
- `git diff --check` passed

## Screenshots

Not applicable; this is a CLI JSON classification fix.