### PR TITLE
fix(pptx): preserve equation order in HTML previews

### DIFF
--- a/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.Text.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.HtmlPreview.Text.cs
@@ -531,33 +531,6 @@ public partial class PowerPointHandler
                 sb.Append($"<span class=\"bullet\"{buStyle}>{HtmlEncode(bullet)}</span>");
             }
 
-            // Check for OfficeMath (a14:m inside mc:AlternateContent) in paragraph XML
-            var paraXml = para.OuterXml;
-            if (paraXml.Contains("oMath"))
-            {
-                // AlternateContent is opaque to Descendants() — parse from XML.
-                // A paragraph can interleave several a14:m equations with its text
-                // runs; emit every match, not just the first (#228 dropped the
-                // second equation of a two-equation paragraph).
-                foreach (System.Text.RegularExpressions.Match mathMatch in System.Text.RegularExpressions.Regex.Matches(paraXml,
-                    @"<m:oMathPara[^>]*>.*?</m:oMathPara>|<m:oMath[^>]*>.*?</m:oMath>",
-                    System.Text.RegularExpressions.RegexOptions.Singleline))
-                {
-                    try
-                    {
-                        var wrapper = new OpenXmlUnknownElement("wrapper");
-                        wrapper.InnerXml = mathMatch.Value;
-                        var oMath = wrapper.Descendants().FirstOrDefault(e => e.LocalName == "oMathPara" || e.LocalName == "oMath");
-                        if (oMath != null)
-                        {
-                            var latex = FormulaParser.ToLatex(oMath);
-                            sb.Append($"<span class=\"katex-formula\" data-formula=\"{HtmlEncode(latex)}\"></span>");
-                        }
-                    }
-                    catch { }
-                }
-            }
-
             // R35: per-paragraph tab-stop context. Read the explicit <a:tabLst>
             // (defined stops with absolute positions + alignment); fall back to
             // the body's default tab interval for tabs beyond the last stop.
@@ -655,6 +628,31 @@ public partial class PowerPointHandler
                             fldRun.RunProperties = (Drawing.RunProperties)fldRpr.CloneNode(true);
                         fldRun.Text = new Drawing.Text(fldText);
                         RenderRun(sb, fldRun, themeColors, paraSize, placeholderPart, themeFontFallback, fontScale, paraColor, inhBold, inhItalic, tabCtx, inhCap, inhU, inhStrike, inhSpc);
+                    }
+                    else if (hasMath)
+                    {
+                        // Keep a14:m / AlternateContent equations at their position
+                        // among runs, breaks and fields (#341). Extracting from the
+                        // whole paragraph first moved every equation before its text.
+                        // AlternateContent is opaque to Descendants(), so retain the
+                        // XML extraction and emit every equation in this child (#228).
+                        foreach (System.Text.RegularExpressions.Match mathMatch in System.Text.RegularExpressions.Regex.Matches(child.OuterXml,
+                            @"<m:oMathPara[^>]*>.*?</m:oMathPara>|<m:oMath[^>]*>.*?</m:oMath>",
+                            System.Text.RegularExpressions.RegexOptions.Singleline))
+                        {
+                            try
+                            {
+                                var wrapper = new OpenXmlUnknownElement("wrapper");
+                                wrapper.InnerXml = mathMatch.Value;
+                                var oMath = wrapper.Descendants().FirstOrDefault(e => e.LocalName == "oMathPara" || e.LocalName == "oMath");
+                                if (oMath != null)
+                                {
+                                    var latex = FormulaParser.ToLatex(oMath);
+                                    sb.Append($"<span class=\"katex-formula\" data-formula=\"{HtmlEncode(latex)}\"></span>");
+                                }
+                            }
+                            catch { }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
PPTX paragraphs that interleave text and equations currently emit every equation before the surrounding text in HTML previews. The sample in #341 turns `The value is [x + y].` into `[x + y]The value is .`.

Render each paragraph's math container at its position among runs, breaks, and fields, keeping the existing equation extraction and multiple-equation support.

Refs #341. This fixes HTML element order only. The existing `displayMode: true` setting still renders equations in display mode; equation sizing and the other items in that issue remain unchanged.

## Validation

From the repository root:

```bash
dotnet build src/officecli/officecli.csproj --configuration Release
math_repro_dir=$(mktemp -d)
curl -L --fail https://github.com/user-attachments/files/31409705/sample.pptx \
  --output "$math_repro_dir/sample.pptx"
OFFICECLI_SKIP_UPDATE=1 OFFICECLI_NO_AUTO_RESIDENT=1 \
  dotnet run --no-build --configuration Release \
  --project src/officecli/officecli.csproj -- \
  view "$math_repro_dir/sample.pptx" html --out "$math_repro_dir/sample.html"
```

The equation paragraph now preserves the source order (text styling omitted):

```html
<!-- Before -->
<span class="katex-formula" data-formula="x + y"></span><span>The value is </span><span>.</span>
<!-- After -->
<span>The value is </span><span class="katex-formula" data-formula="x + y"></span><span>.</span>
```

Local checks on macOS: Release build passed; 11 HTML sequence cases passed, including the public sample, interleaved equations, formula-only paragraphs, `AlternateContent`, and text/break/field controls. Six ordering cases fail before this change. The original display equation still appears exactly once, and the source sample is byte-for-byte unchanged. `git diff --check` passed.
