### PR TITLE
fix(view): preserve native render failure diagnostics

### DIFF
--- a/src/officecli/CommandBuilder.View.cs
+++ b/src/officecli/CommandBuilder.View.cs
@@ -260,7 +260,9 @@ static partial class CommandBuilder
                             ? Math.Max(1, (int)Math.Round(screenshotWidth * (double)nativeH / nativeW))
                             : screenshotHeight;
                     }
-                    if (renderMode != "html" && OperatingSystem.IsWindows())
+                    Exception? nativeFailure = null;
+                    bool nativeAttempted = renderMode != "html" && OperatingSystem.IsWindows();
+                    if (nativeAttempted)
                     {
                         try
                         {
@@ -276,11 +278,11 @@ static partial class CommandBuilder
                                 directPng = OfficeCli.Core.PowerPointPngBackend.Render(file.FullName, pStart ?? 1, pEnd ?? pStart ?? 1, exportW, exportH);
                             }
                         }
-                        catch { directPng = null; }
+                        catch (Exception e) { nativeFailure = e; directPng = null; }
                     }
                     if (renderMode == "native" && directPng == null)
-                        throw new OfficeCli.Core.CliException("--render native requires Windows with Microsoft PowerPoint installed.")
-                        { Code = "native_unavailable", Suggestion = "Use --render html or --render auto." };
+                        throw OfficeCli.Core.NativeRenderDiagnostics.Create(
+                            "Microsoft PowerPoint", nativeAttempted, nativeFailure);
 
                     if (directPng == null)
                     {
@@ -352,14 +354,16 @@ static partial class CommandBuilder
                     if (over > 1.0) { vpW /= over; cellW /= over; cellH /= over; vpH /= over; }
 
                     // Native-first: render each real-Word page and tile (Windows + Word).
-                    if (renderMode != "html" && OperatingSystem.IsWindows())
+                    Exception? nativeFailure = null;
+                    bool nativeAttempted = renderMode != "html" && OperatingSystem.IsWindows();
+                    if (nativeAttempted)
                     {
                         try { directPng = OfficeCli.Core.WordPdfBackend.RenderGrid(file.FullName, $"1-{pageCount}", (int)Math.Round(cellW), (int)Math.Round(cellH), docGridCols, gap, pad); }
-                        catch { directPng = null; }
+                        catch (Exception e) { nativeFailure = e; directPng = null; }
                     }
                     if (renderMode == "native" && directPng == null)
-                        throw new OfficeCli.Core.CliException("--render native requires Windows with Microsoft Word installed.")
-                        { Code = "native_unavailable", Suggestion = "Use --render html or --render auto." };
+                        throw OfficeCli.Core.NativeRenderDiagnostics.Create(
+                            "Microsoft Word", nativeAttempted, nativeFailure);
                     if (directPng == null)
                     {
                         // HTML fallback: layoutGrid tiles in-browser; size the viewport
@@ -377,16 +381,18 @@ static partial class CommandBuilder
                     var effectiveFilter = clipArg != null
                         ? pageFilter
                         : (string.IsNullOrEmpty(pageFilter) ? "1" : pageFilter);
-                    if (renderMode != "html" && OperatingSystem.IsWindows())
+                    Exception? nativeFailure = null;
+                    bool nativeAttempted = renderMode != "html" && OperatingSystem.IsWindows();
+                    if (nativeAttempted)
                     {
                         // effectiveFilter is only null under --range, which forces
                         // renderMode=html — this native branch is then unreachable.
                         try { directPng = OfficeCli.Core.WordPdfBackend.Render(file.FullName, effectiveFilter!); }
-                        catch { directPng = null; }
+                        catch (Exception e) { nativeFailure = e; directPng = null; }
                     }
                     if (renderMode == "native" && directPng == null)
-                        throw new OfficeCli.Core.CliException("--render native requires Windows with Microsoft Word installed.")
-                        { Code = "native_unavailable", Suggestion = "Use --render html or --render auto." };
+                        throw OfficeCli.Core.NativeRenderDiagnostics.Create(
+                            "Microsoft Word", nativeAttempted, nativeFailure);
                     if (directPng == null)
                     {
                         html = RenderViaRegistry(wordHandler, "docx",

--- a/src/officecli/Core/NativeRenderDiagnostics.cs
+++ b/src/officecli/Core/NativeRenderDiagnostics.cs
@@ -1,0 +1,71 @@
+// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.InteropServices;
+
+namespace OfficeCli.Core;
+
+/// <summary>
+/// Converts native Office rendering failures into actionable CLI diagnostics.
+/// Auto rendering still falls back silently; this is used only when the caller
+/// explicitly requested the native backend.
+/// </summary>
+internal static class NativeRenderDiagnostics
+{
+    const int ClassNotRegistered = unchecked((int)0x80040154);
+
+    internal static CliException Create(
+        string application,
+        bool attempted,
+        Exception? failure)
+    {
+        if (!attempted)
+        {
+            return new CliException($"--render native requires Windows with {application} installed.")
+            {
+                Code = "native_unavailable",
+                Suggestion = "Use --render html or --render auto."
+            };
+        }
+
+        if (failure == null)
+        {
+            return new CliException($"{application} native render did not produce an image.")
+            {
+                Code = "native_render_failed",
+                Suggestion = "Verify the document and page range, or use --render html or --render auto."
+            };
+        }
+
+        var detail = Describe(failure);
+        if (IsUnavailable(failure))
+        {
+            return new CliException($"{application} is unavailable: {detail}", failure)
+            {
+                Code = "native_unavailable",
+                Suggestion = $"Install or repair {application}, or use --render html or --render auto."
+            };
+        }
+
+        return new CliException($"{application} native render failed: {detail}", failure)
+        {
+            Code = "native_render_failed",
+            Suggestion = "Verify that the document opens in Office, or use --render html or --render auto."
+        };
+    }
+
+    static bool IsUnavailable(Exception failure)
+        => failure is COMException { HResult: ClassNotRegistered }
+           || failure.Message.StartsWith("app_not_authentic:", StringComparison.Ordinal)
+           || failure.Message.StartsWith("word_not_authentic:", StringComparison.Ordinal);
+
+    static string Describe(Exception failure)
+    {
+        var message = string.IsNullOrWhiteSpace(failure.Message)
+            ? failure.GetType().Name
+            : failure.Message.Trim();
+        if (failure is ExternalException && !message.Contains("0x", StringComparison.OrdinalIgnoreCase))
+            message += $" (HRESULT 0x{failure.HResult:X8})";
+        return message;
+    }
+}

--- a/src/officecli/Core/PowerPointPngBackend.cs
+++ b/src/officecli/Core/PowerPointPngBackend.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading;
@@ -14,9 +15,9 @@ namespace OfficeCli.Core;
 /// OS-native PNG rendering for .pptx on Windows: drives the installed
 /// presentation application through its automation interface to export each
 /// requested slide straight to a PNG, then stitches a multi-slide range
-/// vertically. Returns null on any failure so the caller falls back to the
-/// HTML screenshot path. The COM/IDispatch plumbing and the PNG stitch are
-/// shared with <see cref="WordPdfBackend"/>.
+/// vertically. Failures are surfaced to the caller; auto mode catches them and
+/// falls back to the HTML screenshot path. The COM/IDispatch plumbing and the
+/// PNG stitch are shared with <see cref="WordPdfBackend"/>.
 /// </summary>
 [SupportedOSPlatform("windows")]
 internal static class PowerPointPngBackend
@@ -25,8 +26,7 @@ internal static class PowerPointPngBackend
 
     /// Render slides [startSlide..endSlide] (1-based, inclusive) to a single PNG
     /// at width×height pixels. A range is stitched top-to-bottom. Runs on a
-    /// dedicated STA thread; returns null if the app is unavailable or any step
-    /// fails or exceeds the timeout.
+    /// dedicated STA thread and preserves failures from that thread.
     public static byte[]? Render(string pptx, int startSlide, int endSlide, int width, int height, int timeoutMs = 60000)
     {
         // Keep within the multi-image LLM ceiling, same 1920 long-edge cap as the HTML path.
@@ -45,8 +45,9 @@ internal static class PowerPointPngBackend
         th.SetApartmentState(ApartmentState.STA);
         th.IsBackground = true;
         th.Start();
-        if (!th.Join(timeoutMs + 30000)) return null;
-        if (error != null) return null;
+        if (!th.Join(timeoutMs + 30000))
+            throw new TimeoutException("PowerPoint native rendering timed out.");
+        if (error != null) ExceptionDispatchInfo.Capture(error).Throw();
         return result;
     }
 
@@ -54,7 +55,7 @@ internal static class PowerPointPngBackend
     /// last slide") into an N-column thumbnail grid. Each slide is exported at
     /// cellW×cellH and tiled with the given gap/padding (pixels) on a white
     /// background. Cells are scaled down if the composed image would exceed the
-    /// 1920 long-edge ceiling. Returns null on failure.
+    /// 1920 long-edge ceiling. Failures are surfaced to the caller.
     public static byte[]? RenderGrid(string pptx, int startSlide, int endSlide, int cellW, int cellH, int cols, int gap, int pad, int timeoutMs = 120000)
     {
         byte[]? result = null;
@@ -69,8 +70,9 @@ internal static class PowerPointPngBackend
         th.SetApartmentState(ApartmentState.STA);
         th.IsBackground = true;
         th.Start();
-        if (!th.Join(timeoutMs + 30000)) return null;
-        if (error != null) return null;
+        if (!th.Join(timeoutMs + 30000))
+            throw new TimeoutException("PowerPoint native grid rendering timed out.");
+        if (error != null) ExceptionDispatchInfo.Capture(error).Throw();
         return result;
     }
 

--- a/src/officecli/Core/WordPdfBackend.cs
+++ b/src/officecli/Core/WordPdfBackend.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading;
@@ -660,8 +661,9 @@ internal static class WordPdfBackend
         th.SetApartmentState(ApartmentState.STA);
         th.IsBackground = true;
         th.Start();
-        if (!th.Join(timeoutMs + 30000)) return null;
-        if (error != null) return null;
+        if (!th.Join(timeoutMs + 30000))
+            throw new TimeoutException("Word native rendering timed out.");
+        if (error != null) ExceptionDispatchInfo.Capture(error).Throw();
         return result;
     }
 
@@ -670,13 +672,14 @@ internal static class WordPdfBackend
     /// each to <paramref name="cellW"/>×<paramref name="cellH"/>, and tile them
     /// into a <paramref name="cols"/>-column contact sheet. The docx analogue of
     /// PowerPointPngBackend.RenderGrid (which exports each slide at cell size via
-    /// PowerPoint). Returns null on non-Windows, missing/inauthentic Word, or any
-    /// failure — caller falls back to the HTML grid. cellW/cellH are the FINAL
-    /// (already 1920-capped) cell size, so the stitched image needs no further cap.
+    /// PowerPoint). Failures are surfaced to the caller; auto mode catches them
+    /// and falls back to the HTML grid. cellW/cellH are the FINAL (already
+    /// 1920-capped) cell size, so the stitched image needs no further cap.
     /// </summary>
     public static byte[]? RenderGrid(string docx, string pageFilter, int cellW, int cellH, int cols, int gap, int pad, int timeoutMs = 60000)
     {
         byte[]? result = null;
+        Exception? error = null;
         var th = new Thread(() =>
         {
             string? pdf = null;
@@ -701,13 +704,15 @@ internal static class WordPdfBackend
                 }
                 finally { Marshal.Release(factory); }
             }
-            catch { result = null; }
+            catch (Exception e) { error = e; }
             finally { if (pdf != null) try { File.Delete(pdf); } catch { } }
         });
         th.SetApartmentState(ApartmentState.STA);
         th.IsBackground = true;
         th.Start();
-        if (!th.Join(timeoutMs + 30000)) return null;
+        if (!th.Join(timeoutMs + 30000))
+            throw new TimeoutException("Word native grid rendering timed out.");
+        if (error != null) ExceptionDispatchInfo.Capture(error).Throw();
         return result;
     }
 }

