### PR TITLE
feat(mobilecore): add in-process facade + net10.0-android target for mobile hosts

### DIFF
--- a/src/officecli.mobilecore/MobileDocumentSession.cs
+++ b/src/officecli.mobilecore/MobileDocumentSession.cs
@@ -1,0 +1,170 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using OfficeCli.Core;
+using OfficeCli.Handlers;
+
+namespace OfficeCli.MobileCore;
+
+/// <summary>
+/// In-process, mobile-safe facade over OfficeCLI's OOXML document engine.
+/// It deliberately exposes no shell, process, pipe, plugin, installer, watch,
+/// browser, arbitrary output path, or raw-package operations.
+/// </summary>
+public sealed class MobileDocumentSession : IDisposable
+{
+    private readonly string _documentPath;
+    private readonly IDocumentHandler _handler;
+    private bool _disposed;
+
+    private MobileDocumentSession(string documentPath, IDocumentHandler handler)
+    {
+        _documentPath = documentPath;
+        _handler = handler;
+    }
+
+    public string DocumentPath => _documentPath;
+
+    public static MobileDocumentSession Open(string appPrivateDocumentPath)
+    {
+        var fullPath = Path.GetFullPath(appPrivateDocumentPath);
+        var extension = Path.GetExtension(fullPath);
+        if (extension is not (".docx" or ".xlsx" or ".pptx"))
+            throw new NotSupportedException("Only DOCX, XLSX, and PPTX are supported on mobile.");
+        return new MobileDocumentSession(fullPath, DocumentHandlerFactory.Open(fullPath, editable: true));
+    }
+
+    public static MobileDocumentSession Create(string appPrivateDocumentPath)
+    {
+        var fullPath = Path.GetFullPath(appPrivateDocumentPath);
+        var extension = Path.GetExtension(fullPath);
+        if (extension is not (".docx" or ".xlsx" or ".pptx"))
+            throw new NotSupportedException("Only DOCX, XLSX, and PPTX are supported on mobile.");
+        OfficeCli.BlankDocCreator.Create(fullPath);
+        return Open(fullPath);
+    }
+
+    public string RenderHtml()
+    {
+        ThrowIfDisposed();
+        return _handler switch
+        {
+            WordHandler word => word.ViewAsHtml(),
+            ExcelHandler excel => excel.ViewAsHtml(),
+            PowerPointHandler powerPoint => powerPoint.ViewAsHtml(),
+            _ => throw new NotSupportedException("This document type has no mobile HTML renderer.")
+        };
+    }
+
+    public JsonNode Outline()
+    {
+        ThrowIfDisposed();
+        return _handler.ViewAsOutlineJson();
+    }
+
+    public JsonNode Get(string selector, int depth = 1)
+    {
+        ThrowIfDisposed();
+        ValidateSelector(selector);
+        if (depth is < 0 or > 10) throw new ArgumentOutOfRangeException(nameof(depth));
+        return JsonSerializer.SerializeToNode(_handler.Get(selector, depth))!;
+    }
+
+    public IReadOnlyList<JsonNode> Query(string selector)
+    {
+        ThrowIfDisposed();
+        ValidateSelector(selector);
+        return _handler.Query(selector).Select(node => JsonSerializer.SerializeToNode(node)!).ToArray();
+    }
+
+    public MobileCommandResult Execute(MobileOfficeCommand command)
+        => ExecuteCore(command, save: true);
+
+    public IReadOnlyList<MobileCommandResult> ExecuteBatch(IReadOnlyList<MobileOfficeCommand> commands)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(commands);
+        if (commands.Count is < 1 or > 100) throw new ArgumentException("A batch must contain between 1 and 100 commands.");
+        var results = new List<MobileCommandResult>(commands.Count);
+        foreach (var command in commands) results.Add(ExecuteCore(command, save: false));
+        _handler.Save();
+        return results;
+    }
+
+    private MobileCommandResult ExecuteCore(MobileOfficeCommand command, bool save)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(command);
+        ValidateSelector(command.Path);
+        var properties = command.Properties ?? new Dictionary<string, string>();
+        if (properties.Count > 100) throw new ArgumentException("A command may contain at most 100 properties.");
+
+        string? message;
+        IReadOnlyList<string> unsupported = [];
+        switch (command.Operation)
+        {
+            case MobileOperation.Set:
+                unsupported = _handler.Set(command.Path, properties);
+                message = "Element updated.";
+                break;
+            case MobileOperation.Add:
+                if (string.IsNullOrWhiteSpace(command.Type)) throw new ArgumentException("Add requires an element type.");
+                message = _handler.Add(command.Path, command.Type, ToPosition(command), properties);
+                break;
+            case MobileOperation.Remove:
+                message = _handler.Remove(command.Path, properties);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(command.Operation));
+        }
+
+        if (save) _handler.Save();
+        return new MobileCommandResult(true, message, unsupported);
+    }
+
+    public void Save()
+    {
+        ThrowIfDisposed();
+        _handler.Save();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _handler.Dispose();
+        _disposed = true;
+    }
+
+    private static InsertPosition? ToPosition(MobileOfficeCommand command)
+    {
+        var count = (command.Index.HasValue ? 1 : 0) + (command.Before is not null ? 1 : 0) + (command.After is not null ? 1 : 0);
+        if (count > 1) throw new ArgumentException("Only one insertion position may be specified.");
+        if (command.Index.HasValue) return InsertPosition.AtIndex(command.Index.Value);
+        if (command.Before is not null) return InsertPosition.BeforeElement(command.Before);
+        if (command.After is not null) return InsertPosition.AfterElement(command.After);
+        return null;
+    }
+
+    private static void ValidateSelector(string selector)
+    {
+        if (string.IsNullOrWhiteSpace(selector) || !selector.StartsWith('/'))
+            throw new ArgumentException("An OfficeCLI document selector beginning with '/' is required.");
+        if (selector.Length > 2048) throw new ArgumentException("The selector is too long.");
+        if (selector.Contains("..", StringComparison.Ordinal) || selector.Contains('\0'))
+            throw new ArgumentException("The selector contains a forbidden sequence.");
+    }
+
+    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+}
+
+public enum MobileOperation { Set, Add, Remove }
+
+public sealed record MobileOfficeCommand(
+    MobileOperation Operation,
+    string Path,
+    string? Type = null,
+    Dictionary<string, string>? Properties = null,
+    int? Index = null,
+    string? Before = null,
+    string? After = null);
+
+public sealed record MobileCommandResult(bool Success, string? Message, IReadOnlyList<string> UnsupportedProperties);

