### PR TITLE
HtmlScreenshot: honour OFFICECLI_BROWSER as an explicit chrome-family executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ OfficeCLI is self-contained. The capabilities below ship inside the binary — *
 
 #### Rendering engine — high-fidelity, built-in
 
-OfficeCLI's keystone: a from-scratch, high-fidelity HTML rendering engine that lets an AI agent *see* the rendered document instead of guessing from the DOM. It covers shapes, charts (trendlines, error bars, waterfall, candlestick, sparklines), equations (OMML → LaTeX, rendered with KaTeX), 3D `.glb` models via Three.js, morph transitions, slide zoom, and shape effects. Per-page PNG screenshots are produced by piping the rendered HTML through a headless browser. Three modes:
+OfficeCLI's keystone: a from-scratch, high-fidelity HTML rendering engine that lets an AI agent *see* the rendered document instead of guessing from the DOM. It covers shapes, charts (trendlines, error bars, waterfall, candlestick, sparklines), equations (OMML → LaTeX, rendered with KaTeX), 3D `.glb` models via Three.js, morph transitions, slide zoom, and shape effects. Per-page PNG screenshots are produced by piping the rendered HTML through a headless browser — found on PATH or in a platform-standard install location, or set `OFFICECLI_BROWSER=/path/to/chrome-family-binary` to point OfficeCLI at an explicit Chrome/Chromium/Edge executable outside those locations (e.g. a Chrome for Testing build a host manages itself). Three modes:
 
 - **`view html`** — standalone HTML file, assets inlined. Open in any browser.
 - **`view screenshot`** — per-page PNG, ready for multimodal agents to read.

--- a/src/officecli/Core/HtmlScreenshot.cs
+++ b/src/officecli/Core/HtmlScreenshot.cs
@@ -411,6 +411,13 @@ internal static class HtmlScreenshot
 
     private static string? FindChrome()
     {
+        // Explicit override first: lets hosts that ship their own Chromium
+        // (e.g. a Chrome for Testing build outside the standard install
+        // paths) point OfficeCLI at it without touching PATH.
+        var explicitBrowser = Environment.GetEnvironmentVariable("OFFICECLI_BROWSER");
+        if (!string.IsNullOrWhiteSpace(explicitBrowser) && File.Exists(explicitBrowser))
+            return explicitBrowser;
+
         string[] names = ["google-chrome", "google-chrome-stable", "chromium", "chromium-browser",
                           "chrome", "microsoft-edge", "microsoft-edge-stable", "msedge"];
         var pathHit = WhichFirst(names);


### PR DESCRIPTION

**Files:** `src/officecli/Core/HtmlScreenshot.cs` (`FindChrome()`), `README.md`

## Summary

`FindChrome()` only ever looks for a chrome-family binary by PATH name
(`google-chrome`, `chrome`, `msedge`, …) or a fixed set of platform-standard
install paths (`/Applications/Google Chrome.app`, …). A host that ships its
own Chromium build outside those locations — for example a pinned
"Chrome for Testing" binary staged under an application-support directory —
has no way to point OfficeCLI at it, and screenshot/mermaid rendering fails
with `no_screenshot_backend` even though a perfectly good browser is sitting
right there.

This PR adds one explicit override, checked first: `OFFICECLI_BROWSER`. When
set to a path that exists, `FindChrome()` returns it immediately, before the
PATH and absolute-path fallbacks. When unset (or pointing at a nonexistent
file), behaviour is byte-for-byte unchanged.

```csharp
private static string? FindChrome()
{
    // Explicit override first: lets hosts that ship their own Chromium
    // (e.g. a Chrome for Testing build outside the standard install
    // paths) point OfficeCLI at it without touching PATH.
    var explicitBrowser = Environment.GetEnvironmentVariable("OFFICECLI_BROWSER");
    if (!string.IsNullOrWhiteSpace(explicitBrowser) && File.Exists(explicitBrowser))
        return explicitBrowser;

    string[] names = [...]; // unchanged from here down
    ...
}
```

One README line documents it next to the existing description of the
headless-screenshot rendering path.

## Why

Product-side rationale for the host that needed this: a desktop app ships
its own pinned Chrome for Testing binary for its browser-automation feature
and wants OfficeCLI's screenshot/mermaid rendering to reuse that exact
binary instead of requiring a second, separately-installed system Chrome.
`OFFICECLI_BROWSER` is the minimal, additive way to do that — no new
dependency, no behavior change for anyone who doesn't set it.

## Validation

Toolchain: .NET 10 SDK installed to a scratch directory (`dotnet-install.sh
--channel 10.0`), never touching the system SDK. `dotnet build
src/officecli -c Debug` succeeds on the pristine clone and on this branch.

Command sequence, run on macOS with a real Chrome for Testing binary at a
non-standard path and the platform-standard Chrome/Chromium/Edge locations
made unreadable for the duration of the test (`sandbox-exec` denying
`file-read*` on `/Applications/Google Chrome.app`, `Chromium.app`,
`Microsoft Edge.app` — i.e. "no browser at a standard location", the exact
condition `OFFICECLI_BROWSER` exists to solve):

```bash
officecli create t.docx
officecli add t.docx /body --type paragraph --prop text=hello
officecli close t.docx

# BEFORE (unmodified main, OFFICECLI_BROWSER not yet read by FindChrome()):
OFFICECLI_BROWSER="$CFT_PATH" officecli view t.docx screenshot -o t.png --json
# → {"success":false,"warnings":[{"message":"No headless browser available. ...
#     Last error: playwright: ...", "code":"warning"}]}   (no_screenshot_backend)
# → t.png: No such file or directory

# AFTER (this branch):
OFFICECLI_BROWSER="$CFT_PATH" officecli view t.docx screenshot -o t.png --json
# → {"success":true,"data":".../t.png","message":".../t.png"}
```

`$CFT_PATH` = `.../chrome-149.0.7827.22/chrome-mac-arm64/Google Chrome for
Testing.app/Contents/MacOS/Google Chrome for Testing`.

Result PNG: 1600×1200, 8-bit RGB, 9296 bytes — see attached `U1-screenshot.png`.

Confirmed the override truly changed behavior (not just "a browser happened
to be found"): the identical command against the **unmodified** `main`
branch, with the exact same env var set and the exact same browsers hidden,
still fails with `no_screenshot_backend` — proving `FindChrome()` does not
read `OFFICECLI_BROWSER` before this change, and does after.

## Compatibility

Additive only. `FindChrome()`'s existing PATH-name and absolute-path search
is untouched and still runs whenever `OFFICECLI_BROWSER` is unset.
