### PR TITLE
fix(pptx): honor noFill text outlines in HTML preview

### DIFF
--- a/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.Text.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.Text.cs
@@ -1133,11 +1133,12 @@ public partial class PowerPointHandler
             // Run-level text outline (a:rPr/a:ln). PowerPoint strokes each glyph
             // edge; Chromium renders this via -webkit-text-stroke. Width is the
             // a:ln @w in EMU (12700 EMU = 1pt); convert to px (1pt = 4/3 px) so a
-            // 3pt outline reads as a ~4px stroke. Color comes from the a:ln's
-            // solidFill child (default black when absent). paint-order:stroke fill
-            // keeps the fill painted on top so the stroke hugs the glyph outside.
+            // 3pt outline reads as a ~4px stroke. An explicit noFill disables
+            // the stroke; otherwise color comes from solidFill (default black
+            // when absent). paint-order:stroke fill keeps the fill painted on
+            // top so the stroke hugs the glyph outside.
             var runOutline = rp.GetFirstChild<Drawing.Outline>();
-            if (runOutline != null)
+            if (runOutline != null && runOutline.GetFirstChild<Drawing.NoFill>() == null)
             {
                 double strokePx = runOutline.Width?.HasValue == true
                     ? Units.EmuToPt(runOutline.Width.Value) * 4.0 / 3.0


### PR DESCRIPTION
## Summary

- skip CSS glyph strokes when a run-level text outline explicitly contains `a:noFill`
- preserve the existing rendering path for solid and implicit text outlines

## Scope

This addresses only the `a:rPr/a:ln/a:noFill` text-outline item in #341. The connector, inherited alignment, and equation-rendering items in that issue remain out of scope.

Refs #341

## Validation

- `dotnet build src/officecli/officecli.csproj --configuration Release --no-restore` — passed with 0 errors (one pre-existing nullable warning in `ExcelHandler.SheetShift.cs`)
- rendered the public `sample.pptx` from #341: before this change the affected run emitted a black `-webkit-text-stroke`; after the change it emits no text stroke
- negative control: replacing the same outline with a 1 pt red solid outline still emits `-webkit-text-stroke:1.33px #FF0000`
- `git diff --check`
