### PR TITLE
fix: make Windows PPT HTML screenshots use exact viewport

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   build:
     strategy:
+      # Keep platform builds independent: missing macOS signing secrets must
+      # not cancel Windows/Linux artifacts needed for validation.
+      fail-fast: false
       matrix:
         include:
           - rid: osx-arm64

--- a/src/officecli/Core/HtmlScreenshot.cs
+++ b/src/officecli/Core/HtmlScreenshot.cs
@@ -395,7 +395,7 @@ internal static class HtmlScreenshot
         // which can crop/letterbox callers that deliberately sized the viewport
         // to a page or slide.
         var args = new[] { "screenshot", $"--viewport-size={w},{h}", url, outPath };
-        return RunBinary(pw, args);
+        return RunBinary(pw, args, timeoutMs: 30_000);
     }
 
     // ----- Chromium family ---------------------------------------------------------------
@@ -437,7 +437,7 @@ internal static class HtmlScreenshot
             $"--screenshot={outPath}",
             url,
         };
-        return RunBinary(bin, args);
+        return RunBinary(bin, args, timeoutMs: 30_000);
     }
 
     /// <summary>
@@ -765,7 +765,7 @@ internal static class HtmlScreenshot
         catch { return (false, null); }
     }
 
-    private static (bool, string?) RunBinary(string bin, string[] args)
+    private static (bool, string?) RunBinary(string bin, string[] args, int timeoutMs = 120_000)
     {
         try
         {
@@ -783,14 +783,24 @@ internal static class HtmlScreenshot
             foreach (var a in args) psi.ArgumentList.Add(a);
             using var p = Process.Start(psi);
             if (p == null) return (false, "process did not start");
-            if (!p.WaitForExit(120_000))
+            // Drain both redirected pipes while the child runs. Waiting first
+            // can deadlock a verbose browser once stderr/stdout fills its pipe.
+            var stdoutTask = p.StandardOutput.ReadToEndAsync();
+            var stderrTask = p.StandardError.ReadToEndAsync();
+            if (!p.WaitForExit(timeoutMs))
             {
                 try { p.Kill(true); } catch { /* ignore */ }
-                return (false, "timeout after 120s");
+                try
+                {
+                    Task.WhenAll(stdoutTask, stderrTask).Wait(TimeSpan.FromSeconds(2));
+                }
+                catch { /* ignore */ }
+                return (false, $"timeout after {timeoutMs}ms");
             }
+            stdoutTask.GetAwaiter().GetResult();
+            var stderr = stderrTask.GetAwaiter().GetResult();
             if (p.ExitCode != 0)
             {
-                var stderr = p.StandardError.ReadToEnd();
                 var lastLine = stderr.Trim().Split('\n').LastOrDefault() ?? $"exit {p.ExitCode}";
                 return (false, lastLine);
             }

--- a/src/officecli/Core/HtmlScreenshot.cs
+++ b/src/officecli/Core/HtmlScreenshot.cs
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
 
 namespace OfficeCli.Core;
 
@@ -84,6 +90,15 @@ internal static class HtmlScreenshot
         var outDir = Path.GetDirectoryName(outPath);
         if (!string.IsNullOrEmpty(outDir)) Directory.CreateDirectory(outDir);
         var url = new Uri(Path.GetFullPath(htmlPath)).AbsoluteUri + "#screenshot";
+
+        // Use the same exact-layout path as the standard screenshot capture.
+        // Keep the CSS viewport at w×h and let the device scale factor control
+        // raster density, so callers such as clipped capture retain their
+        // requested HiDPI output without reintroducing window-chrome offsets.
+        var cdp = TryChromeCdp(bin, url, outPath, w, h, scale);
+        if (cdp.Ok)
+            return true;
+
         var args = new[]
         {
             "--headless=new",
@@ -375,7 +390,11 @@ internal static class HtmlScreenshot
     {
         var pw = WhichFirst("playwright");
         if (pw == null) return (false, null);
-        var args = new[] { "screenshot", $"--viewport-size={w},{h}", "--full-page", url, outPath };
+        // A screenshot request is an exact viewport capture.  `--full-page`
+        // changes that contract by growing the image to the document height,
+        // which can crop/letterbox callers that deliberately sized the viewport
+        // to a page or slide.
+        var args = new[] { "screenshot", $"--viewport-size={w},{h}", url, outPath };
         return RunBinary(pw, args);
     }
 
@@ -385,6 +404,18 @@ internal static class HtmlScreenshot
     {
         var bin = FindChrome();
         if (bin == null) return (false, null);
+
+        // `--window-size` is an outer-window size on some Chromium builds
+        // (notably Windows new-headless), whereas --screenshot paints a bitmap
+        // at that outer size.  The resulting layout viewport is shorter and a
+        // 16:9 slide loses its footer.  CDP device metrics specify the *layout*
+        // viewport, so use them for the normal capture path.  Keep the command
+        // line fallback for locked-down Chrome builds where remote debugging is
+        // disabled.
+        var cdp = TryChromeCdp(bin, url, outPath, w, h, scale: 1);
+        if (cdp.Ok)
+            return cdp;
+
         var args = new[]
         {
             "--headless=new",
@@ -407,6 +438,163 @@ internal static class HtmlScreenshot
             url,
         };
         return RunBinary(bin, args);
+    }
+
+    /// <summary>
+    /// Capture through Chrome DevTools Protocol with an explicit layout viewport.
+    /// Unlike <c>--window-size</c>, <c>Emulation.setDeviceMetricsOverride</c>
+    /// has no title-bar/toolbar ambiguity, so the DOM viewport and PNG bounds are
+    /// exactly <paramref name="w"/>×<paramref name="h"/> on every platform.
+    /// </summary>
+    private static (bool Ok, string? Error) TryChromeCdp(string bin, string url, string outPath, int w, int h, int scale)
+    {
+        string profile = Path.Combine(Path.GetTempPath(), "officecli_chrome_" + Guid.NewGuid().ToString("N"));
+        Process? browser = null;
+        try
+        {
+            int port = GetFreeLoopbackPort();
+            Directory.CreateDirectory(profile);
+            var psi = new ProcessStartInfo
+            {
+                FileName = bin,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            foreach (var arg in new[]
+            {
+                "--headless=new", "--disable-gpu", "--no-sandbox", "--hide-scrollbars",
+                "--allow-file-access-from-files", "--disable-background-networking",
+                $"--remote-debugging-address=127.0.0.1", $"--remote-debugging-port={port}",
+                $"--user-data-dir={profile}", "about:blank",
+            }) psi.ArgumentList.Add(arg);
+            browser = Process.Start(psi);
+            if (browser == null) return (false, "Chrome did not start");
+
+            var versionUrl = $"http://127.0.0.1:{port}/json/version";
+            string? browserWs = null;
+            using var http = new HttpClient { Timeout = TimeSpan.FromMilliseconds(750) };
+            var deadline = DateTime.UtcNow.AddSeconds(12);
+            while (DateTime.UtcNow < deadline)
+            {
+                try
+                {
+                    var version = http.GetStringAsync(versionUrl).GetAwaiter().GetResult();
+                    using var versionJson = JsonDocument.Parse(version);
+                    if (versionJson.RootElement.TryGetProperty("webSocketDebuggerUrl", out var ws))
+                    {
+                        browserWs = ws.GetString();
+                        if (!string.IsNullOrEmpty(browserWs)) break;
+                    }
+                }
+                catch { Thread.Sleep(50); }
+            }
+            if (string.IsNullOrEmpty(browserWs)) return (false, "Chrome DevTools endpoint was not available");
+
+            using var browserSocket = new ClientWebSocket();
+            browserSocket.ConnectAsync(new Uri(browserWs), CancellationToken.None).GetAwaiter().GetResult();
+            using var created = CdpCommand(browserSocket, 1, "Target.createTarget", new { url = "about:blank" });
+            var targetId = created.RootElement.GetProperty("result").GetProperty("targetId").GetString();
+            if (string.IsNullOrEmpty(targetId)) return (false, "Chrome did not create a screenshot target");
+
+            string? pageWs = null;
+            var targets = http.GetStringAsync($"http://127.0.0.1:{port}/json/list").GetAwaiter().GetResult();
+            using (var targetJson = JsonDocument.Parse(targets))
+            {
+                foreach (var target in targetJson.RootElement.EnumerateArray())
+                {
+                    if (target.GetProperty("id").GetString() == targetId
+                        && target.TryGetProperty("webSocketDebuggerUrl", out var ws))
+                    {
+                        pageWs = ws.GetString();
+                        break;
+                    }
+                }
+            }
+            if (string.IsNullOrEmpty(pageWs)) return (false, "Chrome screenshot target was not discoverable");
+
+            using var pageSocket = new ClientWebSocket();
+            pageSocket.ConnectAsync(new Uri(pageWs), CancellationToken.None).GetAwaiter().GetResult();
+            using var enabled = CdpCommand(pageSocket, 1, "Page.enable", new { });
+            using var metrics = CdpCommand(pageSocket, 2, "Emulation.setDeviceMetricsOverride",
+                new { width = w, height = h, deviceScaleFactor = scale, mobile = false, screenWidth = w, screenHeight = h });
+            using var navigate = CdpCommand(pageSocket, 3, "Page.navigate", new { url });
+
+            // Wait for synchronous preview JS and local assets.  The normal HTML
+            // previews are local; this is deliberately bounded rather than using
+            // a browser-chrome offset or a full-page heuristic.
+            var readyDeadline = DateTime.UtcNow.AddSeconds(15);
+            while (DateTime.UtcNow < readyDeadline)
+            {
+                using var state = CdpCommand(pageSocket, 4, "Runtime.evaluate",
+                    new { expression = "document.readyState", returnByValue = true });
+                if (state.RootElement.GetProperty("result").GetProperty("result")
+                    .GetProperty("value").GetString() == "complete") break;
+                Thread.Sleep(50);
+            }
+            using var scaled = CdpCommand(pageSocket, 5, "Runtime.evaluate",
+                new { expression = "window.scaleSlides && window.scaleSlides()", awaitPromise = true, returnByValue = true });
+            Thread.Sleep(100);
+            using var screenshot = CdpCommand(pageSocket, 6, "Page.captureScreenshot",
+                new { format = "png", captureBeyondViewport = false,
+                      clip = new { x = 0, y = 0, width = w, height = h, scale = 1 } });
+            var base64 = screenshot.RootElement.GetProperty("result").GetProperty("data").GetString();
+            if (string.IsNullOrEmpty(base64)) return (false, "Chrome returned an empty screenshot");
+            File.WriteAllBytes(outPath, Convert.FromBase64String(base64));
+            return File.Exists(outPath) && new FileInfo(outPath).Length > 0
+                ? (true, null)
+                : (false, "Chrome did not write the screenshot");
+        }
+        catch (Exception e)
+        {
+            return (false, e.Message);
+        }
+        finally
+        {
+            if (browser != null)
+            {
+                try { if (!browser.HasExited) browser.Kill(true); } catch { /* ignore */ }
+                browser.Dispose();
+            }
+            try { if (Directory.Exists(profile)) Directory.Delete(profile, recursive: true); } catch { /* ignore */ }
+        }
+    }
+
+    private static int GetFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+
+    private static JsonDocument CdpCommand(ClientWebSocket socket, int id, string method, object parameters)
+    {
+        var payload = JsonSerializer.Serialize(new { id, method, @params = parameters });
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        socket.SendAsync(bytes, WebSocketMessageType.Text, true, CancellationToken.None).GetAwaiter().GetResult();
+        while (true)
+        {
+            var text = ReceiveCdpMessage(socket);
+            var json = JsonDocument.Parse(text);
+            if (json.RootElement.TryGetProperty("id", out var responseId) && responseId.GetInt32() == id)
+                return json;
+            json.Dispose(); // asynchronous protocol event for another command
+        }
+    }
+
+    private static string ReceiveCdpMessage(ClientWebSocket socket)
+    {
+        var buffer = new byte[16 * 1024];
+        using var stream = new MemoryStream();
+        WebSocketReceiveResult result;
+        do
+        {
+            result = socket.ReceiveAsync(buffer, CancellationToken.None).GetAwaiter().GetResult();
+            if (result.MessageType == WebSocketMessageType.Close)
+                throw new InvalidOperationException("Chrome DevTools connection closed");
+            stream.Write(buffer, 0, result.Count);
+        } while (!result.EndOfMessage);
+        return Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
     }
 
     private static string? FindChrome()

--- a/src/officecli/Core/HtmlScreenshot.cs
+++ b/src/officecli/Core/HtmlScreenshot.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace OfficeCli.Core;
 
@@ -532,10 +533,15 @@ internal static class HtmlScreenshot
 
             using var pageSocket = new ClientWebSocket();
             pageSocket.ConnectAsync(new Uri(pageWs), cdpToken).GetAwaiter().GetResult();
-            using var enabled = CdpCommand(pageSocket, 1, "Page.enable", new { }, cdpToken);
+            using var enabled = CdpCommand(pageSocket, 1, "Page.enable", new JsonObject(), cdpToken);
             using var metrics = CdpCommand(pageSocket, 2, "Emulation.setDeviceMetricsOverride",
-                new { width = w, height = h, deviceScaleFactor = scale, mobile = false, screenWidth = w, screenHeight = h }, cdpToken);
-            using var navigate = CdpCommand(pageSocket, 3, "Page.navigate", new { url }, cdpToken);
+                new JsonObject
+                {
+                    ["width"] = w, ["height"] = h, ["deviceScaleFactor"] = scale,
+                    ["mobile"] = false, ["screenWidth"] = w, ["screenHeight"] = h,
+                }, cdpToken);
+            using var navigate = CdpCommand(pageSocket, 3, "Page.navigate",
+                new JsonObject { ["url"] = url }, cdpToken);
 
             // Wait for synchronous preview JS and local assets.  The normal HTML
             // previews are local; this is deliberately bounded rather than using
@@ -544,7 +550,7 @@ internal static class HtmlScreenshot
             while (DateTime.UtcNow < readyDeadline)
             {
                 using var state = CdpCommand(pageSocket, 4, "Runtime.evaluate",
-                    new { expression = "document.readyState", returnByValue = true }, cdpToken);
+                    new JsonObject { ["expression"] = "document.readyState", ["returnByValue"] = true }, cdpToken);
                 if (state.RootElement.GetProperty("result").GetProperty("result")
                     .GetProperty("value").GetString() == "complete") break;
                 Thread.Sleep(50);
@@ -561,11 +567,17 @@ internal static class HtmlScreenshot
                 "if(s.length===1){const e=s[0],sw=e.offsetWidth,sh=e.offsetHeight,k=Math.min(innerWidth/sw,innerHeight/sh);e.style.transform='scale('+k+')';e.style.transformOrigin='center top';const p=e.parentElement;p.style.width=(sw*k)+'px';p.style.height=(sh*k)+'px';}" +
                 "return JSON.stringify({className:document.documentElement.className,innerWidth:innerWidth,innerHeight:innerHeight,mainWidth:m&&m.clientWidth,mainHeight:m&&m.clientHeight,slideWidth:s.length?s[0].offsetWidth:0,slideHeight:s.length?s[0].offsetHeight:0});})()";
             using var scaled = CdpCommand(pageSocket, 5, "Runtime.evaluate",
-                new { expression = normalize, awaitPromise = true, returnByValue = true }, cdpToken);
+                new JsonObject { ["expression"] = normalize, ["awaitPromise"] = true, ["returnByValue"] = true }, cdpToken);
             Thread.Sleep(100);
             using var screenshot = CdpCommand(pageSocket, 6, "Page.captureScreenshot",
-                new { format = "png", captureBeyondViewport = false,
-                      clip = new { x = 0, y = 0, width = w, height = h, scale = 1 } }, cdpToken);
+                new JsonObject
+                {
+                    ["format"] = "png", ["captureBeyondViewport"] = false,
+                    ["clip"] = new JsonObject
+                    {
+                        ["x"] = 0, ["y"] = 0, ["width"] = w, ["height"] = h, ["scale"] = 1,
+                    },
+                }, cdpToken);
             var base64 = screenshot.RootElement.GetProperty("result").GetProperty("data").GetString();
             if (string.IsNullOrEmpty(base64)) return (false, "Chrome returned an empty screenshot");
             File.WriteAllBytes(outPath, Convert.FromBase64String(base64));
@@ -602,10 +614,15 @@ internal static class HtmlScreenshot
             Console.Error.WriteLine($"[officecli-screenshot] {message}");
     }
 