--- a/src/officecli.mobilecore/README.md
+++ b/src/officecli.mobilecore/README.md
@@ -1,0 +1,17 @@
+# OfficeCLI MobileCore
+
+An experimental in-process facade for Android/iOS hosts. It references the
+existing OfficeCLI assembly but exposes only document-local operations:
+
+- open an OOXML file from app-private storage;
+- render its HTML preview;
+- read outline/get/query data;
+- set, add, and remove document elements;
+- save back to the same file.
+
+It intentionally excludes CLI parsing, MCP stdio, named pipes, watch servers,
+plugins, installers, browsers, subprocesses, raw package writes, and arbitrary
+output paths.
+
+The AI layer should deserialize function calls into `MobileOfficeCommand` and
+invoke `Execute`; it should never receive a shell or CLI command-string tool.

--- a/src/officecli.mobilecore/officecli.mobilecore.csproj
+++ b/src/officecli.mobilecore/officecli.mobilecore.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net10.0-android</TargetFrameworks>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net10.0-android'">24</SupportedOSPlatformVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\officecli\officecli.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/officecli.mobilecore/officecli.mobilecore.csproj
+++ b/src/officecli.mobilecore/officecli.mobilecore.csproj
@@ -6,6 +6,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\officecli\officecli.csproj" />
+    <!-- officecli's net10.0-android target is opt-in (see officecli.csproj);
+         mobilecore always needs it, so request it explicitly here instead
+         of requiring every caller to remember to pass the property. -->
+    <ProjectReference Include="..\officecli\officecli.csproj">
+      <Properties>IncludeAndroidTarget=true</Properties>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/officecli/GlobalUsings.Android.cs
+++ b/src/officecli/GlobalUsings.Android.cs
@@ -1,0 +1,6 @@
+#if ANDROID
+global using TableRow = DocumentFormat.OpenXml.Wordprocessing.TableRow;
+global using TableLayout = DocumentFormat.OpenXml.Wordprocessing.TableLayout;
+global using CheckBox = DocumentFormat.OpenXml.Wordprocessing.CheckBox;
+global using Filter = DocumentFormat.OpenXml.Spreadsheet.Filter;
+#endif

