### PR TITLE
fix(docx): tracked find-replace crosses into a hyperlink it fully covers

### DIFF
--- a/src/officecli/Handlers/Word/WordHandler.Helpers.FindReplace.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Helpers.FindReplace.cs
@@ -555,19 +555,48 @@ public partial class WordHandler
                     if (isRegex && matchObjs != null && i < matchObjs.Count)
                         effectiveReplace = matchObjs[i].Result(replace);
 
-                    // Cross-hyperlink replacement is still rejected — the wrapped
-                    // form would corrupt the URL/format-binding of the hyperlink
-                    // structure just as the unwrapped form did.
+                    // Cross-hyperlink matches are allowed only when every hyperlink
+                    // the match crosses into is FULLY covered — its runs are then
+                    // wrapped in w:del IN PLACE (inside the w:hyperlink), the shape
+                    // Word itself produces for tracked link-text deletion. Schema-wise
+                    // there is no alternative: CT_RunTrackChange has no w:hyperlink
+                    // member, so the hyperlink element itself can never sit under
+                    // w:del. A PARTIALLY covered hyperlink is still rejected — a
+                    // revision deleting half a label would corrupt the URL/format
+                    // binding just as the unwrapped form did. Issue #279 (tracked
+                    // deletion of link text, e.g. --find " 原文" --replace "").
+                    bool spansHyperlinkBoundary;
                     {
-                        var affected = BuildRunTexts(para)
+                        var preSplit = BuildRunTexts(para);
+                        var affected = preSplit
                             .Where(rt => rt.End > matchStart && rt.Start < matchEnd)
                             .Select(rt => rt.Run.Ancestors<Hyperlink>().FirstOrDefault())
                             .Distinct()
                             .ToList();
-                        if (affected.Count > 1)
-                            throw new ArgumentException(
-                                $"find/replace+revision cannot span a hyperlink boundary "
-                                + $"(match at offset {matchStart}, length {matchLen})");
+                        spansHyperlinkBoundary = affected.Count > 1;
+                        if (spansHyperlinkBoundary)
+                        {
+                            foreach (var link in affected)
+                            {
+                                if (link == null) continue;
+                                int linkStart = int.MaxValue, linkEnd = 0;
+                                foreach (var rt in preSplit)
+                                {
+                                    if (!ReferenceEquals(rt.Run.Ancestors<Hyperlink>().FirstOrDefault(), link))
+                                        continue;
+                                    linkStart = Math.Min(linkStart, rt.Start);
+                                    linkEnd = Math.Max(linkEnd, rt.End);
+                                }
+                                if (matchStart > linkStart || matchEnd < linkEnd)
+                                    throw new ArgumentException(
+                                        $"find/replace+revision cannot span a hyperlink boundary "
+                                        + $"(match at offset {matchStart}, length {matchLen}): the "
+                                        + "match covers only part of a hyperlink's text. Widen it to "
+                                        + "cover the hyperlink's whole text (the link label is then "
+                                        + "marked deleted in place), or keep it fully inside or "
+                                        + "outside the hyperlink.");
+                            }
+                        }
                     }
 
                     // Split the runs so the matched span is a contiguous list of
@@ -620,13 +649,26 @@ public partial class WordHandler
 
                     // Insert replacement (skip if user passed --prop replace="" — a
                     // deletion-only operation). The new w:ins sibling sits right
-                    // after the last w:del wrapper.
+                    // after the last w:del wrapper — except when the match CROSSED
+                    // into a hyperlink (necessarily fully covered, so its whole
+                    // label is now deleted): then the anchor is hoisted to the
+                    // hyperlink element itself, because the replacement belongs
+                    // beside the dying link, not inside it, where it would silently
+                    // inherit the URL of a label that no longer exists. A match
+                    // fully INSIDE one hyperlink keeps the in-link placement (label
+                    // edit keeps the link).
                     if (!string.IsNullOrEmpty(effectiveReplace) && lastDelWrapper?.Parent != null)
                     {
+                        OpenXmlElement insAnchor = lastDelWrapper;
+                        if (spansHyperlinkBoundary)
+                        {
+                            var host = lastDelWrapper.Ancestors<Hyperlink>().FirstOrDefault();
+                            if (host?.Parent != null) insAnchor = host;
+                        }
                         var newRun = new Run(
                             templateRPr,
                             new Text(effectiveReplace) { Space = SpaceProcessingModeValues.Preserve });
-                        lastDelWrapper.Parent.InsertAfter(newRun, lastDelWrapper);
+                        insAnchor.Parent!.InsertAfter(newRun, insAnchor);
                         WrapRunAsInserted(newRun, author, date, null);
                     }
                 }


