### PR TITLE
MermaidImageRenderer: OFFICECLI_MERMAID_JS local asset override for render=image

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ OfficeCLI is self-contained. The capabilities below ship inside the binary — *
 
 #### Rendering engine — high-fidelity, built-in
 
-OfficeCLI's keystone: a from-scratch, high-fidelity HTML rendering engine that lets an AI agent *see* the rendered document instead of guessing from the DOM. It covers shapes, charts (trendlines, error bars, waterfall, candlestick, sparklines), equations (OMML → LaTeX, rendered with KaTeX), 3D `.glb` models via Three.js, morph transitions, slide zoom, and shape effects. Per-page PNG screenshots are produced by piping the rendered HTML through a headless browser. Three modes:
+OfficeCLI's keystone: a from-scratch, high-fidelity HTML rendering engine that lets an AI agent *see* the rendered document instead of guessing from the DOM. It covers shapes, charts (trendlines, error bars, waterfall, candlestick, sparklines), equations (OMML → LaTeX, rendered with KaTeX), 3D `.glb` models via Three.js, morph transitions, slide zoom, and shape effects. Per-page PNG screenshots are produced by piping the rendered HTML through a headless browser. `diagram --prop render=image` renders with the real mermaid.js in that same browser, caching mermaid.min.js locally on first use (mirror → CDN); set `OFFICECLI_MERMAID_JS=/path/to/mermaid.min.js` to point it at a local copy instead and skip the network entirely (offline / sandboxed hosts). Three modes:
 
 - **`view html`** — standalone HTML file, assets inlined. Open in any browser.
 - **`view screenshot`** — per-page PNG, ready for multimodal agents to read.

--- a/src/officecli/Core/Diagram/MermaidImageRenderer.cs
+++ b/src/officecli/Core/Diagram/MermaidImageRenderer.cs
@@ -23,7 +23,9 @@ namespace OfficeCli.Core.Diagram;
 ///   <item><b>Chrome-family</b> browser the user already has (via
 ///   <see cref="HtmlScreenshot"/>): render mermaid.js in a page and screenshot it.
 ///   Only mermaid.min.js (~3.5 MB) is fetched to a local cache on first use
-///   (mirror → CDN); if that fails the page loads mermaid from the CDN live.</item>
+///   (mirror → CDN); if that fails the page loads mermaid from the CDN live.
+///   <c>OFFICECLI_MERMAID_JS</c> points at a local mermaid.min.js and skips the
+///   network entirely, for offline / sandboxed hosts.</item>
 ///   <item>otherwise the caller falls back to the native synthesizer
 ///   (<see cref="DiagramCompiler"/>) — zero dependencies, fully editable shapes.</item>
 /// </list>
@@ -180,6 +182,18 @@ public static class MermaidImageRenderer
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".officecli", "cache");
     private static string CachedJsPath => Path.Combine(CacheDir, $"mermaid-{MermaidVersion}.min.js");
 
+    /// <summary>Explicit local mermaid.min.js override for offline / sandboxed hosts
+    /// that cannot reach the mirror or the CDN. Wins over the cache and skips the
+    /// download + refresh path entirely.</summary>
+    private static string? MermaidJsOverride
+    {
+        get
+        {
+            var p = Environment.GetEnvironmentVariable("OFFICECLI_MERMAID_JS");
+            return !string.IsNullOrWhiteSpace(p) && File.Exists(p) ? p : null;
+        }
+    }
+
     /// <summary>True when any image backend is available: mmdc, or a chrome-family browser.</summary>
     public static bool IsAvailable() => TryLocateMmdc(out _) || HtmlScreenshot.HasChromeFamily();
 