--- a/src/officecli/officecli.csproj
+++ b/src/officecli/officecli.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net10.0;net10.0-android</TargetFrameworks>
+    <OutputType Condition="'$(TargetFramework)' == 'net10.0'">Exe</OutputType>
+    <OutputType Condition="'$(TargetFramework)' == 'net10.0-android'">Library</OutputType>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net10.0-android'">24</SupportedOSPlatformVersion>
     <RootNamespace>OfficeCli</RootNamespace>
     <AssemblyName>officecli</AssemblyName>
     <Version>1.0.143</Version>
@@ -10,9 +12,9 @@
     <Company>OfficeCLI</Company>
     <Copyright>Copyright © 2026 OfficeCLI (https://OfficeCLI.AI)</Copyright>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
-    <PublishSingleFile>true</PublishSingleFile>
-    <SelfContained>true</SelfContained>
-    <PublishTrimmed>true</PublishTrimmed>
+    <PublishSingleFile Condition="'$(TargetFramework)' == 'net10.0'">true</PublishSingleFile>
+    <SelfContained Condition="'$(TargetFramework)' == 'net10.0'">true</SelfContained>
+    <PublishTrimmed Condition="'$(TargetFramework)' == 'net10.0'">true</PublishTrimmed>
     <CETCompat>false</CETCompat>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -21,6 +23,12 @@
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.4.1" />
     <PackageReference Include="System.CommandLine" Version="3.0.0-preview.2.26159.112" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
+    <!-- Android hosts the document engine in-process; the desktop CLI entry
+         point is neither needed nor supported in a library target. -->
+    <Compile Remove="Program.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/officecli/officecli.csproj
+++ b/src/officecli/officecli.csproj
@@ -1,7 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net10.0-android</TargetFrameworks>
+    <!-- The Android target is opt-in behind IncludeAndroidTarget: it needs
+         the Android SDK/workload, which most desktop-CLI consumers (this
+         project's own release CI included) don't have installed. Building,
+         running, or publishing this project with no extra property behaves
+         exactly as it did before this target existed - single net10.0
+         target, no Android SDK required. -->
+    <TargetFrameworks Condition="'$(IncludeAndroidTarget)' == 'true'">net10.0;net10.0-android</TargetFrameworks>
+    <TargetFramework Condition="'$(IncludeAndroidTarget)' != 'true'">net10.0</TargetFramework>
     <OutputType Condition="'$(TargetFramework)' == 'net10.0'">Exe</OutputType>
     <OutputType Condition="'$(TargetFramework)' == 'net10.0-android'">Library</OutputType>
     <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net10.0-android'">24</SupportedOSPlatformVersion>


### PR DESCRIPTION
## What
- Multi-targets `officecli` for `net10.0` (existing CLI) and `net10.0-android` (new: library only, no `Program.cs`/CLI entry point) via `<TargetFrameworks>` + per-target `OutputType`/publish conditions.
- Adds `officecli.mobilecore`, a small in-process facade (`MobileDocumentSession`) over the existing document engine for Android/iOS hosts that need to open, edit, and render OOXML documents in-process: no subprocess, no MCP stdio, no named pipes, no shell.

## Why
Embedding officecli directly in a mobile app process (so an on-device AI agent can edit a document without shelling out or running a local server) needs officecli to build as a library for `net10.0-android`, and needs a narrow, mobile-safe surface instead of the full CLI/MCP/plugin/installer surface. `officecli.mobilecore` intentionally exposes only: open/create, render-to-HTML, outline/get/query, set/add/remove, save. No CLI parsing, no watch server, no browser automation, no raw package writes, no arbitrary output paths.

## Validation
The `net10.0-android` target has been building and running this exact flow inside a real Android app throughout development (WebView-rendered live preview, structured mutations end to end). Reproducible without Android, same facade, `net10.0` desktop target:

```
$ dotnet run -c Release
MobileDocumentSession.Create("mobilecore-smoke-f9abc90a6b8d43288a3024ebfd320d3a.docx")
  -> created blank .docx, session open
Execute(Add paragraph) -> success=True message=/body/p[@paraId=00100000]
Outline() -> {"fileName":"mobilecore-smoke-f9abc90a6b8d43288a3024ebfd320d3a.docx","paragraphs":1,"tables":0,"images":0,"equations":0,...
RenderHtml() -> 50084 chars, contains added text: True
Save() -> ok
File on disk: True, 5193 bytes
Smoke test passed.
```

(3-line `Program.cs` + a `ProjectReference` to `officecli.mobilecore.csproj`. Happy to add this as a real test project in the repo if useful.)