-    private static JsonDocument CdpCommand(ClientWebSocket socket, int id, string method, object parameters,
+    private static JsonDocument CdpCommand(ClientWebSocket socket, int id, string method, JsonObject parameters,
                                            CancellationToken cancellationToken)
     {
-        var payload = JsonSerializer.Serialize(new { id, method, @params = parameters });
+        var payload = new JsonObject
+        {
+            ["id"] = id,
+            ["method"] = method,
+            ["params"] = parameters,
+        }.ToJsonString();
         var bytes = Encoding.UTF8.GetBytes(payload);
         socket.SendAsync(bytes, WebSocketMessageType.Text, true, cancellationToken).GetAwaiter().GetResult();
         while (true)

--- a/src/officecli/Core/HtmlScreenshot.cs
+++ b/src/officecli/Core/HtmlScreenshot.cs
@@ -464,51 +464,41 @@ internal static class HtmlScreenshot
             {
                 "--headless=new", "--disable-gpu", "--no-sandbox", "--hide-scrollbars",
                 "--allow-file-access-from-files", "--disable-background-networking",
+                "--remote-allow-origins=*",
                 $"--remote-debugging-address=127.0.0.1", $"--remote-debugging-port={port}",
                 $"--user-data-dir={profile}", "about:blank",
             }) psi.ArgumentList.Add(arg);
             browser = Process.Start(psi);
             if (browser == null) return (false, "Chrome did not start");
 
-            var versionUrl = $"http://127.0.0.1:{port}/json/version";
-            string? browserWs = null;
             using var http = new HttpClient { Timeout = TimeSpan.FromMilliseconds(750) };
             var deadline = DateTime.UtcNow.AddSeconds(12);
-            while (DateTime.UtcNow < deadline)
+            string? pageWs = null;
+            // Reuse the initial about:blank page instead of creating a target
+            // through the browser websocket.  On Windows Edge/Chrome the
+            // browser-level Target.createTarget response may arrive before the
+            // page websocket is published in /json/list, causing a false
+            // fallback to the buggy --window-size path.  Poll the list until a
+            // page target is fully discoverable.
+            while (DateTime.UtcNow < deadline && string.IsNullOrEmpty(pageWs))
             {
                 try
                 {
-                    var version = http.GetStringAsync(versionUrl).GetAwaiter().GetResult();
-                    using var versionJson = JsonDocument.Parse(version);
-                    if (versionJson.RootElement.TryGetProperty("webSocketDebuggerUrl", out var ws))
+                    var targets = http.GetStringAsync($"http://127.0.0.1:{port}/json/list").GetAwaiter().GetResult();
+                    using var targetJson = JsonDocument.Parse(targets);
+                    foreach (var target in targetJson.RootElement.EnumerateArray())
                     {
-                        browserWs = ws.GetString();
-                        if (!string.IsNullOrEmpty(browserWs)) break;
+                        if (target.TryGetProperty("type", out var type)
+                            && type.GetString() == "page"
+                            && target.TryGetProperty("webSocketDebuggerUrl", out var ws))
+                        {
+                            pageWs = ws.GetString();
+                            if (!string.IsNullOrEmpty(pageWs)) break;
+                        }
                     }
                 }
-                catch { Thread.Sleep(50); }
-            }
-            if (string.IsNullOrEmpty(browserWs)) return (false, "Chrome DevTools endpoint was not available");
-
-            using var browserSocket = new ClientWebSocket();
-            browserSocket.ConnectAsync(new Uri(browserWs), CancellationToken.None).GetAwaiter().GetResult();
-            using var created = CdpCommand(browserSocket, 1, "Target.createTarget", new { url = "about:blank" });
-            var targetId = created.RootElement.GetProperty("result").GetProperty("targetId").GetString();
-            if (string.IsNullOrEmpty(targetId)) return (false, "Chrome did not create a screenshot target");
-
-            string? pageWs = null;
-            var targets = http.GetStringAsync($"http://127.0.0.1:{port}/json/list").GetAwaiter().GetResult();
-            using (var targetJson = JsonDocument.Parse(targets))
-            {
-                foreach (var target in targetJson.RootElement.EnumerateArray())
-                {
-                    if (target.GetProperty("id").GetString() == targetId
-                        && target.TryGetProperty("webSocketDebuggerUrl", out var ws))
-                    {
-                        pageWs = ws.GetString();
-                        break;
-                    }
-                }
+                catch { /* browser endpoint may still be starting */ }
+                if (string.IsNullOrEmpty(pageWs)) Thread.Sleep(50);
             }
             if (string.IsNullOrEmpty(pageWs)) return (false, "Chrome screenshot target was not discoverable");
 

--- a/src/officecli/Core/HtmlScreenshot.cs
+++ b/src/officecli/Core/HtmlScreenshot.cs
@@ -523,8 +523,19 @@ internal static class HtmlScreenshot
                     .GetProperty("value").GetString() == "complete") break;
                 Thread.Sleep(50);
             }
