### PR TITLE
HtmlScreenshot: headless Chrome launches use a private, temporary user-data-dir

### DIFF
--- a/src/officecli/Core/HtmlScreenshot.cs
+++ b/src/officecli/Core/HtmlScreenshot.cs
@@ -17,6 +17,20 @@ internal static class HtmlScreenshot
 
     public sealed record PaginationResult(int TotalPages, Dictionary<string, int> AnchorPageMap);
 
+    /// <summary>Path for a fresh, private headless-Chrome profile directory for one
+    /// launch. Keeps a headless run from touching — or blocking on a lock held by —
+    /// the caller's own default Chrome profile, and lets screenshotting work under
+    /// sandboxes that deny writes to the default profile directory. The directory
+    /// is created by Chrome itself on first use; callers delete it with
+    /// <see cref="CleanupChromeUserDataDir"/> once the launch that created it exits.</summary>
+    private static string NewChromeUserDataDir() =>
+        Path.Combine(Path.GetTempPath(), $"officecli-chrome-{Guid.NewGuid():N}");
+
+    private static void CleanupChromeUserDataDir(string dir)
+    {
+        try { Directory.Delete(dir, true); } catch { /* best effort */ }
+    }
+
     /// Run a chromium-family browser in dump-dom mode against the given HTML
     /// and parse the document title for "PAGES:N|MAP:anchor=p,anchor=p,...".
     /// The HTML must set the title from JS after layout settles.
@@ -32,11 +46,13 @@ internal static class HtmlScreenshot
         var url = new Uri(Path.GetFullPath(htmlPath)).AbsoluteUri + "#screenshot";
         var bin = FindChrome();
         if (bin == null) return null;
+        var userDataDir = NewChromeUserDataDir();
         var args = new List<string>
         {
             "--headless=new",
             "--disable-gpu",
             "--no-sandbox",
+            $"--user-data-dir={userDataDir}",
             "--virtual-time-budget=15000",
             "--timeout=20000",  // wall-clock backstop: a stalled resource is not rescued by virtual time (issue #181)
         };
@@ -64,6 +80,7 @@ internal static class HtmlScreenshot
             return stdout;
         }
         catch { return null; }
+        finally { CleanupChromeUserDataDir(userDataDir); }
     }
 
     /// <summary>True when a chrome-family browser (Chrome/Chromium/Edge) is available.</summary>
@@ -84,12 +101,14 @@ internal static class HtmlScreenshot
         var outDir = Path.GetDirectoryName(outPath);
         if (!string.IsNullOrEmpty(outDir)) Directory.CreateDirectory(outDir);
         var url = new Uri(Path.GetFullPath(htmlPath)).AbsoluteUri + "#screenshot";
+        var userDataDir = NewChromeUserDataDir();
         var args = new[]
         {
             "--headless=new",
             "--disable-gpu",
             "--no-sandbox",
             "--hide-scrollbars",
+            $"--user-data-dir={userDataDir}",
             $"--force-device-scale-factor={scale}",
             $"--window-size={w},{h}",
             "--virtual-time-budget=15000",
@@ -98,8 +117,12 @@ internal static class HtmlScreenshot
             $"--screenshot={outPath}",
             url,
         };
-        var (ok, _) = RunBinary(bin, args);
-        return ok && File.Exists(outPath) && new FileInfo(outPath).Length > 0;
+        try
+        {
+            var (ok, _) = RunBinary(bin, args);
+            return ok && File.Exists(outPath) && new FileInfo(outPath).Length > 0;
+        }
+        finally { CleanupChromeUserDataDir(userDataDir); }
     }
 
     public static PaginationResult? GetPaginationFromDom(string htmlPath, int timeoutMs = 60000)
@@ -385,12 +408,14 @@ internal static class HtmlScreenshot
     {
         var bin = FindChrome();
         if (bin == null) return (false, null);
+        var userDataDir = NewChromeUserDataDir();
         var args = new[]
         {
             "--headless=new",
             "--disable-gpu",
             "--no-sandbox",
             "--hide-scrollbars",
+            $"--user-data-dir={userDataDir}",
             $"--window-size={w},{h}",
             // Without these caps, new-headless --screenshot waits for the
             // page's external resources (CDN fonts / KaTeX css+js) to settle;
@@ -406,7 +431,8 @@ internal static class HtmlScreenshot
             $"--screenshot={outPath}",
             url,
         };
-        return RunBinary(bin, args);
+        try { return RunBinary(bin, args); }
+        finally { CleanupChromeUserDataDir(userDataDir); }
     }
 
     private static string? FindChrome()
@@ -542,6 +568,7 @@ internal static class HtmlScreenshot
         if (bin == null) return (false, null);
         outPath = Path.GetFullPath(outPath);
         var url = new Uri(Path.GetFullPath(htmlPath)).AbsoluteUri + "#screenshot";
