### PR TITLE
fix(pptx): speaker notes scale to match slides

### DIFF
--- a/src/officecli/Resources/preview.js
+++ b/src/officecli/Resources/preview.js
@@ -24,6 +24,7 @@
         // and multi-slide views only ever shrink to fit.
         const fill = headless && slides.length === 1;
         slides.forEach(slide => {
+            const notes = slide.closest('.slide-container')?.querySelector('.slide-notes');
             const designW = slide.offsetWidth;
             if (availW > 0 && (fill || designW > availW)) {
                 const s = availW / designW;
@@ -32,10 +33,12 @@
                 const designH = slide.offsetHeight;
                 slide.parentElement.style.height = (designH * s) + 'px';
                 slide.parentElement.style.width = (designW * s) + 'px';
+                if (notes) notes.style.width = (designW * s) + 'px';
             } else {
                 slide.style.transform = '';
                 slide.parentElement.style.height = '';
                 slide.parentElement.style.width = '';
+                if (notes) notes.style.width = '';
             }
         });
     }


### PR DESCRIPTION
## Problem

In the interactive HTML preview, `.slide-notes` is sized `width: var(--slide-design-w)` — the slide's *design* width. When the viewport is narrower than the slide, `scaleSlides()` scales `.slide` down by `s` and resizes `.slide-wrapper` to `designW * s`, but the notes box keeps its full design width.

The notes panel therefore renders far wider than the slide above it, and its text is clipped at the viewport edge with no way to scroll to the cut-off portion.

Issue: https://github.com/iOfficeAI/OfficeCLI/issues/396

**Before**
<img width="821" height="607" alt="Screenshot 2026-08-20 at 11 27 11 PM" src="https://github.com/user-attachments/assets/ede3b4e4-9fda-45a7-b31e-1ca4f725eaf3" />

## Fix

Apply the same scale factor to the notes box width, in both the scaled and the reset branch of `scaleSlides()`.

## How to verify

```bash
officecli create notes.pptx
officecli add notes.pptx / --type slide
officecli add notes.pptx "/slide[1]" --type shape \
  --prop text="Quarterly Review" --prop x=4cm --prop y=6cm \
  --prop width=18cm --prop height=3cm
officecli add notes.pptx "/slide[1]" --type notes \
  --prop text="A long speaker note that runs past the right edge of the slide when the notes box is not scaled with it."
officecli watch notes.pptx
```

Narrow the browser window until the slide visibly shrinks to fit.

- **Before:** the Notes block extends well past the right edge of the slide and its text is clipped at the viewport boundary — unreachable by scrolling.
- **After:** the Notes block tracks the slide's scaled width and the text wraps inside it.

`officecli view notes.pptx html -o preview.html` and opening that file works equally well for checking this.

Note that this is only reproducible in the **interactive** preview: headless/screenshot mode sets `.slide-notes { display: none }` (`PowerPointHandler.HtmlPreview.cs:140`), so `view screenshot` shows no notes either way.

**After**
<img width="784" height="630" alt="Screenshot 2026-08-20 at 11 26 17 PM" src="https://github.com/user-attachments/assets/8afe299f-4171-48a8-931e-1f11e35f9788" />
