### PR TITLE
fix(pptx-animation): entrance defaults to afterprevious to fix SlideShow nav

### DIFF
--- a/src/officecli/Handlers/Pptx/PowerPointHandler.Add.Misc.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.Add.Misc.cs
@@ -1762,7 +1762,11 @@ public partial class PowerPointHandler
                 // animValue parser would silently default these to 400 with a
                 // stderr-only warning.
                 ValidateAnimationDuration(duration);
-                var trigger = properties.GetValueOrDefault("trigger", "onclick");
+                // FIX: entrance defaults to afterprevious (auto-play) to match PowerPoint UI;
+                // "onclick" produced clickEffect + outerDelay="indefinite" which blocks
+                // SlideShow mouse-wheel-up navigation. Exit/emphasis keep onclick default.
+                var defaultTrigger = (cls == "entrance" || cls == "in") ? "afterprevious" : "onclick";
+                var trigger = properties.GetValueOrDefault("trigger", defaultTrigger);
 
                 // Validate delay symmetrically with duration. The composite
                 // animValue split('-') silently drops the minus sign on a

--- a/src/officecli/Handlers/Pptx/PowerPointHandler.Animations.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.Animations.cs
@@ -967,12 +967,15 @@ public partial class PowerPointHandler
         {
             // Auto: first animation on slide → click, subsequent → after previous (sequential)
             // Exception: morph slides default to after (morph already shows shapes, click would be invisible)
+            // FIX: entrance defaults to AfterPrevious to match PowerPoint UI auto-play; clickEffect
+            // + outerDelay="indefinite" wrapper blocks SlideShow mouse-wheel-up navigation.
             var hasExistingAnimations = slide.GetFirstChild<Timing>()
                 ?.Descendants<CommonTimeNode>()
                 .Any(ctn => ctn.PresetId != null) ?? false;
             var hasMorphTransition = slide.ChildElements.Any(c =>
                 c.LocalName == "AlternateContent" && c.InnerXml.Contains("morph"));
-            trigger = (hasExistingAnimations || hasMorphTransition)
+            var isEntrance = presetClass == TimeNodePresetClassValues.Entrance;
+            trigger = (hasExistingAnimations || hasMorphTransition || isEntrance)
                 ? AnimTrigger.AfterPrevious : AnimTrigger.OnClick;
         }
         var nodeType = trigger switch


### PR DESCRIPTION
## Summary

Entrance animations (fade, fly, wipe, etc.) previously defaulted to trigger=onclick, which produced a 3-layer wrapper structure with nodeType=clickEffect and outerDelay="indefinite".

PowerPoint SlideShow intercepts any input event (mouse-wheel-up, click, key press) for clickEffect animations, preventing navigation to the previous slide. This affected all officecli users who added entrance animations programmatically.

## Fix

Change default trigger for **entrance** animations to **afterprevious** (= auto-play), which produces afterEffect + outerDelay=0. This matches PowerPoint UI behavior: entrance animations in PowerPoint UI auto-play on slide enter, never wait for click.

**Exit / Emphasis still default to onclick** (user expectation: click-to-play).

## Files changed

- `src/officecli/Handlers/Pptx/PowerPointHandler.Add.Misc.cs` (line 1758): change trigger default to `afterprevious` when cls=entrance
- `src/officecli/Handlers/Pptx/PowerPointHandler.Animations.cs` (line 977): defensive guard inside `ApplyShapeAnimation` for entrance presetClass

## Verification

Re-tested with simple PowerPoint builds:

| Animation | clickEffect | afterEffect | indefinite | Expected |
|---|---|---|---|---|
| entrance (fade, class=entrance) | 0 | 1 | 0 | auto-play |
| exit (fade, class=exit) | 1 | 0 | 1 | click-trigger |
| emphasis (spin, class=emphasis) | 1 | 0 | 1 | click-trigger |

User reproduction context: 27-slide PPTX with entrance animations on multiple slides; mouse-wheel-up in PowerPoint SlideShow was not returning to previous slide.

## Backward compatibility

This change only affects the **default** trigger when caller does NOT specify `trigger=`. Users who explicitly pass `trigger=onclick` retain click-trigger behavior. Users who pass `trigger=after` or `trigger=with` are unaffected.

If downstream tooling relies on the entrance-animation-as-click-trigger default, they can pass `trigger=onclick` explicitly to restore previous behavior.