### PR TITLE
fix(docx): render explicit whitespace underlines in HTML preview

### DIFF
--- a/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Css.cs
+++ b/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Css.cs
@@ -1661,26 +1661,21 @@ public partial class WordHandler
         // OOXML vals: single, double, thick, dotted, dottedHeavy, dash, dashedHeavy,
         //   dashLong, dashLongHeavy, dotDash, dotDashHeavy, dotDotDash, dotDotDashHeavy,
         //   wave, wavyHeavy, wavyDouble, words, none
-        if (rProps.Underline?.Val != null)
+        if (rProps.Underline != null)
         {
-            var ulVal = rProps.Underline.Val.InnerText;
+            // CT_Underline defaults a missing w:val to single. Treat <w:u/>
+            // the same as <w:u w:val="single"/> for both visible text and the
+            // whitespace fill-line path in HtmlPreview.Text.
+            var ulVal = UnderlineValue(rProps.Underline);
             if (ulVal != "none")
             {
                 parts.Add("text-decoration:underline");
                 // Map to text-decoration-style
-                string? style = ulVal switch
-                {
-                    "double" or "wavyDouble" => "double",
-                    "dotted" or "dottedHeavy" => "dotted",
-                    "dash" or "dashedHeavy" or "dashLong" or "dashLongHeavy"
-                        or "dotDash" or "dotDashHeavy" or "dotDotDash" or "dotDotDashHeavy" => "dashed",
-                    "wave" or "wavyHeavy" => "wavy",
-                    _ => null,
-                };
+                var style = UnderlineDecorationStyle(ulVal);
                 if (style != null)
                     parts.Add($"text-decoration-style:{style}");
                 // Thickness: "thick" and any *Heavy variant
-                if (ulVal == "thick" || (ulVal?.EndsWith("Heavy") ?? false))
+                if (IsHeavyUnderline(ulVal))
                     parts.Add("text-decoration-thickness:2px");
                 // Per-underline color via w:u w:color="RRGGBB"
                 var ulColor = rProps.Underline.Color?.Value;

--- a/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.HtmlPreview.Text.cs
@@ -154,6 +154,53 @@ public partial class WordHandler
         return $"border-bottom:{width} {lineStyle} {color};";
     }
 
+    private static string UnderlineValue(Underline underline)
+        => underline.Val?.InnerText ?? "single";
+
+    private static string? UnderlineDecorationStyle(string ulVal) => ulVal switch
+    {
+        "double" or "wavyDouble" => "double",
+        "dotted" or "dottedHeavy" => "dotted",
+        "dash" or "dashedHeavy" or "dashLong" or "dashLongHeavy"
+            or "dotDash" or "dotDashHeavy" or "dotDotDash" or "dotDotDashHeavy" => "dashed",
+        "wave" or "wavyHeavy" => "wavy",
+        _ => null,
+    };
+
+    private static bool IsHeavyUnderline(string ulVal)
+        => ulVal == "thick" || ulVal.EndsWith("Heavy", StringComparison.Ordinal);
+
+    // Map a directly declared w:u to the border used for a whitespace-only
+    // fill-in line. Unlike UnderlineBorderFromStyle, this reads the underline
+    // element itself so a co-present double-strike's CSS style cannot turn a
+    // single underline into a double border. A missing w:val defaults to single;
+    // `words` intentionally returns no border because it never decorates spaces.
+    private static string UnderlineBorderFromUnderline(Underline? underline)
+    {
+        if (underline == null) return "";
+        var ulVal = UnderlineValue(underline);
+        if (ulVal is "none" or "words") return "";
+
+        var width = "1px";
+        var lineStyle = "solid";
+        var decorationStyle = UnderlineDecorationStyle(ulVal);
+        if (decorationStyle == "double")
+        { width = "3px"; lineStyle = decorationStyle; }
+        else if (decorationStyle is "dotted" or "dashed")
+            lineStyle = decorationStyle;
+        // wavy has no border equivalent → keep solid.
+        if (IsHeavyUnderline(ulVal))
+            width = "2px";
+
+        var color = "currentColor";
+        var ulColor = underline.Color?.Value;
+        if (!string.IsNullOrEmpty(ulColor)
+            && !ulColor.Equals("auto", StringComparison.OrdinalIgnoreCase)
+            && IsHexColor(ulColor))
+            color = $"#{ulColor}";
+        return $"border-bottom:{width} {lineStyle} {color};";
+    }
+
     /// <summary>
     /// True when <paramref name="run"/> holds the LAST &lt;w:tab&gt; in the
     /// paragraph (counting tabs at any depth, e.g. inside a &lt;w:hyperlink&gt;
@@ -238,7 +285,7 @@ public partial class WordHandler
     // Removes the "underline" keyword from a space-separated text-decoration
     // declaration while preserving any co-present "line-through". Leaves all
     // other style declarations untouched.
-    private static string StripUnderlineDecoration(string style)
+    private static string StripUnderlineDecoration(string style, bool preserveDoubleStrikeStyle)
     {
         var parts = style.Split(';');
         var kept = new List<string>(parts.Length);
@@ -257,8 +304,19 @@ public partial class WordHandler
             }
             // Underline-only sub-properties become meaningless once underline
             // is gone; drop them so no orphan style/thickness/color lingers.
-            if (trimmed.StartsWith("text-decoration-style:", StringComparison.Ordinal)
-                || trimmed.StartsWith("text-decoration-thickness:", StringComparison.Ordinal)
+            if (trimmed.StartsWith("text-decoration-style:", StringComparison.Ordinal))
+            {
+                // GetRunInlineCss uses this declaration for w:dstrike too. Once
+                // underline is removed, keep exactly one double style when the
+                // remaining line-through is a double strike; discard underline-
+                // only styles such as dotted/dashed/wavy.
+                if (preserveDoubleStrikeStyle
+                    && trimmed == "text-decoration-style:double"
+                    && !kept.Contains(trimmed))
+                    kept.Add(trimmed);
+                continue;
+            }
+            if (trimmed.StartsWith("text-decoration-thickness:", StringComparison.Ordinal)
                 || trimmed.StartsWith("text-decoration-color:", StringComparison.Ordinal))
                 continue;
             if (trimmed.Length > 0) kept.Add(trimmed);
@@ -858,18 +916,33 @@ public partial class WordHandler
         var style = GetRunInlineCss(rProps, para);
 
         // Phantom-underline suppression: a run whose entire visible content is
-        // whitespace (e.g. a 30-space spacer carrying a Heading2 style's
-        // <w:u w:val="single"/>) draws NO underline in real Word. Strip the
-        // inherited underline from such a run's style. Restricted to runs whose
+        // whitespace (e.g. a 30-space spacer inheriting Heading2's underline)
+        // draws NO underline in real Word. A DIRECT w:u on the run is different:
+        // it is a deliberate fill-in line, so preserve its advance width and
+        // re-express the underline as a border (Chromium does not reliably paint
+        // text-decoration across trailing spaces). Restricted to runs whose
         // content is purely whitespace TEXT — tab-only runs are excluded so the
         // underlined-tab heading separator (RunHasContentAfter path below) and
-        // positional-tab leaders keep their decoration. line-through is
-        // preserved (strike on a blank run is unusual but harmless).
+        // positional-tab leaders keep their decoration. StripUnderlineDecoration
+        // preserves any co-present line-through; other run CSS such as character
+        // spacing remains on the inline-block.
         if (!string.IsNullOrEmpty(style)
             && style.Contains("text-decoration:underline", StringComparison.Ordinal)
             && IsWhitespaceOnlyTextRun(run))
         {
-            style = StripUnderlineDecoration(style);
+            var underlineBorder = UnderlineBorderFromUnderline(run.RunProperties?.Underline);
+            var preserveDoubleStrikeStyle = rProps.DoubleStrike != null
+                && (rProps.DoubleStrike.Val == null || rProps.DoubleStrike.Val.Value);
+            if (!string.IsNullOrEmpty(underlineBorder))
+            {
+                style = StripUnderlineDecoration(style, preserveDoubleStrikeStyle);
+                var fillLineCss = $"display:inline-block;white-space:pre;{underlineBorder}";
+                style = string.IsNullOrEmpty(style) ? fillLineCss : style + ";" + fillLineCss;
+            }
+            else
+            {
+                style = StripUnderlineDecoration(style, preserveDoubleStrikeStyle);
+            }
         }
 
         // Format revision (w:rPrChange) — a tracked formatting change. The


### PR DESCRIPTION
## Summary

- render whitespace-only runs with a directly declared, enabled `w:u` as width-preserving inline blocks with equivalent bottom borders
- keep suppressing phantom underlines inherited from character or paragraph styles
- treat `<w:u/>` without `w:val` as the OOXML default `single`
- avoid drawing fill lines for `w:u w:val="words"` whitespace
- derive fill-line style from the direct `w:u` element so underline and strike variants do not contaminate each other

Fixes #306.

## Root cause

The renderer first merges direct and inherited run properties, then previously removed underline decoration from every whitespace-only run. At that point it could not distinguish a deliberate fill-in line declared directly on the run from whitespace that merely inherited underline through a style.

The initial border mapping also used merged CSS. Because underline and `w:dstrike` both contribute `text-decoration-style`, a direct single underline combined with double strike could incorrectly become a double bottom border.

The fix reads direct `w:u` properties for whitespace fill lines while continuing to use effective properties for the remaining run formatting.

## Validation

Built the project successfully:

```sh
dotnet build src/officecli/officecli.csproj \
  --configuration Release \
  --no-restore
```

Result: 0 errors. The build reports one unrelated existing nullable warning in `ExcelHandler.SheetShift.cs`.

Generated HTML from a minimal DOCX fixture containing direct, inherited, missing-value, `words`, color, spacing, single-strike, and double-strike cases:

```sh
dotnet src/officecli/bin/Release/net10.0/osx-arm64/officecli.dll \
  view whitespace-underline.docx html \
  --out review-final.html
```

All 14 HTML assertions passed:

- direct `single` whitespace -> `border-bottom:1px solid currentColor`
- inherited whitespace underline remains suppressed
- direct red `double` whitespace -> `border-bottom:3px double #FF0000`
- red double underline plus `w:strike` retains single `line-through`
- character spacing remains `letter-spacing:1pt`
- `<w:u/>` whitespace defaults to a single fill line
- `<w:u/>` visible text remains `text-decoration:underline`
- `w:u w:val="words"` whitespace has no fill line
- `words` visible text remains `text-decoration:underline`
- single underline plus `w:dstrike` keeps `border-bottom:1px solid currentColor`
- single underline plus `w:dstrike` keeps `text-decoration-style:double` for the line-through
- double underline plus `w:strike` keeps `border-bottom:3px double currentColor`
- double underline plus `w:strike` keeps a single `line-through`
- ordinary visible underlined text remains `text-decoration:underline`