--- a/src/officecli/ResidentServer.cs
+++ b/src/officecli/ResidentServer.cs
@@ -1597,7 +1597,9 @@ public class ResidentServer : IDisposable
                 int pptGridCols = gridCols < 0
                     ? OfficeCli.Core.HtmlScreenshot.AutoGridColumns((pEnd ?? pptShotHandler.GetSlideCount()) - (pStart ?? 1) + 1, nativeW, nativeH)
                     : gridCols;
-                if (renderMode != "html" && OperatingSystem.IsWindows())
+                Exception? nativeFailure = null;
+                bool nativeAttempted = renderMode != "html" && OperatingSystem.IsWindows();
+                if (nativeAttempted)
                 {
                     // A read-only handler holds only read access with FileShare.ReadWrite,
                     // so the app can open the file for read concurrently — no dispose
@@ -1620,7 +1622,7 @@ public class ResidentServer : IDisposable
                             ? OfficeCli.Core.PowerPointPngBackend.RenderGrid(_filePath, ps, gEnd, gCellW, gCellH, pptGridCols, gGap, gPad)
                             : OfficeCli.Core.PowerPointPngBackend.Render(_filePath, ps, pEnd ?? ps, exportW, exportH);
                     }
-                    catch { directPng = null; }
+                    catch (Exception e) { nativeFailure = e; directPng = null; }
                     if (_editable)
                     {
                         _handler = OfficeCli.Handlers.DocumentHandlerFactory.Open(_filePath, _editable);
@@ -1629,7 +1631,8 @@ public class ResidentServer : IDisposable
                 }
                 if (renderMode == "native" && directPng == null)
                 {
-                    Console.Error.WriteLine("--render native requires Windows with Microsoft PowerPoint installed.");
+                    Console.Error.WriteLine(OfficeCli.Core.NativeRenderDiagnostics.Create(
+                        "Microsoft PowerPoint", nativeAttempted, nativeFailure).Message);
                     return;
                 }
                 if (directPng == null)