+        var userDataDir = NewChromeUserDataDir();
         try
         {
             var psi = new ProcessStartInfo
@@ -563,6 +590,7 @@ internal static class HtmlScreenshot
                 "--hide-scrollbars",
                 "--enable-logging=stderr",
                 "--v=0",
+                $"--user-data-dir={userDataDir}",
                 $"--force-device-scale-factor={scale}",
                 $"--window-size={w},{h}",
                 "--virtual-time-budget=15000",
@@ -582,6 +610,7 @@ internal static class HtmlScreenshot
             return (p.ExitCode == 0, errTask.GetAwaiter().GetResult());
         }
         catch { return (false, null); }
+        finally { CleanupChromeUserDataDir(userDataDir); }
     }
 
     private static (bool, string?) RunBinary(string bin, string[] args)


### PR DESCRIPTION

**Files:** `src/officecli/Core/HtmlScreenshot.cs` (`DumpDom`, `CaptureChromeSized`,
`TryChrome`, `RunChromeCapture`)

## Summary

Every headless Chrome launch in this file (`DumpDom`, `CaptureChromeSized`,
`TryChrome`, `RunChromeCapture`) previously relied on Chrome's own default
profile-directory resolution. Two consequences:

1. A screenshot can contend with a Chrome window the host already has open
   on the same default profile.
2. It cannot run at all under a sandbox that denies writes to the default
   profile directory (a real constraint for hosts that run OfficeCLI inside
   a restricted exec sandbox).

This PR adds a fresh, private `--user-data-dir` under the OS temp directory
to all four headless launch sites, and deletes it once that specific launch
exits:

```csharp
private static string NewChromeUserDataDir() =>
    Path.Combine(Path.GetTempPath(), $"officecli-chrome-{Guid.NewGuid():N}");

private static void CleanupChromeUserDataDir(string dir)
{
    try { Directory.Delete(dir, true); } catch { /* best effort */ }
}
```

Each call site: generate the dir path before building the argument list, add
`--user-data-dir={dir}` alongside the existing `--headless=new` flags, and
delete it in a `finally` around the existing try/catch (or a new
try/finally where the site had none) so it's cleaned up on every exit path
— success, failure, or the existing timeout-kill branch.

## Why

Same sandboxed-host motivation as the two sibling PRs: the host needing this
runs OfficeCLI's headless-screenshot path inside a restricted environment
and cannot guarantee the default Chrome profile directory is writable or
uncontended.

## Validation

Toolchain: same scratch .NET 10 SDK as the sibling PRs. `dotnet build
src/officecli -c Debug` succeeds.

Ran a screenshot while another chrome-family process already had the real
default profile directory (`~/Library/Application Support/Google/Chrome`)
open (a background `--headless=new` instance against the unmodified
default profile, holding its `SingletonSocket`), confirming this branch's
screenshot still succeeds:

```bash
officecli create t.docx
officecli add t.docx /body --type paragraph --prop text=hello
officecli close t.docx
officecli view t.docx screenshot -o t.png --json
# → {"success":true,"data":".../t.png", ...}
```

Result PNG: 1600×1200, 8-bit RGB, 9296 bytes — see attached `U3-screenshot.png`
(identical render to the sibling PR's baseline "hello" document, confirming
no regression).

Directly observed the fix taking effect (not just "it happened to work"):
polled the OS temp directory once a second while the screenshot ran and
caught the profile directory mid-flight —

```
officecli-chrome-9e74a0025e2b4486a6da60bd19c016f3
```

— matching the `officecli-chrome-<guid>` pattern in `NewChromeUserDataDir()`,
confirming the flag is actually being passed and used, not merely present in
the diff. After the command completed normally:

```bash
ls "$TMPDIR" | grep '^officecli-chrome-'
# → (nothing — no leftover profile dir)
```

Note on the "before" comparison: the concurrent-headless-instance repro
above did **not** reproduce a hard failure on the unmodified `main` branch
with this Chrome version (149.0.7827.22 / 151.0.7922.138) — a second
`--headless=new` instance against an already-open default profile completed
without contention on this build. The fix is still correct and worth
landing on its own merits (verified via direct observation of the isolated
profile directory's creation and cleanup above): it removes any dependency
on the host's default-profile availability at all, which is what makes
screenshotting work under a sandbox that denies writes to that directory —
the harder and more relevant constraint for the sandboxed host this change
is for. Did not attempt a foreground (non-headless, visibly-windowed) Chrome
instance for this test, to avoid interacting with the tester's real,
in-use browser session.

## Compatibility

Additive/isolating only — every headless launch site behaves exactly as
before except for the added, self-cleaning profile directory. No public API
change; `HasChromeFamily()` / `FindChrome()` are untouched.
