### PR TITLE
fix(install): version pinning defeated on PS 5.1, and TEMP cleanup leaks on spaced profiles

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -7,6 +7,27 @@ $arch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { 
 $asset = if ($arch -eq "ARM64") { "officecli-win-arm64.exe" } else { "officecli-win-x64.exe" }
 $binary = "officecli.exe"
 
+# Expand TEMP when Windows hands it to us in 8.3 short form. Profiles whose
+# name contains a space (e.g. "C:\Users\Win 1") surface as C:\Users\WIN1~1\...,
+# and the filesystem provider cannot resolve that "~" segment -- so every
+# Remove-Item cleanup below fails with "An object at the specified path
+# C:\Users\WIN1~1 does not exist" and leaks the binary + SHA256SUMS into TEMP.
+# -LiteralPath does NOT help; the short path itself has to be expanded. No-op
+# when TEMP is already long.
+if ($env:TEMP -match '~') {
+    try {
+        Add-Type -MemberDefinition @"
+[DllImport("kernel32.dll", CharSet=CharSet.Unicode, SetLastError=true)]
+public static extern uint GetLongPathName(string lpszShortPath, System.Text.StringBuilder lpszLongPath, uint cchBuffer);
+"@ -Name PathHelper -Namespace OfficeCli -ErrorAction Stop
+        $sb = New-Object System.Text.StringBuilder 32767
+        if ([OfficeCli.PathHelper]::GetLongPathName($env:TEMP, $sb, 32767) -gt 0) {
+            $env:TEMP = $sb.ToString()
+            $env:TMP = $env:TEMP
+        }
+    } catch { }
+}
+
 # Mirror primary, github fallback. The mirror is exercised first so issues
 # surface there fast; github is the safety net when CF or the mirror is
 # unreachable.
@@ -17,13 +38,13 @@ $githubRawBase = "https://raw.githubusercontent.com/$repo/main"
 function Fetch-WithFallback {
     param([string]$Primary, [string]$Fallback, [string]$OutFile)
     try {
-        Invoke-WebRequest -Uri $Primary -OutFile $OutFile -TimeoutSec 30 -ErrorAction Stop
+        Invoke-WebRequest -Uri $Primary -OutFile $OutFile -UseBasicParsing -TimeoutSec 30 -ErrorAction Stop
         Write-Host "  (via mirror)"
         return $true
     } catch {
         Write-Host "  mirror unreachable, falling back to github..."
         try {
-            Invoke-WebRequest -Uri $Fallback -OutFile $OutFile -TimeoutSec 300 -ErrorAction Stop
+            Invoke-WebRequest -Uri $Fallback -OutFile $OutFile -UseBasicParsing -TimeoutSec 300 -ErrorAction Stop
             return $true
         } catch {
             return $false
@@ -40,7 +61,14 @@ function Fetch-WithFallback {
 function Resolve-Version {
     foreach ($base in @("$mirrorBase/releases/latest", "https://github.com/$repo/releases/latest")) {
         try {
-            $resp = Invoke-WebRequest -Uri $base -MaximumRedirection 5 -TimeoutSec 30 -ErrorAction Stop
+            # -UseBasicParsing is required, not cosmetic: without it PS 5.1 hands
+            # the response to the IE engine for DOM parsing, which needs IE
+            # first-run setup and can prompt. That throws here, Resolve-Version
+            # returns $null, and the download silently degrades to the mutable
+            # /releases/latest/download/ path this function exists to avoid --
+            # the exact stale-binary-with-matching-stale-checksum case described
+            # above. The -OutFile calls dodge it because -OutFile skips parsing.
+            $resp = Invoke-WebRequest -Uri $base -UseBasicParsing -MaximumRedirection 5 -TimeoutSec 30 -ErrorAction Stop
             $finalUrl = $resp.BaseResponse.ResponseUri.AbsoluteUri
             if ($finalUrl -match '/releases/tag/(v[0-9]+\.[0-9]+\.[0-9]+)') {
                 return $matches[1]


### PR DESCRIPTION
Two independent bugs in `install.ps1`, both of which fail silently on Windows. Found while installing on Windows 11 / Windows PowerShell 5.1 with a user profile containing a space (`C:\Users\Win 1`).

## 1. Version pinning is defeated on Windows PowerShell 5.1

`Resolve-Version` calls `Invoke-WebRequest` without `-UseBasicParsing`. On PS 5.1 that routes the response through the Internet Explorer engine for DOM parsing, which requires IE first-run setup and can prompt. The call throws, `Resolve-Version` returns `$null`, and the script prints:

```
Could not resolve latest version; falling back to 'latest' path.
```

That fallback is the mutable `/releases/latest/download/` path — precisely the stale-binary case the comment above `Resolve-Version` warns about:

> right after a release it can serve the PREVIOUS binary together with a self-consistent stale SHA256SUMS — which passes checksum and installs an old version despite printing success

So on PS 5.1 the immutable-versioned-URL protection never engaged. This is the more consequential of the two bugs: the install still reports success, and the checksum still verifies, because the stale manifest matches the stale binary.

Worth noting the two `-OutFile` downloads were unaffected — `-OutFile` skips HTML parsing entirely. That asymmetry is why only this one step failed while everything else looked healthy, and why the failure is easy to miss. I added `-UseBasicParsing` to those two calls as well; it changes nothing today but removes the same latent IE dependency.

## 2. Cleanup leaks files when the profile path contains a space

Windows reports `TEMP` in 8.3 short form for such profiles (`C:\Users\WIN1~1\AppData\Local\Temp`). PowerShell's filesystem provider cannot resolve the `~` segment, so every cleanup call fails:

```
Remove-Item : An object at the specified path C:\Users\WIN1~1 does not exist.
At line:108 char:9
At line:158 char:1
```

The downloaded binary (~33 MB) and `SHA256SUMS` are left in `TEMP` on **every** run, including every future upgrade. `-LiteralPath` does *not* fix this — I tested it; the short path itself has to be expanded via `GetLongPathName`. The added block is a no-op when `TEMP` is already long.

## Verification

Same machine, same shell, before and after.

Before:
```
Could not resolve latest version; falling back to 'latest' path.
Downloading OfficeCLI...
  (via mirror)
Checksum verified.
Remove-Item : An object at the specified path C:\Users\WIN1~1 does not exist.
Remove-Item : An object at the specified path C:\Users\WIN1~1 does not exist.
OfficeCLI installed successfully!
```
→ 2 errors, 2 leaked files in `TEMP`, downloaded from the mutable path.

After:
```
Latest version: v1.0.146
Downloading OfficeCLI...
  (via mirror)
Checksum verified.
Download verified.
OfficeCLI installed successfully!
```
→ exit 0, no errors, 0 leftovers, downloaded from the pinned immutable path.

Also confirmed the resulting install is healthy (`officecli --version` → `1.0.146`) and that `Resolve-Version` now returns `v1.0.146` from both the mirror and the GitHub fallback.

## Scope

Both changes are confined to `install.ps1`. No behavior change on systems already unaffected: `-UseBasicParsing` is the recommended form on 5.1 and is the default and a no-op on PowerShell 7+, and the TEMP block only runs when `TEMP` actually contains a `~`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
