### PR TITLE
fix(xlsx): exclude phonetic guide text from cell values

### DIFF
--- a/src/officecli/Handlers/Excel/ExcelHandler.Helpers.Cell.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Helpers.Cell.cs
@@ -53,7 +53,16 @@ public partial class ExcelHandler
             if (sst?.SharedStringTable != null && int.TryParse(value, out int idx))
             {
                 var item = sst.SharedStringTable.Elements<SharedStringItem>().ElementAtOrDefault(idx);
-                return item?.InnerText ?? value;
+                if (item != null)
+                {
+                    // CT_Rst.InnerText also includes <rPh> phonetic-guide text.
+                    // That text annotates the base value; it is not part of the
+                    // ordinary cell content. Read only the direct <t> value or
+                    // rich-text <r><t> runs, while BuildCellNode continues to
+                    // expose the guide separately as Format["phonetic"].
+                    return item.Text?.Text
+                        ?? string.Concat(item.Elements<Run>().Select(r => r.Text?.Text ?? ""));
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- exclude `<rPh>` phonetic-guide text from ordinary XLSX cell display values
- preserve direct shared-string text and rich-text runs
- keep the guide available separately through the existing `format.phonetic` readback

Fixes #343

## Validation

Using the reporter's attached `sample.xlsx`:

```bash
officecli view sample.xlsx html
# Before: <td data-path="/Sheet1/A1">項目コウモク</td>
# After:  <td data-path="/Sheet1/A1">項目</td>

officecli view sample.xlsx text
# Before: A1=項目コウモク
# After:  A1=項目

officecli get sample.xlsx /Sheet1/A1 --json
# text: "項目"
# format.phonetic: "コウモク"

officecli validate sample.xlsx
# Validation passed: no errors found.
```

I also created a shared-string cell with two formatted runs (`Hello` bold, ` world` italic). `view text` still returns `Hello world`, `view html` retains both formatted spans, and `officecli validate` passes.

Project build:

```bash
dotnet build src/officecli/officecli.csproj -c Release --no-restore
# Build succeeded (one pre-existing CS8602 warning in ExcelHandler.SheetShift.cs).
```