### PR DESCRIPTION
Fixes #279.

## What was broken

`set <file> / --find X --replace Y --prop revision.author=…` rejected every match that touched both plain text and hyperlink text:

```
Error: find/replace+revision cannot span a hyperlink boundary (match at offset 4, length 3)
```

which made revision-mode deletion of a link label (the issue's reference-list "原文" use case) impossible — even though a match **fully inside** one hyperlink was already supported.

## The fix

One rule change in the tracked-replace guard of `ProcessFindInParagraph`:

- A crossed hyperlink whose text is **fully covered** by the match is now allowed. Its runs are wrapped in `w:del` **in place, inside the `w:hyperlink`** — the shape Word itself produces for tracked link-text deletion. Schema-wise there is no alternative: `CT_RunTrackChange` has no `w:hyperlink` member, so the hyperlink element itself can never sit under `w:del`.
- The replacement `w:ins` (when non-empty) is anchored **after the hyperlink element** instead of inside the fully-deleted link, so the new text does not silently inherit the URL of a label that no longer exists. A match fully inside one hyperlink keeps the existing in-link placement (label edit keeps the link).
- A **partially covered** hyperlink is still rejected — a revision deleting half a label would corrupt the URL/format binding — but the error now says what to do about it.

## Validation

```bash
# Fixture: plain text ending in a space + hyperlink labeled 原文
officecli create refs.docx
officecli add refs.docx /body --type paragraph --prop "text=来源:见 "
officecli add refs.docx "/body/p[1]" --type hyperlink --prop url=https://example.com/a --prop "text=原文"

# Before my fix:
officecli set refs.docx / --find " 原文" --replace "" --prop revision.author=A
# → Error: find/replace+revision cannot span a hyperlink boundary (match at offset 4, length 3)  ❌

# After my fix:
officecli set refs.docx / --find " 原文" --replace "" --prop revision.author=A
# → Updated /: revision.author=A, find= 原文, replace= (1 matched)  ✓
officecli validate refs.docx
# → Validation passed: no errors found.  ✓
```

Resulting XML (space `w:del` at paragraph level; label `w:del` inside the hyperlink, `w:t` → `w:delText`, rPr preserved):

```xml
<w:r><w:t xml:space="preserve">来源:见</w:t></w:r>
<w:del w:author="A" …><w:r><w:delText xml:space="preserve"> </w:delText></w:r></w:del>
<w:hyperlink r:id="R15cb16108f734e85">
  <w:del w:author="A" …>
    <w:r><w:rPr><w:color w:val="0563C1" w:themeColor="hyperlink"/><w:u w:val="single"/></w:rPr>
      <w:delText xml:space="preserve">原文</w:delText></w:r>
  </w:del>
</w:hyperlink>
```

Round-trips (all pass `officecli validate`):

```bash
officecli set refs.docx /revision --prop revision.action=accept   # → "来源:见"
officecli set refs.docx /revision --prop revision.action=reject   # → "来源:见 原文", link intact (isHyperlink=true url=…)
```

Non-empty replacement — the `w:ins` lands after the hyperlink, outside it:

```bash
officecli set refs.docx / --find " 原文" --replace " 译文" --prop revision.author=A
# → …<w:hyperlink>…<w:del>原文</w:del>…</w:hyperlink><w:ins><w:r><w:t> 译文</w:t></w:r></w:ins>  ✓
```

Partial coverage still rejected, with an actionable message (hyperlink labeled 原文链接):

```bash
officecli set partial.docx / --find " 原文" --replace "" --prop revision.author=A
# → Error: find/replace+revision cannot span a hyperlink boundary (match at offset 1, length 3):
#   the match covers only part of a hyperlink's text. Widen it to cover the hyperlink's whole
#   text (the link label is then marked deleted in place), or keep it fully inside or outside
#   the hyperlink.
```

Regression check — match fully inside one hyperlink (previously supported path) is unchanged: `--find "原文" --replace "译文"` still produces `w:del`+`w:ins` inside the link and validates clean.

## Scope

Only the `revisionProps != null` branch changes. The non-tracked replace path (`BUG-BT-2` guard) keeps its existing boundary rejection — that path rewrites text in place rather than wrapping, so full-coverage support there is a separate change with its own semantics (happy to follow up if wanted).