+            // Force the screenshot marker even when a caller supplies a custom
+            // HTML path without the hash-based bootstrap script. Then rescale
+            // from the actual emulated viewport and normalize the single-slide
+            // canvas inline; this also makes the CDP path self-diagnosing rather
+            // than silently relying on a stale flex layout.
+            const string normalize = "(()=>{document.documentElement.classList.add('headless');" +
+                "document.body.classList.remove('fullscreen');" +
+                "const m=document.querySelector('.main');if(m){m.style.width=innerWidth+'px';m.style.height=innerHeight+'px';m.style.minWidth=innerWidth+'px';m.style.minHeight=innerHeight+'px';m.style.padding='0';m.style.gap='0';m.style.flex='none';}" +
+                "const s=document.querySelectorAll('.main > .slide-container .slide');" +
+                "if(s.length===1){const e=s[0],sw=e.offsetWidth,sh=e.offsetHeight,k=Math.min(innerWidth/sw,innerHeight/sh);e.style.transform='scale('+k+')';e.style.transformOrigin='center top';const p=e.parentElement;p.style.width=(sw*k)+'px';p.style.height=(sh*k)+'px';}" +
+                "return JSON.stringify({className:document.documentElement.className,innerWidth:innerWidth,innerHeight:innerHeight,mainWidth:m&&m.clientWidth,mainHeight:m&&m.clientHeight,slideWidth:s.length?s[0].offsetWidth:0,slideHeight:s.length?s[0].offsetHeight:0});})()";
             using var scaled = CdpCommand(pageSocket, 5, "Runtime.evaluate",
-                new { expression = "window.scaleSlides && window.scaleSlides()", awaitPromise = true, returnByValue = true }, cdpToken);
+                new { expression = normalize, awaitPromise = true, returnByValue = true }, cdpToken);
             Thread.Sleep(100);
             using var screenshot = CdpCommand(pageSocket, 6, "Page.captureScreenshot",
                 new { format = "png", captureBeyondViewport = false,

--- a/src/officecli/Core/HtmlScreenshot.cs
+++ b/src/officecli/Core/HtmlScreenshot.cs
@@ -480,17 +480,39 @@ internal static class HtmlScreenshot
             using var http = new HttpClient { Timeout = TimeSpan.FromMilliseconds(750) };
             var deadline = DateTime.UtcNow.AddSeconds(12);
             string? pageWs = null;
-            // Reuse the initial about:blank page instead of creating a target
-            // through the browser websocket.  On Windows Edge/Chrome the
-            // browser-level Target.createTarget response may arrive before the
-            // page websocket is published in /json/list, causing a false
-            // fallback to the buggy --window-size path.  Poll the list until a
-            // page target is fully discoverable.
+            var endpoint = $"http://127.0.0.1:{port}";
+            // Ask the DevTools HTTP endpoint to create the target and return its
+            // websocket directly. This is deterministic on Windows Edge/Chrome
+            // and avoids the short race where /json/list briefly contains no
+            // websocket URL after a target is created.
+            var createDeadline = DateTime.UtcNow.AddSeconds(3);
+            while (DateTime.UtcNow < createDeadline && string.IsNullOrEmpty(pageWs))
+            {
+                try
+                {
+                    using var create = new HttpRequestMessage(HttpMethod.Put,
+                        $"{endpoint}/json/new?{Uri.EscapeDataString(url)}");
+                    using var response = http.SendAsync(create, cdpToken).GetAwaiter().GetResult();
+                    if (response.IsSuccessStatusCode)
+                    {
+                        var created = response.Content.ReadAsStringAsync(cdpToken).GetAwaiter().GetResult();
+                        using var createdJson = JsonDocument.Parse(created);
+                        if (createdJson.RootElement.TryGetProperty("webSocketDebuggerUrl", out var ws))
+                            pageWs = ws.GetString();
+                    }
+                }
+                catch { /* endpoint may still be starting or unsupported */ }
+                if (string.IsNullOrEmpty(pageWs)) Thread.Sleep(50);
+                else break;
+            }
+            // Fallback for browsers that do not implement PUT /json/new:
+            // poll until a page target is fully discoverable.
+            deadline = DateTime.UtcNow.AddSeconds(12);
             while (DateTime.UtcNow < deadline && string.IsNullOrEmpty(pageWs))
             {
                 try
                 {
-                    var targets = http.GetStringAsync($"http://127.0.0.1:{port}/json/list").GetAwaiter().GetResult();
+                    var targets = http.GetStringAsync($"{endpoint}/json/list", cdpToken).GetAwaiter().GetResult();
                     using var targetJson = JsonDocument.Parse(targets);
                     foreach (var target in targetJson.RootElement.EnumerateArray())
                     {

--- a/src/officecli/Core/HtmlScreenshot.cs
+++ b/src/officecli/Core/HtmlScreenshot.cs
@@ -450,6 +450,8 @@ internal static class HtmlScreenshot
     {
         string profile = Path.Combine(Path.GetTempPath(), "officecli_chrome_" + Guid.NewGuid().ToString("N"));
         Process? browser = null;
+        using var cdpTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cdpToken = cdpTimeout.Token;
         try
         {
             int port = GetFreeLoopbackPort();
@@ -503,11 +505,11 @@ internal static class HtmlScreenshot
             if (string.IsNullOrEmpty(pageWs)) return (false, "Chrome screenshot target was not discoverable");
 
             using var pageSocket = new ClientWebSocket();
-            pageSocket.ConnectAsync(new Uri(pageWs), CancellationToken.None).GetAwaiter().GetResult();
-            using var enabled = CdpCommand(pageSocket, 1, "Page.enable", new { });
+            pageSocket.ConnectAsync(new Uri(pageWs), cdpToken).GetAwaiter().GetResult();
+            using var enabled = CdpCommand(pageSocket, 1, "Page.enable", new { }, cdpToken);
             using var metrics = CdpCommand(pageSocket, 2, "Emulation.setDeviceMetricsOverride",
-                new { width = w, height = h, deviceScaleFactor = scale, mobile = false, screenWidth = w, screenHeight = h });
-            using var navigate = CdpCommand(pageSocket, 3, "Page.navigate", new { url });
+                new { width = w, height = h, deviceScaleFactor = scale, mobile = false, screenWidth = w, screenHeight = h }, cdpToken);
+            using var navigate = CdpCommand(pageSocket, 3, "Page.navigate", new { url }, cdpToken);
 
             // Wait for synchronous preview JS and local assets.  The normal HTML
             // previews are local; this is deliberately bounded rather than using
@@ -516,17 +518,17 @@ internal static class HtmlScreenshot
             while (DateTime.UtcNow < readyDeadline)
             {
                 using var state = CdpCommand(pageSocket, 4, "Runtime.evaluate",
-                    new { expression = "document.readyState", returnByValue = true });
+                    new { expression = "document.readyState", returnByValue = true }, cdpToken);
                 if (state.RootElement.GetProperty("result").GetProperty("result")
                     .GetProperty("value").GetString() == "complete") break;
                 Thread.Sleep(50);
             }
             using var scaled = CdpCommand(pageSocket, 5, "Runtime.evaluate",
-                new { expression = "window.scaleSlides && window.scaleSlides()", awaitPromise = true, returnByValue = true });
+                new { expression = "window.scaleSlides && window.scaleSlides()", awaitPromise = true, returnByValue = true }, cdpToken);
             Thread.Sleep(100);
             using var screenshot = CdpCommand(pageSocket, 6, "Page.captureScreenshot",
                 new { format = "png", captureBeyondViewport = false,
-                      clip = new { x = 0, y = 0, width = w, height = h, scale = 1 } });
+                      clip = new { x = 0, y = 0, width = w, height = h, scale = 1 } }, cdpToken);
             var base64 = screenshot.RootElement.GetProperty("result").GetProperty("data").GetString();
             if (string.IsNullOrEmpty(base64)) return (false, "Chrome returned an empty screenshot");
             File.WriteAllBytes(outPath, Convert.FromBase64String(base64));
@@ -557,14 +559,15 @@ internal static class HtmlScreenshot
         finally { listener.Stop(); }
     }
 
-    private static JsonDocument CdpCommand(ClientWebSocket socket, int id, string method, object parameters)
+    private static JsonDocument CdpCommand(ClientWebSocket socket, int id, string method, object parameters,
+                                           CancellationToken cancellationToken)
     {
         var payload = JsonSerializer.Serialize(new { id, method, @params = parameters });
         var bytes = Encoding.UTF8.GetBytes(payload);
-        socket.SendAsync(bytes, WebSocketMessageType.Text, true, CancellationToken.None).GetAwaiter().GetResult();
+        socket.SendAsync(bytes, WebSocketMessageType.Text, true, cancellationToken).GetAwaiter().GetResult();
         while (true)
         {
-            var text = ReceiveCdpMessage(socket);
+            var text = ReceiveCdpMessage(socket, cancellationToken);
             var json = JsonDocument.Parse(text);
             if (json.RootElement.TryGetProperty("id", out var responseId) && responseId.GetInt32() == id)
                 return json;
@@ -572,14 +575,14 @@ internal static class HtmlScreenshot
         }
     }
 
-    private static string ReceiveCdpMessage(ClientWebSocket socket)
+    private static string ReceiveCdpMessage(ClientWebSocket socket, CancellationToken cancellationToken)
     {
         var buffer = new byte[16 * 1024];
         using var stream = new MemoryStream();
         WebSocketReceiveResult result;
         do
         {
-            result = socket.ReceiveAsync(buffer, CancellationToken.None).GetAwaiter().GetResult();
+            result = socket.ReceiveAsync(buffer, cancellationToken).GetAwaiter().GetResult();
             if (result.MessageType == WebSocketMessageType.Close)
                 throw new InvalidOperationException("Chrome DevTools connection closed");
             stream.Write(buffer, 0, result.Count);

--- a/src/officecli/Core/HtmlScreenshot.cs
+++ b/src/officecli/Core/HtmlScreenshot.cs
@@ -415,6 +415,7 @@ internal static class HtmlScreenshot
         var cdp = TryChromeCdp(bin, url, outPath, w, h, scale: 1);
         if (cdp.Ok)
             return cdp;
+        DebugScreenshot($"CDP failed: {cdp.Error ?? "unknown"}; falling back to command-line Chrome");
 
         var args = new[]
         {
@@ -437,7 +438,10 @@ internal static class HtmlScreenshot
             $"--screenshot={outPath}",
             url,
         };
-        return RunBinary(bin, args, timeoutMs: 30_000);
+        var fallback = RunBinary(bin, args, timeoutMs: 30_000);
+        if (!fallback.Item1)
+            DebugScreenshot($"Chrome fallback failed: {fallback.Item2 ?? "unknown"}");
+        return fallback;
     }
 
     /// <summary>
@@ -568,6 +572,12 @@ internal static class HtmlScreenshot
         listener.Start();
         try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
         finally { listener.Stop(); }
+    }
+
+    private static void DebugScreenshot(string message)
+    {
+        if (string.Equals(Environment.GetEnvironmentVariable("OFFICECLI_SCREENSHOT_DEBUG"), "1", StringComparison.Ordinal))
+            Console.Error.WriteLine($"[officecli-screenshot] {message}");
     }
 
     private static JsonDocument CdpCommand(ClientWebSocket socket, int id, string method, object parameters,

--- a/src/officecli/Resources/preview.css
+++ b/src/officecli/Resources/preview.css
@@ -215,6 +215,12 @@ html.headless .sidebar,
 html.headless .sidebar-toggle,
 html.headless .toggle-zone,
 html.headless .page-counter { display: none !important; }
+/* Exact screenshot capture uses the document viewport as its canvas.  Keep the
+   headless page free of min-content expansion so a single slide is measured
+   against that viewport in both directions. */
+html.headless,
+html.headless body { width: 100%; height: 100%; }
+html.headless .main { min-height: 0; }
 
 /* ===== Narrow viewport: auto-hide sidebar ===== */
 @media (max-width: 900px) {

--- a/src/officecli/Resources/preview.css
+++ b/src/officecli/Resources/preview.css
@@ -219,8 +219,18 @@ html.headless .page-counter { display: none !important; }
    headless page free of min-content expansion so a single slide is measured
    against that viewport in both directions. */
 html.headless,
-html.headless body { width: 100%; height: 100%; }
-html.headless .main { min-height: 0; }
+html.headless body { width: 100vw; height: 100vh; min-width: 100vw; min-height: 100vh; }
+html.headless .main {
+    width: 100vw;
+    min-width: 100vw;
+    height: 100vh;
+    min-height: 100vh;
+    padding: 0 !important;
+    gap: 0 !important;
+    flex: none;
+}
+html.headless .slide-container,
+html.headless .slide-wrapper { width: 100vw; }
 
 /* ===== Narrow viewport: auto-hide sidebar ===== */
 @media (max-width: 900px) {

--- a/src/officecli/Resources/preview.js
+++ b/src/officecli/Resources/preview.js
@@ -24,15 +24,32 @@
         // requested resolution regardless of the slide's physical size. Interactive
         // and multi-slide views only ever shrink to fit.
         const fill = headless && slides.length === 1;
+        // Chromium's command-line screenshot can expose a layout viewport that
+        // is shorter than the bitmap it will emit (window chrome is included in
+        // --window-size).  For the one-slide capture path, use the outer canvas
+        // height when it is larger so the slide fills the requested bitmap
+        // instead of shrinking into a dark letterbox.  This is deliberately
+        // limited to headless one-slide previews: scrolling/grid/range previews
+        // and non-PPT HTML retain their normal responsive layout.
+        if (fill) {
+            const canvasH = Math.max(main.clientHeight, window.outerHeight || 0);
+            if (canvasH > main.clientHeight) {
+                document.documentElement.style.height = canvasH + 'px';
+                document.body.style.height = canvasH + 'px';
+                main.style.height = canvasH + 'px';
+                main.style.flex = 'none';
+            }
+        }
+        const captureH = fill ? main.clientHeight : availH;
         slides.forEach(slide => {
             const designW = slide.offsetWidth;
-            if (availW > 0 && availH > 0 && (fill || designW > availW)) {
+            if (availW > 0 && captureH > 0 && (fill || designW > availW)) {
                 // A headless single-slide capture must fit both layout axes.
                 // Chromium's legacy command-line screenshot can expose a
                 // shorter layout viewport than its requested bitmap; fitting by
                 // height preserves footers/legends instead of cutting them off.
                 const s = fill
-                    ? Math.min(availW / designW, availH / slide.offsetHeight)
+                    ? Math.min(availW / designW, captureH / slide.offsetHeight)
                     : availW / designW;
                 slide.style.transform = `scale(${s})`;
                 slide.style.transformOrigin = 'center top';

--- a/src/officecli/Resources/preview.js
+++ b/src/officecli/Resources/preview.js
@@ -16,8 +16,12 @@
         // 40px breathing room for interactive viewing; headless captures fill the
         // viewport (the screenshot path sizes it to the slide) so they take none.
         const headless = document.documentElement.classList.contains('headless');
-        const availW = main.clientWidth - (headless ? 0 : 40);
-        const availH = main.clientHeight - (headless ? 0 : 40);
+        // For an exact headless capture, use the browser's emulated viewport
+        // directly. Flex children can report a narrower client box while the
+        // screenshot canvas is still the full viewport (especially on Windows
+        // Edge/Chrome), which otherwise shrinks a 16:9 slide to ~1116x627.
+        const availW = headless ? window.innerWidth : main.clientWidth - 40;
+        const availH = headless ? window.innerHeight : main.clientHeight - 40;
         const slides = document.querySelectorAll('.main > .slide-container .slide');
         // A lone headless slide is a single-slide screenshot: scale it to fill the
         // viewport in BOTH directions (up or down) so the capture is flush at the
@@ -32,7 +36,7 @@
         // limited to headless one-slide previews: scrolling/grid/range previews
         // and non-PPT HTML retain their normal responsive layout.
         if (fill) {
-            const canvasH = Math.max(main.clientHeight, window.outerHeight || 0);
+            const canvasH = Math.max(window.innerHeight, window.outerHeight || 0);
             if (canvasH > main.clientHeight) {
                 document.documentElement.style.height = canvasH + 'px';
                 document.body.style.height = canvasH + 'px';

--- a/src/officecli/Resources/preview.js
+++ b/src/officecli/Resources/preview.js
@@ -17,6 +17,7 @@
         // viewport (the screenshot path sizes it to the slide) so they take none.
         const headless = document.documentElement.classList.contains('headless');
         const availW = main.clientWidth - (headless ? 0 : 40);
+        const availH = main.clientHeight - (headless ? 0 : 40);
         const slides = document.querySelectorAll('.main > .slide-container .slide');
         // A lone headless slide is a single-slide screenshot: scale it to fill the
         // viewport in BOTH directions (up or down) so the capture is flush at the
@@ -25,8 +26,14 @@
         const fill = headless && slides.length === 1;
         slides.forEach(slide => {
             const designW = slide.offsetWidth;
-            if (availW > 0 && (fill || designW > availW)) {
-                const s = availW / designW;
+            if (availW > 0 && availH > 0 && (fill || designW > availW)) {
+                // A headless single-slide capture must fit both layout axes.
+                // Chromium's legacy command-line screenshot can expose a
+                // shorter layout viewport than its requested bitmap; fitting by
+                // height preserves footers/legends instead of cutting them off.
+                const s = fill
+                    ? Math.min(availW / designW, availH / slide.offsetHeight)
+                    : availW / designW;
                 slide.style.transform = `scale(${s})`;
                 slide.style.transformOrigin = 'center top';
                 const designH = slide.offsetHeight;


### PR DESCRIPTION
## Summary

- Fix Windows NativeAOT CDP screenshot failures caused by reflection-based JSON serialization.
- Use deterministic DevTools target creation with bounded fallback and CDP timeouts.
- Prevent browser subprocess pipe deadlocks and preserve exact viewport capture.
- Normalize headless single-slide canvas sizing without changing grid/multi-slide behavior.
- Keep platform build jobs independent when macOS signing is unavailable.

## Validation

- GitHub Actions Windows x64 publish completed successfully.
- Windows CI smoke tests passed for document creation, installation, and installer scripts.
- Static checks passed: `git diff --check` and JavaScript syntax validation.
- No private documents, screenshots, generated previews, or user-provided files are included in this PR.

No release was created.