### PR TITLE
feat(xlsx): report numeric display overflow

### DIFF
--- a/src/officecli/Core/IssueSubtypes.cs
+++ b/src/officecli/Core/IssueSubtypes.cs
@@ -24,6 +24,12 @@ public static class IssueSubtypes
     public const string DefinedNameBroken = "definedname_broken";
     public const string DefinedNameTargetMissing = "definedname_target_missing";
     public const string BrokenPartRef = "broken_part_ref";
+    /// <summary>xlsx-only: a visible numeric/date cell with an explicit,
+    /// width-stable number format cannot fit its formatted value in the visible
+    /// column budget. General and unresolved formats are intentionally skipped
+    /// because Excel can adapt their display to the available width. Format
+    /// bucket, Warning.</summary>
+    public const string NumericOverflow = "numeric_overflow";
     /// <summary>pptx-only: notesSlide raw-set passthrough references an
     /// rId (<c>r:embed</c> / <c>r:link</c>) the dump pass cannot reproduce
     /// on the replay target (e.g. a non-image rel attached to a NotesSlidePart
@@ -66,12 +72,11 @@ public static class IssueSubtypes
         SlideFieldNotEvaluated, NotesUnresolvedRid, LowContrast,
         ChartSeriesRefMissingSheet, ChartCacheStale,
         DefinedNameBroken, DefinedNameTargetMissing,
-        BrokenPartRef,
+        BrokenPartRef, NumericOverflow,
     };
 
-    /// <summary>Subtypes that are scanned by default and surface under
-    /// <c>--type content</c>. Opt-in subtypes (currently only
-    /// <see cref="ChartCacheStale"/>) require an exact-name request.</summary>
+    /// <summary>Subtypes that require an exact-name request rather than being
+    /// scanned by default or via their broad issue bucket.</summary>
     public static readonly string[] OptInSubtypes = new[] { ChartCacheStale };
 
     /// <summary>One-line summary suitable for the CLI <c>--type</c> help
@@ -83,11 +88,11 @@ public static class IssueSubtypes
         return "Issue type filter. Broad buckets: "
             + string.Join(", ", BucketNames)
             + " (alias " + string.Join(", ", BucketAliases) + "). "
-            + "Subtypes (Content bucket, returned by default and via --type content): "
+            + "Subtypes (returned by default and via their matching broad bucket): "
             + string.Join(", ", defaults) + ". "
             + "Opt-in only (request by exact name; not included in --type content): "
             + string.Join(", ", OptInSubtypes) + ". "
-            + "Subtypes are format-specific — formula_* / chart_* / definedname_* apply to xlsx, "
+            + "Subtypes are format-specific — formula_* / chart_* / definedname_* / numeric_overflow apply to xlsx, "
             + "field_* to docx, slide_field_* / notes_unresolved_rid / broken_part_ref / low_contrast to pptx; requesting a subtype that does not apply to "
             + "the queried file returns count=0 (not an error). "
             + "All values are case-insensitive and surrounding whitespace is trimmed.";

