### PR TITLE
fix(config): use XDG directory on new Linux installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ officecli install    # explicit
 officecli            # bare invocation also triggers install
 ```
 
-Updates are checked automatically in the background. Disable with `officecli config autoUpdate false` or skip per-invocation with `OFFICECLI_SKIP_UPDATE=1`. Configuration lives under `~/.officecli/config.json`.
+Updates are checked automatically in the background. Disable with `officecli config autoUpdate false` or skip per-invocation with `OFFICECLI_SKIP_UPDATE=1`. On new Linux installs, configuration follows XDG: `$XDG_CONFIG_HOME/officecli/config.json` when set, otherwise `~/.config/officecli/config.json`. Existing Linux installs and other platforms continue using `~/.officecli/config.json`.
 
 ## Key Features
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -243,7 +243,7 @@ officecli install    # 明示的インストール
 officecli            # 直接実行でもインストールがトリガー
 ```
 
-更新はバックグラウンドで自動チェックされます。`officecli config autoUpdate false` で無効化、または `OFFICECLI_SKIP_UPDATE=1` で単回スキップ可能。設定は `~/.officecli/config.json` にあります。
+更新はバックグラウンドで自動チェックされます。`officecli config autoUpdate false` で無効化、または `OFFICECLI_SKIP_UPDATE=1` で単回スキップ可能。新規 Linux インストールでは XDG に従い、`$XDG_CONFIG_HOME` が設定されている場合は `$XDG_CONFIG_HOME/officecli/config.json`、未設定の場合は `~/.config/officecli/config.json` に保存されます。既存の Linux インストールとその他のプラットフォームでは、引き続き `~/.officecli/config.json` を使用します。
 
 ## 主な機能
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -243,7 +243,7 @@ officecli install    # 명시적 설치
 officecli            # 직접 실행으로도 설치 트리거
 ```
 
-업데이트는 백그라운드에서 자동 확인됩니다. `officecli config autoUpdate false`로 비활성화하거나 `OFFICECLI_SKIP_UPDATE=1`로 단일 실행 시 건너뛸 수 있습니다. 설정은 `~/.officecli/config.json`에 있습니다.
+업데이트는 백그라운드에서 자동 확인됩니다. `officecli config autoUpdate false`로 비활성화하거나 `OFFICECLI_SKIP_UPDATE=1`로 단일 실행 시 건너뛸 수 있습니다. 새 Linux 설치에서는 XDG를 따르며, `$XDG_CONFIG_HOME`이 설정된 경우 `$XDG_CONFIG_HOME/officecli/config.json`에, 설정되지 않은 경우 `~/.config/officecli/config.json`에 저장됩니다. 기존 Linux 설치와 다른 플랫폼에서는 계속 `~/.officecli/config.json`을 사용합니다.
 
 ## 주요 기능
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -243,7 +243,7 @@ officecli install    # 显式安装
 officecli            # 直接运行也会触发安装
 ```
 
-OfficeCLI 会在后台自动检查更新。通过 `officecli config autoUpdate false` 关闭，或通过 `OFFICECLI_SKIP_UPDATE=1` 跳过单次检查。配置文件位于 `~/.officecli/config.json`。
+OfficeCLI 会在后台自动检查更新。通过 `officecli config autoUpdate false` 关闭，或通过 `OFFICECLI_SKIP_UPDATE=1` 跳过单次检查。新安装的 Linux 版本遵循 XDG：设置了 `$XDG_CONFIG_HOME` 时，配置文件位于 `$XDG_CONFIG_HOME/officecli/config.json`；否则位于 `~/.config/officecli/config.json`。已有 Linux 安装和其他平台继续使用 `~/.officecli/config.json`。
 
 ## 核心功能
 