@@ -1675,11 +1678,13 @@ public class ResidentServer : IDisposable
                 // Native-first on Windows: release an editable write lock (blocks
                 // Word) before rendering, then reopen — same dance as the single-page
                 // branch below.
-                if (renderMode != "html" && OperatingSystem.IsWindows())
+                Exception? nativeFailure = null;
+                bool nativeAttempted = renderMode != "html" && OperatingSystem.IsWindows();
+                if (nativeAttempted)
                 {
                     if (_editable) _handler.Dispose();
                     try { directPng = OfficeCli.Core.WordPdfBackend.RenderGrid(_filePath, $"1-{gPageCount}", (int)Math.Round(gCellW), (int)Math.Round(gCellH), gCols, gGap, gPad); }
-                    catch { directPng = null; }
+                    catch (Exception e) { nativeFailure = e; directPng = null; }
                     if (_editable)
                     {
                         _handler = OfficeCli.Handlers.DocumentHandlerFactory.Open(_filePath, _editable);
@@ -1688,7 +1693,8 @@ public class ResidentServer : IDisposable
                 }
                 if (renderMode == "native" && directPng == null)
                 {
-                    Console.Error.WriteLine("--render native requires Windows with Microsoft Word installed.");
+                    Console.Error.WriteLine(OfficeCli.Core.NativeRenderDiagnostics.Create(
+                        "Microsoft Word", nativeAttempted, nativeFailure).Message);
                     return;
                 }
                 if (directPng == null)
@@ -1704,14 +1710,17 @@ public class ResidentServer : IDisposable
                 var effectiveFilter = rangeArg != null
                     ? pageFilter
                     : (string.IsNullOrEmpty(pageFilter) ? "1" : pageFilter);
-                if (renderMode != "html" && OperatingSystem.IsWindows())
+                Exception? nativeFailure = null;
+                bool nativeAttempted = renderMode != "html" && OperatingSystem.IsWindows();
+                if (nativeAttempted)
                 {
                     // See the pptx branch: only an editable handler must be released
                     // (its write handle blocks Word); a read-only handler coexists.
                     if (_editable) _handler.Dispose();
                     // effectiveFilter is only null under --range, which forces
                     // renderMode=html — this native branch is then unreachable.
-                    try { directPng = OfficeCli.Core.WordPdfBackend.Render(_filePath, effectiveFilter!); } catch { directPng = null; }
+                    try { directPng = OfficeCli.Core.WordPdfBackend.Render(_filePath, effectiveFilter!); }
+                    catch (Exception e) { nativeFailure = e; directPng = null; }
                     if (_editable)
                     {
                         _handler = OfficeCli.Handlers.DocumentHandlerFactory.Open(_filePath, _editable);
@@ -1720,7 +1729,8 @@ public class ResidentServer : IDisposable
                 }
                 if (renderMode == "native" && directPng == null)
                 {
-                    Console.Error.WriteLine("--render native requires Windows with Microsoft Word installed.");
+                    Console.Error.WriteLine(OfficeCli.Core.NativeRenderDiagnostics.Create(
+                        "Microsoft Word", nativeAttempted, nativeFailure).Message);
                     return;
                 }
                 if (directPng == null) html = CommandBuilder.RenderViaRegistry(wordShotHandler, "docx",


### PR DESCRIPTION
## Summary

- preserve native PowerPoint and Word rendering exceptions instead of replacing every failure with an “Office is not installed” message
- distinguish COM class-registration/application availability failures from document-open or rendering failures
- retain the original failure stage and HRESULT in explicit `--render native` diagnostics
- keep `--render auto` behavior unchanged: native failures still fall back silently to HTML

## Why

When Office is installed and COM activation succeeds, a document-specific open failure such as `Invoke(Open) hr=0x80070570` was swallowed by the native backend. The caller then reported that PowerPoint or Word was not installed, which sent users toward the wrong fix and hid the useful HRESULT.

The native backends now surface worker-thread failures while preserving their original stack. Explicit native mode maps those failures to either `native_unavailable` or `native_render_failed`; auto mode continues to catch them and use the existing HTML fallback.

## Validation

- `dotnet build src/officecli/officecli.csproj -c Release` — succeeded with 0 errors
- targeted diagnostic harness covered:
  - non-Windows native request → `native_unavailable`
  - COM class-not-registered → `native_unavailable` with HRESULT
  - `Invoke(Open) hr=0x80070570` → `native_render_failed` with the original stage and HRESULT
  - native backend returning no image → `native_render_failed`
- verified that every production caller catches the surfaced backend exception, so `--render auto` retains its fallback behavior

Closes #326