--- a/src/officecli/Handlers/Excel/ExcelHandler.CheckNumericOverflow.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.CheckNumericOverflow.cs
@@ -1,0 +1,476 @@
+// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Globalization;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeCli.Handlers;
+
+public partial class ExcelHandler
+{
+    // Excel's General format is width-adaptive: it can drop decimal places or
+    // switch to scientific notation before it renders ###. The HTML formatter
+    // has no column-width input, so comparing its General string against a
+    // narrow column would create false positives. This scanner intentionally
+    // limits itself to explicit, understood numeric/date formats whose display
+    // width is stable. Unknown formats are skipped for the same reason.
+
+    private const double NumericFitCellPaddingPt = 3.0;
+    private const double NumericFitGlyphAdvance = 0.62;
+
+    private sealed record NumericOverflowFinding(
+        string Path,
+        string Message,
+        string Context,
+        string Suggestion);
+
+    private readonly record struct NumericMergeRange(
+        int StartColumn,
+        int StartRow,
+        int EndColumn,
+        int EndRow);
+
+    private List<NumericOverflowFinding> CheckAllNumericOverflow(int? limit = null)
+    {
+        var findings = new List<NumericOverflowFinding>();
+        if (limit is <= 0) return findings;
+        var stylesheet = _doc.WorkbookPart?.WorkbookStylesPart?.Stylesheet;
+        if (stylesheet == null) return findings;
+        var renderStyles = new RenderStyleArrays(stylesheet);
+        if (renderStyles.CellFormats.Length == 0) return findings;
+
+        foreach (var (sheetName, part) in GetWorksheets(_doc))
+        {
+            // A hidden sheet has no delivered visual surface.
+            if (IsSheetHidden(sheetName)) continue;
+            var ws = part.Worksheet;
+            if (ws == null) continue;
+            var sheetData = ws.GetFirstChild<SheetData>();
+            if (sheetData == null) continue;
+
+            bool showFormulas = SheetShowsFormulas(ws);
+            var evaluator = new Core.FormulaEvaluator(sheetData, _doc.WorkbookPart);
+            // BuildMergeMap is intentionally capped at row 5000 / column 200
+            // for HTML DOM rendering. An issues scan covers the full worksheet,
+            // so use compact, untruncated ranges and keep only the ranges active
+            // for the current row.
+            var mergeRanges = GetNumericMergeRanges(ws);
+            var activeMerges = new List<NumericMergeRange>();
+            int nextMerge = 0;
+            var colWidths = GetColumnWidths(ws);
+            var hiddenCols = GetHiddenColumns(ws);
+            var columnStyles = GetColumnStyleIndexes(ws);
+            var sheetFmtPr = ws.GetFirstChild<SheetFormatProperties>();
+            double defaultColWidthPt = sheetFmtPr?.DefaultColumnWidth?.Value != null
+                ? sheetFmtPr.DefaultColumnWidth.Value * ColWidthCharToPt
+                : ExcelDefaultColWidthPt;
+
+            foreach (var row in sheetData.Elements<Row>()
+                         .OrderBy(row => row.RowIndex?.Value ?? uint.MaxValue))
+            {
+                int rowIndex = (int)(row.RowIndex?.Value ?? 0);
+                if (rowIndex <= 0) continue;
+                activeMerges.RemoveAll(range => range.EndRow < rowIndex);
+                while (nextMerge < mergeRanges.Count
+                    && mergeRanges[nextMerge].StartRow <= rowIndex)
+                {
+                    var range = mergeRanges[nextMerge++];
+                    if (range.EndRow >= rowIndex) activeMerges.Add(range);
+                }
+                if (row.Hidden?.Value == true || row.Height?.Value == 0) continue;
+
+                foreach (var cell in row.Elements<Cell>())
+                {
+                    // Show Formulas changes only formula cells. Ordinary numeric
+                    // and date cells on the same sheet still render normally.
+                    if (showFormulas && cell.CellFormula != null) continue;
+                    var cellRef = cell.CellReference?.Value;
+                    if (string.IsNullOrEmpty(cellRef)) continue;
+
+                    var (startCol, cellRow) = ParseCellReference(cellRef);
+                    int startColIdx = ColumnNameToIndex(startCol);
+                    var mergeRange = activeMerges.FirstOrDefault(range =>
+                        cellRow >= range.StartRow && cellRow <= range.EndRow
+                        && startColIdx >= range.StartColumn && startColIdx <= range.EndColumn);
+                    bool isMerged = mergeRange.StartColumn != 0;
+                    if (isMerged
+                        && (startColIdx != mergeRange.StartColumn || cellRow != mergeRange.StartRow))
+                        continue;
+                    int colSpan = isMerged
+                        ? mergeRange.EndColumn - mergeRange.StartColumn + 1
+                        : 1;
+                    if (colSpan <= 0 || hiddenCols.Contains(startColIdx)) continue;
+
+                    double totalWidthPt = 0;
+                    for (int colIdx = startColIdx; colIdx < startColIdx + colSpan; colIdx++)
+                    {
+                        if (hiddenCols.Contains(colIdx)) continue;
+                        totalWidthPt += colWidths.TryGetValue(colIdx, out var widthPt)
+                            ? widthPt
+                            : defaultColWidthPt;
+                    }
+                    if (!double.IsFinite(totalWidthPt)
+                        || totalWidthPt <= NumericFitCellPaddingPt)
+                        continue;
+
+                    uint styleIndex = ResolveNumericFitStyleIndex(
+                        cell, row, startColIdx, columnStyles);
+                    if (!TryGetNumericFitStyle(styleIndex, stylesheet, renderStyles,
+                            out var fontSizePt, out var shrinkToFit))
+                        continue;
+                    if (shrinkToFit) continue;
+
+                    if (!TryGetStableNumericDisplay(
+                            cell, styleIndex, stylesheet, renderStyles, evaluator,
+                            out var displayValue, out var formatCode))
+                        continue;
+
+                    double requiredPt = displayValue.Length * fontSizePt * NumericFitGlyphAdvance;
+                    double usablePt = totalWidthPt - NumericFitCellPaddingPt;
+                    // The glyph model is deliberately approximate. Require more
+                    // than one point of overflow so rounding noise at the fit
+                    // boundary does not become an audit finding.
+                    if (requiredPt <= usablePt + 1.0) continue;
+
+                    double requiredWidthChars = (requiredPt + NumericFitCellPaddingPt) / ColWidthCharToPt;
+                    double currentWidthChars = totalWidthPt / ColWidthCharToPt;
+                    int suggestedWidth = Math.Max(1, (int)Math.Ceiling(requiredWidthChars));
+                    string widthTarget = isMerged
+                        ? $"merged range {cellRef}:{IndexToColumnName(startColIdx + colSpan - 1)}{row.RowIndex?.Value ?? 0}"
+                        : $"column {startCol}";
+
+                    findings.Add(new NumericOverflowFinding(
+                        $"/{sheetName}/{cellRef}",
+                        $"numeric overflow: '{displayValue}' at {fontSizePt:F1}pt needs {requiredWidthChars:F1} width, {widthTarget} is {currentWidthChars:F2}",
+                        $"format=\"{formatCode}\" required={requiredPt:F1}pt available={usablePt:F1}pt",
+                        suggestedWidth <= 255
+                            ? $"suggest.width={suggestedWidth}; widen column {startCol} to at least {suggestedWidth}"
+                            : "required width exceeds Excel's 255-character column limit; use shrinkToFit or a shorter number format"));
+                    if (limit.HasValue && findings.Count >= limit.Value) return findings;
+                }
+            }
+        }
+
+        return findings;
+    }
+
+    private static bool SheetShowsFormulas(Worksheet ws)
+        => ws.GetFirstChild<SheetViews>()?.Elements<SheetView>()
+            .Any(view => view.ShowFormulas?.Value == true) == true;
+
+    private static List<NumericMergeRange> GetNumericMergeRanges(Worksheet ws)
+    {
+        var result = new List<NumericMergeRange>();
+        var mergeCells = ws.GetFirstChild<MergeCells>();
+        if (mergeCells == null) return result;
+
+        foreach (var mergeCell in mergeCells.Elements<MergeCell>())
+        {
+            var reference = mergeCell.Reference?.Value?.Replace("$", "");
+            if (string.IsNullOrWhiteSpace(reference)) continue;
+            var parts = reference.Split(':');
+            if (parts.Length != 2) continue;
+            var (startColumnName, startRow) = ParseCellReference(parts[0]);
+            var (endColumnName, endRow) = ParseCellReference(parts[1]);
+            int startColumn = ColumnNameToIndex(startColumnName);
+            int endColumn = ColumnNameToIndex(endColumnName);
+            if (startColumn > endColumn) (startColumn, endColumn) = (endColumn, startColumn);
+            if (startRow > endRow) (startRow, endRow) = (endRow, startRow);
+            result.Add(new NumericMergeRange(startColumn, startRow, endColumn, endRow));
+        }
+
+        return result
+            .OrderBy(range => range.StartRow)
+            .ThenBy(range => range.StartColumn)
+            .ToList();
+    }
+
+    private static HashSet<int> GetHiddenColumns(Worksheet ws)
+    {
+        var result = new HashSet<int>();
+        var columns = ws.GetFirstChild<Columns>();
+        if (columns == null) return result;
+
+        foreach (var col in columns.Elements<Column>())
+        {
+            if (col.Hidden?.Value != true && col.Width?.Value != 0) continue;
+            uint minRaw = col.Min?.Value ?? 1;
+            uint maxRaw = col.Max?.Value ?? minRaw;
+            int min = (int)Math.Min(16384u, Math.Max(1u, minRaw));
+            int max = (int)Math.Min(16384u, Math.Max(1u, maxRaw));
+            for (int colIdx = min; colIdx <= max; colIdx++) result.Add(colIdx);
+        }
+        return result;
+    }
+
+    private static Dictionary<int, uint> GetColumnStyleIndexes(Worksheet ws)
+    {
+        var result = new Dictionary<int, uint>();
+        var columns = ws.GetFirstChild<Columns>();
+        if (columns == null) return result;
+
+        foreach (var col in columns.Elements<Column>())
+        {
+            if (col.Style?.Value is not uint styleIndex) continue;
+            uint minRaw = col.Min?.Value ?? 1;
+            uint maxRaw = col.Max?.Value ?? minRaw;
+            int min = (int)Math.Min(16384u, Math.Max(1u, minRaw));
+            int max = (int)Math.Min(16384u, Math.Max(1u, maxRaw));
+            for (int colIdx = min; colIdx <= max; colIdx++) result[colIdx] = styleIndex;
+        }
+        return result;
+    }
+
+    private static uint ResolveNumericFitStyleIndex(
+        Cell cell,
+        Row row,
+        int columnIndex,
+        Dictionary<int, uint> columnStyles)
+    {
+        // Direct cell style wins even when explicitly set to 0 (General).
+        if (cell.StyleIndex?.Value is uint cellStyle) return cellStyle;
+        // OOXML gates a row's default style on customFormat=true.
+        if (row.CustomFormat?.Value == true && row.StyleIndex?.Value is uint rowStyle)
+            return rowStyle;
+        return columnStyles.TryGetValue(columnIndex, out var columnStyle)
+            ? columnStyle
+            : 0;
+    }
+
+    private static bool TryGetNumericFitStyle(
+        uint styleIndex,
+        Stylesheet stylesheet,
+        RenderStyleArrays renderStyles,
+        out double fontSizePt,
+        out bool shrinkToFit)
+    {
+        fontSizePt = 11.0;
+        shrinkToFit = false;
+
+        if (styleIndex >= (uint)renderStyles.CellFormats.Length)
+            return false;
+
+        var format = renderStyles.CellFormats[(int)styleIndex];
+        var baseFormat = GetBaseCellStyleFormat(format, stylesheet);
+        var alignment = format.Alignment;
+        var baseAlignment = baseFormat?.Alignment;
+        // If either level requests shrinking, skipping the finding is the
+        // conservative choice. This prevents a base cellStyle's shrinkToFit
+        // from being mistaken for an overflowing direct cellXf.
+        shrinkToFit = alignment?.ShrinkToFit?.Value == true
+            || baseAlignment?.ShrinkToFit?.Value == true;
+
+        // Rotated/vertical text has different horizontal geometry. Skipping is
+        // safer than treating the unrotated width estimate as authoritative.
+        if ((alignment?.TextRotation?.Value ?? 0) != 0
+            || (baseAlignment?.TextRotation?.Value ?? 0) != 0)
+            return false;
+
+        uint fontId = format.ApplyFont?.Value == false
+            ? baseFormat?.FontId?.Value ?? format.FontId?.Value ?? 0
+            : format.FontId?.Value ?? baseFormat?.FontId?.Value ?? 0;
+        if (fontId < (uint)renderStyles.Fonts.Length)
+            fontSizePt = renderStyles.Fonts[(int)fontId].FontSize?.Val?.Value ?? 11.0;
+        return double.IsFinite(fontSizePt) && fontSizePt > 0;
+    }
+
+    private bool TryGetStableNumericDisplay(
+        Cell cell,
+        uint styleIndex,
+        Stylesheet stylesheet,
+        RenderStyleArrays renderStyles,
+        Core.FormulaEvaluator evaluator,
+        out string displayValue,
+        out string formatCode)
+    {
+        displayValue = "";
+        formatCode = "";
+
+        if (!TryGetNumericValue(cell, evaluator, out var evaluatedValue)) return false;
+
+        var resolvedFormat = ResolveNumericFitFormatCode(styleIndex, stylesheet, renderStyles);
+        if (string.IsNullOrWhiteSpace(resolvedFormat)) return false;
+        var activeFormat = SelectNumericFitFormatSection(evaluatedValue, resolvedFormat);
+        if (string.IsNullOrWhiteSpace(activeFormat) || IsGeneralFormatSection(activeFormat))
+            return false;
+        bool isElapsedFormat = System.Text.RegularExpressions.Regex.IsMatch(
+            activeFormat, @"\[(h+|m+|s+)\]", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        bool isCalendarFormat = !isElapsedFormat
+            && ExcelDataFormatter.LooksLikeDateFormatCode(activeFormat);
+        if (!isElapsedFormat && !isCalendarFormat
+            && !ContainsNumericPlaceholderOutsideQuotes(activeFormat))
+            return false;
+
+        // FormulaEvaluator mixes two date-epoch domains in 1904 workbooks:
+        // DATE()/TODAY() return an absolute OADate, while a reference to a
+        // stored cell returns the workbook's 1904 serial. Until that evaluator
+        // contract is unified, any adjustment would be wrong for one family.
+        if (isCalendarFormat && IsWorkbookDate1904() && cell.CellFormula != null)
+            return false;
+
+        // Reuse the HTML preview's canonical ApplyNumberFormat pipeline so the
+        // finding describes the same formatted value OfficeCLI renders. Apply
+        // the workbook's date epoch here: GetFormattedCellValue recovers a raw
+        // serial after its first formatting pass and currently loses the 1904
+        // adjustment, which would make an audit message name the wrong date.
+        // ISO date cells already carry an absolute date and need no epoch shift.
+        double displayValueNumber = evaluatedValue;
+        DateTime isoDate = default;
+        bool isIsoDateCell = cell.DataType?.Value == CellValues.Date
+            && DateTime.TryParse(cell.CellValue?.Text, CultureInfo.InvariantCulture,
+                DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.RoundtripKind, out isoDate);
+        if (isCalendarFormat)
+        {
+            if (isIsoDateCell) displayValueNumber = isoDate.ToOADate();
+            else if (IsWorkbookDate1904()) displayValueNumber += 1462.0;
+            // A negative date/time serial renders ### regardless of column
+            // width, so a suggest.width finding would prescribe a non-fix.
+            if (displayValueNumber < 0) return false;
+        }
+        else if (isElapsedFormat && evaluatedValue < 0 && !IsWorkbookDate1904())
+        {
+            // The 1900 date system renders negative elapsed/time values as
+            // #### regardless of column width. A width suggestion cannot fix
+            // that display, while the 1904 system can render negative time.
+            return false;
+        }
+        else if (isElapsedFormat && isIsoDateCell)
+        {
+            // An ISO absolute date formatted as an elapsed duration has no
+            // unambiguous serial-domain interpretation; do not guess.
+            return false;
+        }
+        displayValue = ApplyNumberFormat(displayValueNumber, resolvedFormat);
+
+        if (string.IsNullOrEmpty(displayValue) || IsExcelErrorText(displayValue)) return false;
+        formatCode = resolvedFormat;
+        return true;
+    }
+
+    private static string SelectNumericFitFormatSection(double value, string formatCode)
+    {
+        if (!formatCode.Contains(';')) return formatCode.Trim();
+        var sections = formatCode.Split(';');
+        if (System.Text.RegularExpressions.Regex.IsMatch(formatCode, @"\[[<>=]=?\d"))
+            return SelectConditionalSection(value, sections);
+        if (value < 0 && sections.Length >= 2) return sections[1].Trim();
+        if (value == 0 && sections.Length >= 3) return sections[2].Trim();
+        return sections[0].Trim();
+    }
+
+    private static bool IsGeneralFormatSection(string formatSection)
+    {
+        // Modifiers and literals do not make General width-stable:
+        // [Red]General and General "units" still adapt to the column width.
+        var semantic = System.Text.RegularExpressions.Regex.Replace(
+            formatSection, "\"[^\"]*\"", "");
+        semantic = System.Text.RegularExpressions.Regex.Replace(semantic, @"\[[^\]]*\]", "");
+        semantic = System.Text.RegularExpressions.Regex.Replace(semantic, @"_.|\*.", "");
+        semantic = System.Text.RegularExpressions.Regex.Replace(semantic, @"\\.", "");
+        return semantic.Trim().Equals("General", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CellFormat? GetBaseCellStyleFormat(
+        CellFormat format,
+        Stylesheet stylesheet)
+    {
+        if (format.FormatId?.Value is not uint baseIndex || baseIndex > int.MaxValue) return null;
+        return stylesheet.CellStyleFormats?.Elements<CellFormat>()
+            .ElementAtOrDefault((int)baseIndex);
+    }
+
+    private static string? ResolveNumericFitFormatCode(
+        uint styleIndex,
+        Stylesheet stylesheet,
+        RenderStyleArrays renderStyles)
+    {
+        if (styleIndex >= (uint)renderStyles.CellFormats.Length) return null;
+        var format = renderStyles.CellFormats[(int)styleIndex];
+        var baseFormat = GetBaseCellStyleFormat(format, stylesheet);
+        uint directId = format.NumberFormatId?.Value ?? 0;
+        uint baseId = baseFormat?.NumberFormatId?.Value ?? 0;
+        uint numberFormatId;
+        if (format.ApplyNumberFormat?.Value == true || baseFormat == null)
+        {
+            numberFormatId = directId;
+        }
+        else if (format.ApplyNumberFormat?.Value == false)
+        {
+            numberFormatId = baseId;
+        }
+        else if (directId != 0 && baseId != 0 && directId != baseId)
+        {
+            // Ambiguous inheritance is not a safe basis for an audit finding.
+            return null;
+        }
+        else
+        {
+            numberFormatId = directId != 0 ? directId : baseId;
+        }
+        if (numberFormatId == 0) return null; // General
+
+        var customFormat = stylesheet.NumberingFormats?.Elements<NumberingFormat>()
+            .FirstOrDefault(format => format.NumberFormatId?.Value == numberFormatId)
+            ?.FormatCode?.Value;
+        return customFormat ?? ExcelDataFormatter.ResolveBuiltInFormatCode(numberFormatId);
+    }
+
+    private static bool TryGetNumericValue(
+        Cell cell,
+        Core.FormulaEvaluator evaluator,
+        out double numericValue)
+    {
+        numericValue = 0;
+        if (cell.CellFormula?.Text is { } formula)
+        {
+            var result = evaluator.TryEvaluateFull(formula);
+            if (result != null)
+            {
+                if (!result.IsNumeric) return false;
+                numericValue = result.NumericValue!.Value;
+                return double.IsFinite(numericValue);
+            }
+        }
+
+        var dataType = cell.DataType?.Value;
+        if (dataType == CellValues.SharedString
+            || dataType == CellValues.InlineString
+            || dataType == CellValues.String
+            || dataType == CellValues.Boolean
+            || dataType == CellValues.Error)
+            return false;
+
+        if (double.TryParse(cell.CellValue?.Text, NumberStyles.Any,
+                CultureInfo.InvariantCulture, out numericValue))
+            return double.IsFinite(numericValue);
+
+        // ISO date cells (t="d") are uncommon but still numeric/date display
+        // candidates. Their stable visible value is handled by the shared
+        // formatter; this conversion is only for candidate classification.
+        if (dataType == CellValues.Date
+            && DateTime.TryParse(cell.CellValue?.Text, CultureInfo.InvariantCulture,
+                DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.RoundtripKind, out var date))
+        {
+            numericValue = date.ToOADate();
+            return true;
+        }
+        return false;
+    }
+
+    private static bool ContainsNumericPlaceholderOutsideQuotes(string formatCode)
+    {
+        bool inQuote = false;
+        int bracketDepth = 0;
+        for (int i = 0; i < formatCode.Length; i++)
+        {
+            char ch = formatCode[i];
+            if (ch == '\\' && i + 1 < formatCode.Length) { i++; continue; }
+            if (ch == '"') { inQuote = !inQuote; continue; }
+            if (inQuote) continue;
+            if (ch == '[') { bracketDepth++; continue; }
+            if (ch == ']' && bracketDepth > 0) { bracketDepth--; continue; }
+            if (bracketDepth == 0 && ch is '0' or '#' or '?') return true;
+        }
+        return false;
+    }
+}

--- a/src/officecli/Handlers/Excel/ExcelHandler.View.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.View.cs
@@ -535,18 +535,25 @@ public partial class ExcelHandler
         _viewAsIssuesSheetNameCache = null;
 
         // Should the scan that produces issues of `subtypeName` run?
-        // True when no filter is active, when the filter is the broad
-        // bucket the subtype belongs to (here always Content), or when
-        // the filter names the subtype exactly. Centralising this keeps
-        // every inline gate consistent with the end-of-function filter,
-        // so `--type content` and the no-filter default both see every
-        // Content-bucket subtype.
-        bool ShouldScan(string subtypeName)
+        // True when no filter is active, when the filter is the broad bucket
+        // the subtype belongs to, or when the filter names the subtype exactly.
+        // Centralising this keeps every inline gate consistent with the final
+        // filter while avoiding expensive scans for unrelated buckets.
+        bool ShouldScan(string subtypeName, IssueType bucket = IssueType.Content)
         {
             if (issueType == null) return true;
+            var bucketMatch = bucket switch
+            {
+                IssueType.Format => string.Equals(issueType, "format", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(issueType, "f", StringComparison.OrdinalIgnoreCase),
+                IssueType.Content => string.Equals(issueType, "content", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(issueType, "c", StringComparison.OrdinalIgnoreCase),
+                IssueType.Structure => string.Equals(issueType, "structure", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(issueType, "s", StringComparison.OrdinalIgnoreCase),
+                _ => false
+            };
             return string.Equals(issueType, subtypeName, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(issueType, "content", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(issueType, "c", StringComparison.OrdinalIgnoreCase);
+                || bucketMatch;
         }
 
         // cachedValue vs computedValue agreement (1e-9 relative tolerance for
@@ -712,6 +719,33 @@ public partial class ExcelHandler
             }
         }
 
+        // Width-stable numeric/date cells whose visible formatted value cannot
+        // fit the column render as ### in Excel. Keep this before the other
+        // issue families so default output follows the worksheet scan order;
+        // each later family is gated too, so unrelated findings cannot consume
+        // an exact/broad Format request's --limit capacity.
+        if (ShouldScan(Core.IssueSubtypes.NumericOverflow, IssueType.Format))
+        {
+            int? remaining = limit.HasValue
+                ? Math.Max(0, limit.Value - issues.Count)
+                : null;
+            foreach (var finding in CheckAllNumericOverflow(remaining))
+            {
+                if (limit.HasValue && issues.Count >= limit.Value) break;
+                issues.Add(new DocumentIssue
+                {
+                    Id = $"N{++issueNum}",
+                    Type = IssueType.Format,
+                    Subtype = Core.IssueSubtypes.NumericOverflow,
+                    Severity = IssueSeverity.Warning,
+                    Path = finding.Path,
+                    Message = finding.Message,
+                    Context = finding.Context,
+                    Suggestion = finding.Suggestion
+                });
+            }
+        }
+
         // Defined names whose body references a sheet that no longer exists.
         // Excel persists the stale ref (or writes #REF!) and silently returns
         // 0 in any formula using the name — see ResolveSheetCellResult. The
@@ -721,7 +755,9 @@ public partial class ExcelHandler
         // before the name was cleaned up.
         var workbook = _doc.WorkbookPart?.Workbook;
         var definedNames = workbook?.DefinedNames?.Elements<DefinedName>();
-        if (definedNames != null)
+        bool scanDefinedNameBroken = ShouldScan(Core.IssueSubtypes.DefinedNameBroken);
+        bool scanDefinedNameTargetMissing = ShouldScan(Core.IssueSubtypes.DefinedNameTargetMissing);
+        if (definedNames != null && (scanDefinedNameBroken || scanDefinedNameTargetMissing))
         {
             foreach (var dn in definedNames)
             {
@@ -737,17 +773,20 @@ public partial class ExcelHandler
                 var lid = dn.LocalSheetId?.Value;
                 if (lid.HasValue && lid.Value >= sheetCount)
                 {
-                    issues.Add(new DocumentIssue
+                    if (scanDefinedNameBroken)
                     {
-                        Id = $"D{++issueNum}",
-                        Type = IssueType.Content,
-                        Subtype = Core.IssueSubtypes.DefinedNameBroken,
-                        Severity = IssueSeverity.Error,
-                        Path = $"/namedrange[{name}]",
-                        Message = $"Defined name '{name}' has out-of-range scope localSheetId={lid.Value} (workbook has {sheetCount} sheet(s)); Excel will refuse to open this file",
-                        Context = body,
-                        Suggestion = "Rescope the name to an existing sheet index or remove it."
-                    });
+                        issues.Add(new DocumentIssue
+                        {
+                            Id = $"D{++issueNum}",
+                            Type = IssueType.Content,
+                            Subtype = Core.IssueSubtypes.DefinedNameBroken,
+                            Severity = IssueSeverity.Error,
+                            Path = $"/namedrange[{name}]",
+                            Message = $"Defined name '{name}' has out-of-range scope localSheetId={lid.Value} (workbook has {sheetCount} sheet(s)); Excel will refuse to open this file",
+                            Context = body,
+                            Suggestion = "Rescope the name to an existing sheet index or remove it."
+                        });
+                    }
                     continue;
                 }
                 // Body that is an error literal (#REF!) is already handled
@@ -756,19 +795,23 @@ public partial class ExcelHandler
                 // too so it's discoverable.
                 if (body.StartsWith('#') && body.EndsWith('!'))
                 {
-                    issues.Add(new DocumentIssue
+                    if (scanDefinedNameBroken)
                     {
-                        Id = $"D{++issueNum}",
-                        Type = IssueType.Content,
-                        Subtype = Core.IssueSubtypes.DefinedNameBroken,
-                        Severity = IssueSeverity.Error,
-                        Path = $"/namedrange[{name}]",
-                        Message = $"Defined name '{name}' has error body {body}",
-                        Context = body,
-                        Suggestion = "Rebind to a valid range or remove the name."
-                    });
+                        issues.Add(new DocumentIssue
+                        {
+                            Id = $"D{++issueNum}",
+                            Type = IssueType.Content,
+                            Subtype = Core.IssueSubtypes.DefinedNameBroken,
+                            Severity = IssueSeverity.Error,
+                            Path = $"/namedrange[{name}]",
+                            Message = $"Defined name '{name}' has error body {body}",
+                            Context = body,
+                            Suggestion = "Rebind to a valid range or remove it."
+                        });
+                    }
                     continue;
                 }
+                if (!scanDefinedNameTargetMissing) continue;
                 if (!ChartRefSheetExists(body, out var missingSheet)) continue;
                 issues.Add(new DocumentIssue
                 {
@@ -791,21 +834,24 @@ public partial class ExcelHandler
         // ref becomes a silent landmine for the next refresh. Detect by
         // scanning every chart's c:f formulas and matching the sheet prefix
         // against the live workbook.
-        foreach (var (slug, formula) in EnumerateChartRefFormulas())
+        if (ShouldScan(Core.IssueSubtypes.ChartSeriesRefMissingSheet))
         {
-            if (limit.HasValue && issues.Count >= limit.Value) break;
-            if (!ChartRefSheetExists(formula, out var missingSheet)) continue;
-            issues.Add(new DocumentIssue
+            foreach (var (slug, formula) in EnumerateChartRefFormulas())
             {
-                Id = $"R{++issueNum}",
-                Type = IssueType.Content,
-                Subtype = Core.IssueSubtypes.ChartSeriesRefMissingSheet,
-                Severity = IssueSeverity.Error,
-                Path = slug,
-                Message = $"Chart series references missing sheet '{missingSheet}'",
-                Context = formula,
-                Suggestion = "Restore the sheet, or rebuild the chart against an existing range."
-            });
+                if (limit.HasValue && issues.Count >= limit.Value) break;
+                if (!ChartRefSheetExists(formula, out var missingSheet)) continue;
+                issues.Add(new DocumentIssue
+                {
+                    Id = $"R{++issueNum}",
+                    Type = IssueType.Content,
+                    Subtype = Core.IssueSubtypes.ChartSeriesRefMissingSheet,
+                    Severity = IssueSeverity.Error,
+                    Path = slug,
+                    Message = $"Chart series references missing sheet '{missingSheet}'",
+                    Context = formula,
+                    Suggestion = "Restore the sheet, or rebuild the chart against an existing range."
+                });
+            }
         }
 
         // Chart numCache vs live cell values — stale-cache detection.
@@ -868,17 +914,23 @@ public partial class ExcelHandler
 
         // CONSISTENCY(text-overflow-check): merged in from former `check` command.
         // Emits wrapText-cells whose visible row-height budget can't fit the wrapped text.
-        foreach (var (path, msg) in CheckAllCellOverflow())
+        bool scanBroadFormat = issueType == null
+            || string.Equals(issueType, "format", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(issueType, "f", StringComparison.OrdinalIgnoreCase);
+        if (scanBroadFormat && (!limit.HasValue || issues.Count < limit.Value))
         {
-            if (limit.HasValue && issues.Count >= limit.Value) break;
-            issues.Add(new DocumentIssue
+            foreach (var (path, msg) in CheckAllCellOverflow())
             {
-                Id = $"O{++issueNum}",
-                Type = IssueType.Format,
-                Severity = IssueSeverity.Warning,
-                Path = path,
-                Message = msg
-            });
+                if (limit.HasValue && issues.Count >= limit.Value) break;
+                issues.Add(new DocumentIssue
+                {
+                    Id = $"O{++issueNum}",
+                    Type = IssueType.Format,
+                    Severity = IssueSeverity.Warning,
+                    Path = path,
+                    Message = msg
+                });
+            }
         }
 
         // Subtype / type filter (mirrors WordHandler.ViewAsIssues). xlsx

--- a/tests/OfficeCli.NumericFit.Tests/OfficeCli.NumericFit.Tests.csproj
+++ b/tests/OfficeCli.NumericFit.Tests/OfficeCli.NumericFit.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <SelfContained>true</SelfContained>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/officecli/officecli.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/OfficeCli.NumericFit.Tests/Program.cs
+++ b/tests/OfficeCli.NumericFit.Tests/Program.cs
@@ -1,0 +1,434 @@
+// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
+// SPDX-License-Identifier: Apache-2.0
+
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeCli.Core;
+using OfficeCli.Handlers;
+
+const string NumericOverflowSubtype = "numeric_overflow";
+
+var standardPath = Path.Combine(Path.GetTempPath(), $"officecli-numeric-fit-{Guid.NewGuid():N}.xlsx");
+var date1904Path = Path.Combine(Path.GetTempPath(), $"officecli-numeric-fit-1904-{Guid.NewGuid():N}.xlsx");
+try
+{
+    CreateStandardFixture(standardPath);
+    VerifyStandardWorkbook(standardPath);
+
+    CreateDate1904Fixture(date1904Path);
+    VerifyDate1904Workbook(date1904Path);
+
+    Console.WriteLine("XLSX numeric-fit issue tests passed.");
+}
+finally
+{
+    if (File.Exists(standardPath)) File.Delete(standardPath);
+    if (File.Exists(date1904Path)) File.Delete(date1904Path);
+}
+
+static void VerifyStandardWorkbook(string path)
+{
+    string[] expectedPaths =
+    [
+        "/FormulaView/A1", // Show Formulas does not hide an ordinary number
+        "/Sheet1/A1",     // explicit narrow number
+        "/Sheet1/B1",     // explicit narrow date serial
+        "/Sheet1/F1",     // wrapText does not make a number spill
+        "/Sheet1/M1",     // evaluated numeric formula
+        "/Sheet1/N1",     // ISO t=d date
+        "/Sheet1/P1",     // bracketed color numeric format
+        "/Sheet1/T1",     // inherited column style
+        "/Sheet1/U3",     // row style wins over column style
+        "/Sheet1/W1",     // direct cell style wins over column shrinkToFit
+        "/Sheet1/X4",     // direct cell style wins over row shrinkToFit
+        "/Sheet1/AD1",    // active non-General section is still checked
+    ];
+
+    using var handler = new ExcelHandler(path, editable: false);
+    var allIssues = handler.ViewAsIssues();
+    var numericIssues = allIssues
+        .Where(issue => issue.Subtype == NumericOverflowSubtype)
+        .ToList();
+
+    AssertPaths(expectedPaths, numericIssues.Select(issue => issue.Path), "default issues scan");
+
+    foreach (var issue in numericIssues)
+    {
+        Assert(issue.Type == IssueType.Format, $"{issue.Path} should use the Format bucket");
+        Assert(issue.Severity == IssueSeverity.Warning, $"{issue.Path} should be a warning");
+        Assert(issue.Message.Contains("numeric overflow", StringComparison.Ordinal),
+            $"{issue.Path} should describe the rendering defect");
+        Assert(issue.Suggestion?.Contains("suggest.width=", StringComparison.Ordinal) == true,
+            $"{issue.Path} should carry an actionable width suggestion");
+    }
+    Assert(numericIssues.Single(issue => issue.Path == "/Sheet1/A1").Message
+            .Contains("'1,234,567.89'", StringComparison.Ordinal),
+        "numeric finding should use the formatted display value");
+    Assert(numericIssues.Single(issue => issue.Path == "/Sheet1/B1").Message
+            .Contains("'2024-10-02'", StringComparison.Ordinal),
+        "date finding should use the formatted display value");
+    Assert(numericIssues.Single(issue => issue.Path == "/Sheet1/N1").Message
+            .Contains("'2024-10-02'", StringComparison.Ordinal),
+        "ISO date finding should use its absolute date");
+    Assert(numericIssues.All(issue => issue.Path is not "/Sheet1/AE1"
+            and not "/Sheet1/AF1" and not "/Sheet1/AG1"),
+        "non-finite numeric values should not produce width findings");
+    Assert(numericIssues.All(issue => issue.Path != "/Sheet1/AH1"),
+        "negative elapsed values in a 1900 workbook need a non-width fix");
+
+    var exactIssues = handler.ViewAsIssues(NumericOverflowSubtype);
+    AssertPaths(expectedPaths, exactIssues.Select(issue => issue.Path), "exact subtype filter");
+
+    var formatIssues = handler.ViewAsIssues("format")
+        .Where(issue => issue.Subtype == NumericOverflowSubtype);
+    AssertPaths(expectedPaths, formatIssues.Select(issue => issue.Path), "format bucket filter");
+
+    // The scanner receives only the remaining capacity and stops at the first
+    // matching Format finding; the broken defined name cannot consume it.
+    var exactLimited = handler.ViewAsIssues(NumericOverflowSubtype, limit: 1);
+    AssertPaths(["/Sheet1/A1"], exactLimited.Select(issue => issue.Path), "exact subtype limit");
+    var formatLimited = handler.ViewAsIssues("format", limit: 1);
+    AssertPaths(["/Sheet1/A1"], formatLimited.Select(issue => issue.Path), "format bucket limit");
+}
+
+static void VerifyDate1904Workbook(string path)
+{
+    using var handler = new ExcelHandler(path, editable: false);
+    var issues = handler.ViewAsIssues(NumericOverflowSubtype);
+    AssertPaths(
+        [
+            "/Sheet1/A1", "/Sheet1/C1", "/Sheet1/E1", "/Sheet1/F1",
+            "/Sheet1/G1", "/Sheet1/H1", "/Sheet1/I1"
+        ],
+        issues.Select(issue => issue.Path),
+        "1904 date-system scan");
+    Assert(issues.Single(issue => issue.Path == "/Sheet1/A1").Message
+            .Contains("'1904-01-01'", StringComparison.Ordinal),
+        "a stored 1904 serial should use the workbook epoch");
+    Assert(issues.All(issue => issue.Path is not "/Sheet1/B1" and not "/Sheet1/D1"),
+        "date-formatted formulas in a 1904 workbook should be skipped conservatively");
+    Assert(issues.Single(issue => issue.Path == "/Sheet1/F1").Message
+            .Contains("'36:00:00'", StringComparison.Ordinal),
+        "1904 workbooks must not epoch-shift positive elapsed hours");
+    Assert(issues.Single(issue => issue.Path == "/Sheet1/G1").Message
+            .Contains("'-36:00:00'", StringComparison.Ordinal),
+        "1904 workbooks must not epoch-shift negative elapsed hours");
+}
+
+static void CreateStandardFixture(string path)
+{
+    using var document = SpreadsheetDocument.Create(path, SpreadsheetDocumentType.Workbook);
+    var workbookPart = document.AddWorkbookPart();
+    workbookPart.Workbook = new Workbook();
+
+    var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+    stylesPart.Stylesheet = CreateStylesheet();
+
+    var visiblePart = workbookPart.AddNewPart<WorksheetPart>();
+    visiblePart.Worksheet = CreateVisibleWorksheet();
+    var formulaViewPart = workbookPart.AddNewPart<WorksheetPart>();
+    formulaViewPart.Worksheet = CreateFormulaViewWorksheet();
+    var hiddenPart = workbookPart.AddNewPart<WorksheetPart>();
+    hiddenPart.Worksheet = CreateHiddenWorksheet();
+
+    workbookPart.Workbook.Append(
+        new Sheets(
+            SheetFor(workbookPart, visiblePart, 1, "Sheet1"),
+            SheetFor(workbookPart, formulaViewPart, 2, "FormulaView"),
+            SheetFor(workbookPart, hiddenPart, 3, "HiddenSheet", SheetStateValues.Hidden)),
+        new DefinedNames(new DefinedName("#REF!") { Name = "BrokenName" }));
+    workbookPart.Workbook.Save();
+}
+
+static void CreateDate1904Fixture(string path)
+{
+    using var document = SpreadsheetDocument.Create(path, SpreadsheetDocumentType.Workbook);
+    var workbookPart = document.AddWorkbookPart();
+    workbookPart.Workbook = new Workbook(new WorkbookProperties { Date1904 = true });
+    var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+    stylesPart.Stylesheet = CreateStylesheet();
+    var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+    worksheetPart.Worksheet = new Worksheet(
+        new SheetFormatProperties { DefaultRowHeight = 15D, DefaultColumnWidth = 8.43D },
+        new Columns(
+            Col(1, 4), Col(2, 4), Col(3, 2), Col(4, 4), Col(5, 2),
+            Col(6, 2), Col(7, 2), Col(8, 2), Col(9, 2)),
+        new SheetData(new Row(
+            NumberCell("A1", "0", 2),
+            FormulaCell("B1", "DATE(2024,10,2)", 2),
+            FormulaCell("C1", "1234567.89", 1),
+            FormulaCell("D1", "A1", 2),
+            NumberCell("E1", "0.5", 10),
+            NumberCell("F1", "1.5", 11),
+            NumberCell("G1", "-1.5", 11),
+            NumberCell("H1", "0.000011574074", 12),
+            NumberCell("I1", "1234567", 13))
+        { RowIndex = 1 }));
+    workbookPart.Workbook.Append(new Sheets(
+        SheetFor(workbookPart, worksheetPart, 1, "Sheet1")));
+    workbookPart.Workbook.Save();
+}
+
+static Sheet SheetFor(
+    WorkbookPart workbookPart,
+    WorksheetPart worksheetPart,
+    uint id,
+    string name,
+    SheetStateValues? state = null)
+{
+    var sheet = new Sheet
+    {
+        Id = workbookPart.GetIdOfPart(worksheetPart),
+        SheetId = id,
+        Name = name
+    };
+    if (state != null) sheet.State = state.Value;
+    return sheet;
+}
+
+static Stylesheet CreateStylesheet()
+{
+    var numberingFormats = new NumberingFormats(
+        new NumberingFormat { NumberFormatId = 164, FormatCode = "#,##0.00" },
+        new NumberingFormat { NumberFormatId = 165, FormatCode = "yyyy-mm-dd" },
+        new NumberingFormat { NumberFormatId = 166, FormatCode = "[Red]General" },
+        new NumberingFormat { NumberFormatId = 167, FormatCode = "[Red]#,##0.00" },
+        new NumberingFormat { NumberFormatId = 168, FormatCode = "General;0.00" })
+    { Count = 5 };
+
+    var fonts = new Fonts(
+        new Font(new FontSize { Val = 11D }, new FontName { Val = "Calibri" }))
+    { Count = 1 };
+    var fills = new Fills(
+        new Fill(new PatternFill { PatternType = PatternValues.None }),
+        new Fill(new PatternFill { PatternType = PatternValues.Gray125 }))
+    { Count = 2 };
+    var borders = new Borders(new Border()) { Count = 1 };
+    var cellStyleFormats = new CellStyleFormats(
+        new CellFormat(),
+        new CellFormat
+        {
+            ApplyAlignment = true,
+            Alignment = new Alignment { ShrinkToFit = true }
+        })
+    { Count = 2 };
+    var cellFormats = new CellFormats(
+        new CellFormat(),
+        new CellFormat { NumberFormatId = 164, FontId = 0, ApplyNumberFormat = true },
+        new CellFormat { NumberFormatId = 165, FontId = 0, ApplyNumberFormat = true },
+        new CellFormat
+        {
+            NumberFormatId = 164,
+            FontId = 0,
+            ApplyNumberFormat = true,
+            ApplyAlignment = true,
+            Alignment = new Alignment { ShrinkToFit = true }
+        },
+        new CellFormat
+        {
+            NumberFormatId = 164,
+            FontId = 0,
+            ApplyNumberFormat = true,
+            ApplyAlignment = true,
+            Alignment = new Alignment { WrapText = true }
+        },
+        new CellFormat { NumberFormatId = 199, FontId = 0, ApplyNumberFormat = true },
+        new CellFormat
+        {
+            NumberFormatId = 164,
+            FontId = 0,
+            FormatId = 1,
+            ApplyNumberFormat = true
+        },
+        new CellFormat { NumberFormatId = 166, FontId = 0, ApplyNumberFormat = true },
+        new CellFormat { NumberFormatId = 167, FontId = 0, ApplyNumberFormat = true },
+        new CellFormat { NumberFormatId = 168, FontId = 0, ApplyNumberFormat = true },
+        new CellFormat { NumberFormatId = 45, FontId = 0, ApplyNumberFormat = true },
+        new CellFormat { NumberFormatId = 46, FontId = 0, ApplyNumberFormat = true },
+        new CellFormat { NumberFormatId = 47, FontId = 0, ApplyNumberFormat = true },
+        new CellFormat { NumberFormatId = 48, FontId = 0, ApplyNumberFormat = true })
+    { Count = 14 };
+    var cellStyles = new CellStyles(
+        new CellStyle { Name = "Normal", FormatId = 0, BuiltinId = 0 },
+        new CellStyle { Name = "ShrinkBase", FormatId = 1 })
+    { Count = 2 };
+
+    return new Stylesheet(
+        numberingFormats,
+        fonts,
+        fills,
+        borders,
+        cellStyleFormats,
+        cellFormats,
+        cellStyles,
+        new DifferentialFormats { Count = 0 },
+        new TableStyles { Count = 0 });
+}
+
+static Worksheet CreateVisibleWorksheet()
+{
+    var columns = new Columns(
+        Col(1, 2), Col(2, 4), Col(3, 24), Col(4, 2), Col(5, 2), Col(6, 2),
+        Col(7, 8), Col(8, 8), Col(9, 2, hidden: true), Col(10, 2),
+        Col(11, 2), Col(12, 2), Col(13, 2), Col(14, 4), Col(15, 2), Col(16, 2),
+        Col(17, 7), Col(18, 7),
+        Col(20, 2, styleIndex: 1), Col(21, 2, styleIndex: 3),
+        Col(22, 2, styleIndex: 1), Col(23, 2, styleIndex: 3), Col(24, 2),
+        Col(25, 2), Col(26, 2, styleIndex: 3), Col(27, 2, styleIndex: 1), Col(28, 2),
+        Col(29, 2), Col(30, 2), Col(31, 2), Col(32, 2), Col(33, 2), Col(34, 2),
+        Col(201, 7), Col(202, 7));
+
+    var row1 = new Row(
+        NumberCell("A1", "1234567.89", 1),
+        NumberCell("B1", "45567", 2),
+        NumberCell("C1", "1234567.89", 1),
+        InlineTextCell("D1", "1234567.89"),
+        NumberCell("E1", "1234567.89", 3),
+        NumberCell("F1", "1234567.89", 4),
+        NumberCell("G1", "1234567.89", 1),
+        NumberCell("H1", "9876543.21", 1),
+        NumberCell("I1", "1234567.89", 1),
+        NumberCell("K1", "123456789", 0),
+        NumberCell("L1", "1234567.89", 5),
+        FormulaCell("M1", "1234567.89", 1),
+        IsoDateCell("N1", "2024-10-02T00:00:00Z", 2),
+        NumberCell("O1", "123456789", 7),
+        NumberCell("P1", "-1234567.89", 8),
+        NumberCell("T1", "1234567.89"),
+        NumberCell("V1", "1234567.89", 3),
+        NumberCell("W1", "1234567.89", 1),
+        NumberCell("Z1", "1234567.89"),
+        NumberCell("AA1", "1234567.89", 0),
+        NumberCell("AB1", "1234567.89", 6),
+        NumberCell("AC1", "123456789", 9),
+        NumberCell("AD1", "-1234567.89", 9),
+        NumberCell("AE1", "NaN", 1),
+        NumberCell("AF1", "Infinity", 1),
+        NumberCell("AG1", "-Infinity", 1),
+        NumberCell("AH1", "-1.5", 11),
+        NumberCell("GS1", "12345.67", 1),
+        NumberCell("GT1", "98765.43", 1))
+    { RowIndex = 1 };
+    var row2 = new Row(NumberCell("J2", "1234567.89", 1))
+    {
+        RowIndex = 2,
+        Hidden = true
+    };
+    var row3 = new Row(NumberCell("U3", "1234567.89"))
+    {
+        RowIndex = 3,
+        CustomFormat = true,
+        StyleIndex = 1
+    };
+    var row4 = new Row(NumberCell("X4", "1234567.89", 1))
+    {
+        RowIndex = 4,
+        CustomFormat = true,
+        StyleIndex = 3
+    };
+    var row5 = new Row(NumberCell("Y5", "1234567.89"))
+    {
+        RowIndex = 5,
+        CustomFormat = true,
+        StyleIndex = 3
+    };
+    var row5001 = new Row(
+        NumberCell("Q5001", "12345.67", 1),
+        NumberCell("R5001", "98765.43", 1))
+    { RowIndex = 5001 };
+
+    var sheetData = new SheetData(row1, row2, row3, row4, row5, row5001);
+    var mergeCells = new MergeCells(
+        new MergeCell { Reference = "G1:H1" },
+        new MergeCell { Reference = "Q5001:R5001" },
+        new MergeCell { Reference = "GS1:GT1" })
+    { Count = 3 };
+    return new Worksheet(
+        new SheetFormatProperties { DefaultRowHeight = 15D, DefaultColumnWidth = 8.43D },
+        columns,
+        sheetData,
+        mergeCells);
+}
+
+static Worksheet CreateFormulaViewWorksheet()
+{
+    return new Worksheet(
+        new SheetViews(new SheetView { WorkbookViewId = 0, ShowFormulas = true }),
+        new SheetFormatProperties { DefaultRowHeight = 15D, DefaultColumnWidth = 2D },
+        new Columns(Col(1, 2), Col(2, 2)),
+        new SheetData(new Row(
+            NumberCell("A1", "1234567.89", 1),
+            FormulaCell("B1", "1234567.89", 1))
+        { RowIndex = 1 }));
+}
+
+static Worksheet CreateHiddenWorksheet()
+{
+    return new Worksheet(
+        new SheetFormatProperties { DefaultRowHeight = 15D, DefaultColumnWidth = 2D },
+        new Columns(Col(1, 2)),
+        new SheetData(new Row(NumberCell("A1", "1234567.89", 1)) { RowIndex = 1 }));
+}
+
+static Column Col(uint index, double width, bool hidden = false, uint? styleIndex = null)
+{
+    var column = new Column
+    {
+        Min = index,
+        Max = index,
+        Width = width,
+        CustomWidth = true,
+        Hidden = hidden
+    };
+    if (styleIndex.HasValue) column.Style = styleIndex.Value;
+    return column;
+}
+
+static Cell NumberCell(string reference, string value, uint? styleIndex = null)
+{
+    var cell = new Cell
+    {
+        CellReference = reference,
+        CellValue = new CellValue(value)
+    };
+    if (styleIndex.HasValue) cell.StyleIndex = styleIndex.Value;
+    return cell;
+}
+
+static Cell FormulaCell(string reference, string formula, uint styleIndex) => new()
+{
+    CellReference = reference,
+    StyleIndex = styleIndex,
+    CellFormula = new CellFormula(formula)
+};
+
+static Cell IsoDateCell(string reference, string value, uint styleIndex) => new()
+{
+    CellReference = reference,
+    StyleIndex = styleIndex,
+    DataType = CellValues.Date,
+    CellValue = new CellValue(value)
+};
+
+static Cell InlineTextCell(string reference, string value) => new()
+{
+    CellReference = reference,
+    StyleIndex = 1,
+    DataType = CellValues.InlineString,
+    InlineString = new InlineString(new Text(value))
+};
+
+static void AssertPaths(IEnumerable<string> expected, IEnumerable<string> actual, string scenario)
+{
+    var expectedList = expected.OrderBy(path => path, StringComparer.Ordinal).ToArray();
+    var actualList = actual.OrderBy(path => path, StringComparer.Ordinal).ToArray();
+    if (expectedList.SequenceEqual(actualList, StringComparer.Ordinal)) return;
+    throw new InvalidOperationException(
+        $"{scenario}: expected [{string.Join(", ", expectedList)}], got [{string.Join(", ", actualList)}]");
+}
+
+static void Assert(bool condition, string message)
+{
+    if (!condition) throw new InvalidOperationException(message);
+}


### PR DESCRIPTION
## Summary

- add a machine-readable `numeric_overflow` warning in the Format bucket when an explicit, width-stable xlsx numeric or date display cannot fit its visible column or merged-range width
- honor effective cell, row, column, and base styles; hidden surfaces; merged cells; `shrinkToFit`; Show Formulas; 1900/1904 date semantics; and remaining `--limit` capacity
- conservatively skip General and unresolved formats, rotated or shrink-to-fit cells, ambiguous 1904 date formulas, and negative 1900 elapsed values where widening is not a valid fix

## Scope

Part 1 of #301 only. PPTX layout and spacing checks remain out of scope.

Refs #301

## Validation

- `dotnet run --project tests/OfficeCli.NumericFit.Tests/OfficeCli.NumericFit.Tests.csproj --configuration Release --no-restore` (passed; only the existing `ExcelHandler.SheetShift.cs:538` CS8602 warning appeared during the full rebuild)
- `dotnet build src/officecli/officecli.csproj --configuration Release --no-restore` (passed, 0 errors)
- public `ViewAsIssues` runner covers narrow and adequate widths, General and explicit formats, formulas, ISO and 1904 dates, built-ins 45-48, style inheritance, merges beyond renderer caps, hidden surfaces, `shrinkToFit`, non-finite values, and exact/bucket limits
- CLI black box: `view issues --type numeric_overflow --json` reported the narrow formatted value at `/Sheet1/A1` with a machine-readable width suggestion
- `git diff --check`