--- a/src/officecli/Core/CliLogger.cs
+++ b/src/officecli/Core/CliLogger.cs
@@ -9,7 +9,7 @@ namespace OfficeCli.Core;
 /// </summary>
 internal static class CliLogger
 {
-    private static readonly string LogPath = Path.Combine(UpdateChecker.ConfigDir, "officecli.log");
+    private static readonly string LogPath = Path.Combine(UpdateChecker.LegacyStateDir, "officecli.log");
     private const long MaxLogSize = 1024 * 1024; // 1 MB
 
     internal static bool Enabled
@@ -51,7 +51,7 @@ internal static class CliLogger
     {
         try
         {
-            Directory.CreateDirectory(UpdateChecker.ConfigDir);
+            Directory.CreateDirectory(UpdateChecker.LegacyStateDir);
 
             var escaped = message.ReplaceLineEndings("\\n");
             TrimIfNeeded();

--- a/src/officecli/Core/ConfigPathResolver.cs
+++ b/src/officecli/Core/ConfigPathResolver.cs
@@ -1,0 +1,58 @@
+// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OfficeCli.Core;
+
+internal static class ConfigPathResolver
+{
+    internal static string ResolveCurrent()
+    {
+        var userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var legacyDirectory = Path.Combine(userHome, ".officecli");
+        if (!OperatingSystem.IsLinux())
+            return legacyDirectory;
+
+        var xdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        var xdgDirectory = XdgDirectory(userHome, xdgConfigHome);
+        return Resolve(
+            userHome,
+            xdgConfigHome,
+            isLinux: true,
+            Directory.Exists(legacyDirectory),
+            File.Exists(Path.Combine(legacyDirectory, "config.json")),
+            File.Exists(Path.Combine(xdgDirectory, "config.json")));
+    }
+
+    internal static string Resolve(
+        string userHome,
+        string? xdgConfigHome,
+        bool isLinux,
+        bool legacyDirectoryExists,
+        bool legacyConfigExists,
+        bool xdgConfigExists)
+    {
+        var legacyDirectory = Path.Combine(userHome, ".officecli");
+        if (!isLinux)
+            return legacyDirectory;
+
+        var xdgDirectory = XdgDirectory(userHome, xdgConfigHome);
+        if (legacyConfigExists)
+            return legacyDirectory;
+
+        // A fresh XDG install may still create ~/.officecli later for logs,
+        // plugins, or caches. Once its config exists, do not switch paths.
+        if (xdgConfigExists)
+            return xdgDirectory;
+
+        return legacyDirectoryExists ? legacyDirectory : xdgDirectory;
+    }
+
+    private static string XdgDirectory(string userHome, string? xdgConfigHome)
+    {
+        var configRoot = string.IsNullOrWhiteSpace(xdgConfigHome) ||
+                         !Path.IsPathRooted(xdgConfigHome)
+            ? Path.Combine(userHome, ".config")
+            : xdgConfigHome;
+        return Path.Combine(configRoot, "officecli");
+    }
+}

--- a/src/officecli/Core/Installer.cs
+++ b/src/officecli/Core/Installer.cs
@@ -129,8 +129,8 @@ internal static class Installer
         // install (added to PATH manually, or by install.ps1 into a pre-existing
         // on-PATH dir). Don't drop a second copy into the canonical dir; treat the
         // on-PATH location as the install. Mirrors install.ps1, which upgrades an
-        // existing on-PATH copy in place rather than relocating it. Config and
-        // plugins live in ~/.officecli regardless, so nothing else moves.
+        // existing on-PATH copy in place rather than relocating it. Per-user
+        // configuration and plugins are independent of the binary location.
         if (IsDirOnPath(Path.GetDirectoryName(src)))
         {
             RecordInstalledVersion();

--- a/src/officecli/Core/UpdateChecker.cs
+++ b/src/officecli/Core/UpdateChecker.cs
@@ -13,7 +13,8 @@ namespace OfficeCli.Core;
 
 /// <summary>
 /// Daily auto-update against GitHub releases.
-/// - Config stored in ~/.officecli/config.json
+/// - Config stored in the XDG config directory on new Linux installs
+/// - Existing Linux installs and non-Linux platforms keep ~/.officecli/config.json
 /// - Checks at most once per day
 /// - Zero performance impact: spawns background process to check and upgrade
 /// - Silently skips if config dir is not writable
@@ -22,11 +23,13 @@ namespace OfficeCli.Core;
 /// </summary>
 internal static class UpdateChecker
 {
-    // Resolved per-call rather than cached so tests can override $HOME between
-    // cases without restarting the process. Production behavior is unchanged —
-    // $HOME never moves under a running officecli invocation.
-    internal static string ConfigDir => Path.Combine(
+    // Logs and other existing state remain under ~/.officecli. Only config.json
+    // follows XDG on fresh Linux installs.
+    internal static string LegacyStateDir => Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".officecli");
+    // Resolved per-call rather than cached so tests and isolated invocations can
+    // override $HOME/XDG_CONFIG_HOME without restarting the process.
+    private static string ConfigDir => ConfigPathResolver.ResolveCurrent();
     private static string ConfigPath => Path.Combine(ConfigDir, "config.json");
     private const string GitHubRepo = "iOfficeAI/OfficeCLI";
     // PrimaryBase is the project-controlled mirror (Cloudflare-fronted nginx on
@@ -564,10 +567,10 @@ internal static class UpdateChecker
         return false;
     }
 
-    /// <summary>Order: $HOME first; $TMPDIR appended only when running in a
+    /// <summary>Order: the platform config path first; $TMPDIR appended only when running in a
     /// container. The /tmp fallback exists for read-only-rootfs containers
     /// (docker --read-only, K8s readOnlyRootFilesystem, Lambda, Cloud Run)
-    /// where ~/.officecli can't be written but /tmp is a tmpfs. Iteration
+    /// where the config directory can't be written but /tmp is a tmpfs. Iteration
     /// stops at the first success — non-container hosts never touch /tmp,
     /// and containers with writable home never touch /tmp either.</summary>
     private static IEnumerable<string> ConfigPathCandidates()

--- a/src/officecli/McpServer.cs
+++ b/src/officecli/McpServer.cs
@@ -62,7 +62,7 @@ public static class McpServer
         // (applies any pending .update from a previous run and kicks a
         // fresh check if >24h stale), then every hour. The hourly wake
         // is cheap because CheckInBackground is debounced by the same
-        // 24h timestamp in ~/.officecli/config.json as the normal CLI
+        // 24h timestamp in the same per-user config.json as the normal CLI
         // path, so 23 of 24 wakes no-op. The actual download / verify /
         // File.Move happens in a spawned subprocess whose stdio is
         // redirected (see UpdateChecker.SpawnRefreshProcess), so

--- a/tests/OfficeCli.ConfigPath.Tests/OfficeCli.ConfigPath.Tests.csproj
+++ b/tests/OfficeCli.ConfigPath.Tests/OfficeCli.ConfigPath.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../../src/officecli/Core/ConfigPathResolver.cs" Link="ConfigPathResolver.cs" />
+  </ItemGroup>
+
+</Project>

--- a/tests/OfficeCli.ConfigPath.Tests/Program.cs
+++ b/tests/OfficeCli.ConfigPath.Tests/Program.cs
@@ -1,0 +1,89 @@
+// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
+// SPDX-License-Identifier: Apache-2.0
+
+using OfficeCli.Core;
+
+var home = Path.Combine(Path.GetPathRoot(Environment.CurrentDirectory)!, "home", "officecli-test");
+var xdg = Path.Combine(Path.GetPathRoot(Environment.CurrentDirectory)!, "xdg", "config");
+var legacy = Path.Combine(home, ".officecli");
+
+AssertPath(
+    Path.Combine(xdg, "officecli"),
+    ConfigPathResolver.Resolve(
+        home, xdg, isLinux: true,
+        legacyDirectoryExists: false,
+        legacyConfigExists: false,
+        xdgConfigExists: false),
+    "fresh Linux install honors XDG_CONFIG_HOME");
+
+AssertPath(
+    Path.Combine(home, ".config", "officecli"),
+    ConfigPathResolver.Resolve(
+        home, null, isLinux: true,
+        legacyDirectoryExists: false,
+        legacyConfigExists: false,
+        xdgConfigExists: false),
+    "fresh Linux install defaults to ~/.config");
+
+AssertPath(
+    Path.Combine(home, ".config", "officecli"),
+    ConfigPathResolver.Resolve(
+        home, "   ", isLinux: true,
+        legacyDirectoryExists: false,
+        legacyConfigExists: false,
+        xdgConfigExists: false),
+    "blank XDG_CONFIG_HOME defaults to ~/.config");
+
+AssertPath(
+    Path.Combine(home, ".config", "officecli"),
+    ConfigPathResolver.Resolve(
+        home, Path.Combine("relative", "config"), isLinux: true,
+        legacyDirectoryExists: false,
+        legacyConfigExists: false,
+        xdgConfigExists: false),
+    "relative XDG_CONFIG_HOME defaults to ~/.config");
+
+AssertPath(
+    legacy,
+    ConfigPathResolver.Resolve(
+        home, xdg, isLinux: true,
+        legacyDirectoryExists: true,
+        legacyConfigExists: false,
+        xdgConfigExists: false),
+    "existing Linux ~/.officecli directory keeps the legacy location");
+
+AssertPath(
+    legacy,
+    ConfigPathResolver.Resolve(
+        home, xdg, isLinux: false,
+        legacyDirectoryExists: true,
+        legacyConfigExists: false,
+        xdgConfigExists: true),
+    "non-Linux platforms keep the legacy location");
+
+AssertPath(
+    Path.Combine(xdg, "officecli"),
+    ConfigPathResolver.Resolve(
+        home, xdg, isLinux: true,
+        legacyDirectoryExists: true,
+        legacyConfigExists: false,
+        xdgConfigExists: true),
+    "an XDG config stays selected after another feature creates ~/.officecli");
+
+AssertPath(
+    legacy,
+    ConfigPathResolver.Resolve(
+        home, xdg, isLinux: true,
+        legacyDirectoryExists: true,
+        legacyConfigExists: true,
+        xdgConfigExists: true),
+    "a legacy config wins when both config files exist");
+
+Console.WriteLine("Config path resolver tests passed.");
+
+static void AssertPath(string expected, string actual, string scenario)
+{
+    if (expected == actual) return;
+    throw new InvalidOperationException(
+        $"{scenario}: expected '{expected}', got '{actual}'");
+}


### PR DESCRIPTION
## Summary

- Store `config.json` under `$XDG_CONFIG_HOME/officecli` on fresh Linux installs, falling back to `~/.config/officecli` when the variable is unset or invalid.
- Preserve `~/.officecli/config.json` for existing Linux installs and all non-Linux platforms.
- Keep an existing XDG config selected if logs, plugins, or caches later create `~/.officecli`.
- Leave logs, plugins, caches, and the container `/tmp` fallback unchanged.
- Document the platform-specific config locations.

Closes #300

## Validation

- `dotnet run --project tests/OfficeCli.ConfigPath.Tests/OfficeCli.ConfigPath.Tests.csproj`
- `dotnet build src/officecli/officecli.csproj -c Release --nologo` — 0 errors; one pre-existing `CS8602` warning in `ExcelHandler.SheetShift.cs:538`
- Isolated macOS smoke test confirming config remains under `~/.officecli/config.json`
