### PR TITLE
fix(batch): preserve per-item warnings across CLI and MCP

### DIFF
--- a/src/officecli/BatchTypes.cs
+++ b/src/officecli/BatchTypes.cs
@@ -225,6 +225,8 @@ public class BatchResult
     public string? Code { get; set; }
     /// <summary>The original batch item, included when the command fails so the agent can inspect/retry.</summary>
     public BatchItem? Item { get; set; }
+    /// <summary>Advisory diagnostics produced while executing this item.</summary>
+    internal List<OfficeCli.Core.CliWarning>? Warnings { get; set; }
 }
 
 /// <summary>
@@ -244,6 +246,8 @@ internal class BatchResultConverter : JsonConverter<BatchResult>
         if (root.TryGetProperty("error", out var err)) result.Error = err.GetString();
         if (root.TryGetProperty("code", out var cod)) result.Code = cod.GetString();
         if (root.TryGetProperty("item", out var itm)) result.Item = JsonSerializer.Deserialize(itm.GetRawText(), BatchJsonContext.Default.BatchItem);
+        if (root.TryGetProperty("warnings", out var wrn))
+            result.Warnings = JsonSerializer.Deserialize(wrn.GetRawText(), OfficeCli.Core.AppJsonContext.Default.ListCliWarning);
         return result;
     }
 
@@ -276,6 +280,11 @@ internal class BatchResultConverter : JsonConverter<BatchResult>
                 writer.WritePropertyName("item");
                 JsonSerializer.Serialize(writer, value.Item, BatchJsonContext.Default.BatchItem);
             }
+        }
+        if (value.Warnings is { Count: > 0 })
+        {
+            writer.WritePropertyName("warnings");
+            JsonSerializer.Serialize(writer, value.Warnings, OfficeCli.Core.AppJsonContext.Default.ListCliWarning);
         }
         writer.WriteEndObject();
     }

--- a/src/officecli/CommandBuilder.Batch.cs
+++ b/src/officecli/CommandBuilder.Batch.cs
@@ -77,14 +77,47 @@ static partial class CommandBuilder
                     continue;
                 }
             }
+            // Batch dispatches straight to the shared handler methods, bypassing
+            // the standalone add/set wrappers that normally drain warnings into
+            // their output envelope. Capture a fresh warning scope per item so
+            // diagnostics retain the step that produced them.
+            OfficeCli.Core.WarningContext.Begin();
             try
             {
                 var output = ExecuteBatchItem(handler, item, json);
-                results.Add(new BatchResult { Index = bi, Success = true, Output = output });
+                var warnings = OfficeCli.Core.WarningContext.End();
+                if (handler is OfficeCli.Handlers.WordHandler word)
+                {
+                    // Word advisories live on the handler rather than in
+                    // WarningContext; standalone add/set merge these explicitly.
+                    var advisory = string.Equals(item.Command, "add", StringComparison.OrdinalIgnoreCase)
+                        ? word.LastAddWarnings
+                        : string.Equals(item.Command, "set", StringComparison.OrdinalIgnoreCase)
+                            ? word.LastSetWarnings
+                            : null;
+                    if (advisory is { Count: > 0 })
+                    {
+                        warnings ??= new List<OfficeCli.Core.CliWarning>();
+                        warnings.AddRange(advisory.Select(message => new OfficeCli.Core.CliWarning
+                        {
+                            Message = message,
+                            Code = "advisory",
+                        }));
+                    }
+                }
+                results.Add(new BatchResult { Index = bi, Success = true, Output = output, Warnings = warnings });
             }
             catch (Exception ex)
             {
-                results.Add(new BatchResult { Index = bi, Success = false, Item = item, Error = ex.Message, Code = OfficeCli.Core.OutputFormatter.InferErrorCode(ex) });
+                results.Add(new BatchResult
+                {
+                    Index = bi,
+                    Success = false,
+                    Item = item,
+                    Error = ex.Message,
+                    Code = OfficeCli.Core.OutputFormatter.InferErrorCode(ex),
+                    Warnings = OfficeCli.Core.WarningContext.End(),
+                });
                 if (stopOnError) break;
             }
             // BUG-BT2: per-item unrecognized-LaTeX diagnostics. The handler

--- a/src/officecli/CommandBuilder.cs
+++ b/src/officecli/CommandBuilder.cs
@@ -1419,6 +1419,11 @@ static partial class CommandBuilder
                                 System.Text.Json.JsonSerializer.Serialize(slimWriter, r.Item, BatchJsonContext.Default.BatchItem);
                             }
                         }
+                        if (r.Warnings is { Count: > 0 })
+                        {
+                            slimWriter.WritePropertyName("warnings");
+                            System.Text.Json.JsonSerializer.Serialize(slimWriter, r.Warnings, OfficeCli.Core.AppJsonContext.Default.ListCliWarning);
+                        }
                         slimWriter.WriteEndObject();
                     }
                     slimWriter.WriteEndArray();
@@ -1452,6 +1457,9 @@ static partial class CommandBuilder
                 {
                     @out.WriteLine($"{prefix}ERROR: {r.Error}");
                 }
+                if (r.Warnings is { Count: > 0 })
+                    foreach (var warning in r.Warnings)
+                        @out.WriteLine($"  WARNING: {warning.Message}");
             }
 
             var succeeded = results.Count(r => r.Success);

--- a/src/officecli/Core/OutputFormatter.cs
+++ b/src/officecli/Core/OutputFormatter.cs
@@ -74,7 +74,7 @@ internal class CliWarning
 }
 
 /// <summary>
-/// Thread-static context for capturing warnings during command execution in JSON mode.
+/// Thread-static context for capturing warnings during command execution.
 /// </summary>
 internal static class WarningContext
 {


### PR DESCRIPTION
## Summary

- capture `WarningContext` diagnostics separately for each batch item
- propagate Word add/set advisories, including dangling-style warnings, into the corresponding `results[]` entry
- print per-item warnings in text mode and preserve them in the large-output spill response

The capture happens in the shared batch loop, so non-resident CLI, resident, MCP, and in-process batch execution inherit the same behavior.

## Why

Batch items call the shared document handlers directly and bypass the standalone add/set wrappers that normally add handler warnings to their output. A successful mutation could therefore silently lose an advisory that the equivalent standalone command exposed.

## Scope

This PR only restores warning propagation. It does not materialize missing Word styles or add downstream dangling-style validation.

## Validation

- `dotnet build src/officecli/officecli.csproj -c Release --no-restore` — passed with 0 errors; only the pre-existing nullable warning in `ExcelHandler.SheetShift.cs`
- plain and JSON DOCX batch add — advisory visible, exit 0
- JSON batch set — advisory visible on the corresponding result, exit 0
- resident batch — advisory preserved
- MCP batch — warning present in the returned text content with `isError=false`
- 180-item JSON batch — triggered the `outputFile` spill path and retained the warning in the slim response
- `git diff --check` — passed

Fixes #350