@@ -195,6 +209,7 @@ public static class MermaidImageRenderer
     {
         try
         {
+            if (MermaidJsOverride != null) return; // explicit local asset — never touch the network
             if (!File.Exists(CachedJsPath)) return; // refresh only what the user actually uses
             using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
             using var req = new HttpRequestMessage(HttpMethod.Get, MirrorUrl);
@@ -396,6 +411,9 @@ public static class MermaidImageRenderer
     /// &lt;script src&gt; (a <c>file://</c> for a cached/downloaded copy, else the CDN).</summary>
     private static string ResolveMermaidJsRef()
     {
+        if (MermaidJsOverride is { } overridePath)
+            return new Uri(Path.GetFullPath(overridePath)).AbsoluteUri;
+
         try
         {
             if (File.Exists(CachedJsPath) && new FileInfo(CachedJsPath).Length > 500_000)


### PR DESCRIPTION

**Files:** `src/officecli/Core/Diagram/MermaidImageRenderer.cs` (`ResolveMermaidJsRef()`,
`RefreshCacheIfPresent()`), `README.md`

## Summary

`diagram --prop render=image`'s chrome-family backend renders with the real
mermaid.js. `ResolveMermaidJsRef()` resolves the script it points the page
at in three steps: an existing local cache → download from OfficeCLI's own
mirror → download from the jsDelivr CDN → give up and reference the CDN URL
live in the page. Every one of those needs a network path out. A host that
is offline, air-gapped, or sandboxed away from the network has no way to use
`render=image` at all, even when it already has a valid `mermaid.min.js` on
disk.

This PR adds `OFFICECLI_MERMAID_JS`: when set to a path that exists,
`ResolveMermaidJsRef()` returns a `file://` URI for it directly — no cache
check, no download attempt, no network call of any kind — and
`RefreshCacheIfPresent()` (the daily background revalidation hook) returns
immediately instead of trying to reach the mirror. Unset, behaviour is
unchanged.

```csharp
private static string? MermaidJsOverride
{
    get
    {
        var p = Environment.GetEnvironmentVariable("OFFICECLI_MERMAID_JS");
        return !string.IsNullOrWhiteSpace(p) && File.Exists(p) ? p : null;
    }
}
```

Same shape as the existing `OFFICECLI_MMDC` override two members away in the
same file.

## Why

Same host as the sibling `OFFICECLI_BROWSER` PR: a desktop app that runs
inside a locked-down sandbox (network egress not guaranteed, no ability to
silently phone a CDN on the user's behalf) wants `render=image` diagrams to
work from an asset it ships and pins itself.

## Validation

Toolchain: same scratch .NET 10 SDK as the sibling PRs.
`mermaid.min.js` downloaded once from
`https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js` into a scratch
directory (not committed, not part of the diff).

**Precedence check** (does the override actually get read, not just
"happen to work because the network was up anyway"): point
`OFFICECLI_MERMAID_JS` at a deliberately invalid JS file
(`not_a_valid_mermaid_js_file();`) and diagram add the same source on both
the unmodified `main` branch and this branch, network fully reachable on
both runs:

```bash
officecli create t.docx && officecli close t.docx

# BEFORE (unmodified main — ResolveMermaidJsRef doesn't know the var exists):
OFFICECLI_MERMAID_JS=/path/to/corrupt.js officecli add t.docx / \
  --type diagram --prop mermaid=$'erDiagram\n  A ||--o{ B : has' --prop render=image --json
# → {"success":true,"data":"Added diagram at /body/p[@paraId=00100000]", ...}
#   (ignores the var, downloads the real mermaid.js from the mirror/CDN, renders fine — 18.8s)

# AFTER (this branch):
OFFICECLI_MERMAID_JS=/path/to/corrupt.js officecli add t.docx / \
  --type diagram --prop mermaid=$'erDiagram\n  A ||--o{ B : has' --prop render=image --json
# → {"success":false,"error":{"error":"mermaid failed to render: mermaid is not defined",
#     "code":"internal_error"}}
#   (loaded the corrupt local file instead of downloading — proves the override took effect — 2.2s)
```

**Offline functional check** — the real command from the task, with the
*valid* local copy and the network genuinely unreachable
(`http_proxy`/`https_proxy` pointed at a closed port; a raw `HttpClient`
probe against the same target confirms this fails in <0.1s rather than
silently succeeding):

```bash
officecli create t.docx && officecli close t.docx
OFFICECLI_MERMAID_JS=/path/to/mermaid.min.js officecli add t.docx / \
  --type diagram --prop mermaid=$'erDiagram\n  A ||--o{ B : has' --prop render=image --json
# → {"success":true,"data":"Added diagram at /body/p[@paraId=00100000]", ...}   (7.6s)
officecli view t.docx outline
# → File: t.docx | 1 paragraphs | 0 tables | 1 images
officecli view t.docx screenshot -o t.png --json
# → PNG written, 21717 bytes, real ER diagram (A —has→ B, crow's-foot notation) — see U2-screenshot.png
ls ~/.officecli/cache/     # → No such file or directory: RefreshCacheIfPresent() never touched it
```

## Compatibility

Additive only. The existing cache → mirror → CDN → live-CDN cascade in
`ResolveMermaidJsRef()` is untouched and still runs whenever
`OFFICECLI_MERMAID_JS` is unset. `RefreshCacheIfPresent()`'s existing
early-return (`!File.Exists(CachedJsPath)`) is untouched; the new check is
strictly earlier in the same method and only short-circuits when the new var
is set.
