### PR TITLE
fix(xlsx): synchronize VML note targets during sheet shifts

### DIFF
--- a/src/officecli/Handlers/Excel/ExcelHandler.SheetShift.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.SheetShift.cs
@@ -32,6 +32,7 @@
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using System.Xml.Linq;
 using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
 using CX = DocumentFormat.OpenXml.Office2016.Drawing.ChartDrawing;
@@ -314,19 +315,24 @@ public partial class ExcelHandler
         var cmtList = commentsPart?.Comments?.GetFirstChild<CommentList>();
         if (cmtList != null)
         {
-            bool cmtDirty = false;
+            var commentMoves = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
             foreach (var cmt in cmtList.Elements<Comment>().ToList())
             {
                 if (cmt.Reference?.Value == null) continue;
-                var shifted = refMapper(cmt.Reference.Value);
-                if (shifted == null) { cmt.Remove(); cmtDirty = true; }
-                else if (!string.Equals(shifted, cmt.Reference.Value, StringComparison.Ordinal))
+                var oldRef = cmt.Reference.Value;
+                var shifted = refMapper(oldRef);
+                if (!string.Equals(shifted, oldRef, StringComparison.Ordinal))
                 {
-                    cmt.Reference = shifted;
-                    cmtDirty = true;
+                    commentMoves[oldRef] = shifted;
+                    if (shifted == null) cmt.Remove();
+                    else cmt.Reference = shifted;
                 }
             }
-            if (cmtDirty) commentsPart!.Comments!.Save();
+            if (commentMoves.Count > 0)
+            {
+                ApplyCommentVmlMutations(worksheet, commentMoves);
+                commentsPart!.Comments!.Save();
+            }
         }
 
         // 6e. sparklines (x14 extension list on the worksheet). Each sparkline
@@ -561,6 +567,51 @@ public partial class ExcelHandler
                 }
                 if (changed) GetWorkbook().Save();
             }
+        }
+    }
+
+    // A legacy comment's text ref and its VML Note target describe the same
+    // cell. Match shapes against ORIGINAL refs in one pass: looking up each
+    // old ref after rewriting the previous shape can shift adjacent notes twice.
+    private static void ApplyCommentVmlMutations(
+        WorksheetPart worksheet, IReadOnlyDictionary<string, string?> commentMoves)
+    {
+        XNamespace v = "urn:schemas-microsoft-com:vml";
+        XNamespace x = "urn:schemas-microsoft-com:office:excel";
+        // Follow this worksheet's relationships, not a guessed part name or
+        // the first VML part (which may belong to header/footer controls).
+        foreach (var vmlPart in worksheet.VmlDrawingParts)
+        {
+            XDocument doc;
+            using (var stream = vmlPart.GetStream(FileMode.Open, FileAccess.Read))
+                doc = XDocument.Load(stream, LoadOptions.PreserveWhitespace);
+            bool dirty = false;
+            foreach (var shape in doc.Descendants(v + "shape").ToList())
+            {
+                var data = shape.Element(x + "ClientData");
+                if (data == null || (string?)data.Attribute("ObjectType") != "Note") continue;
+                var row = data.Element(x + "Row");
+                var col = data.Element(x + "Column");
+                if (row == null || col == null
+                    || !int.TryParse(row.Value, out var r) || r < 0 || r >= ExcelMaxRow
+                    || !int.TryParse(col.Value, out var c) || c < 0 || c >= ExcelMaxCol)
+                    continue;
+                var oldRef = $"{IndexToColumnName(c + 1)}{r + 1}";
+                if (!commentMoves.TryGetValue(oldRef, out var shifted)) continue;
+                if (shifted == null) shape.Remove();
+                else
+                {
+                    var (colName, rowNum) = ParseCellReference(shifted);
+                    row.Value = (rowNum - 1).ToString();
+                    col.Value = (ColumnNameToIndex(colName) - 1).ToString();
+                }
+                // Keep the popup's custom Anchor/style and unrelated controls;
+                // Row/Column identify the comment cell, not the box geometry.
+                dirty = true;
+            }
+            if (!dirty) continue;
+            using var output = vmlPart.GetStream(FileMode.Create, FileAccess.Write);
+            doc.Save(output, SaveOptions.DisableFormatting);
         }
     }
 


### PR DESCRIPTION
Fixes #372.

## Problem

Inserting or deleting worksheet rows/columns already updates `Comment.Reference`, but the matching legacy VML Note still targets the old cell. For example, inserting a row with `--index 3` moves the comment on `D5` to `D6` while its VML target remains `Row=4, Column=3`. Deleting a commented row/column also leaves the Note shape behind.

## Change

Record the original-to-new comment references in the existing sheet mutation walker, then update the affected worksheet's VML Notes in one pass. A deleted comment removes its corresponding Note shape. Matching original references avoids shifting adjacent notes twice.

The implementation follows worksheet relationships, handles namespace prefixes and either Row/Column element order, and preserves unrelated legacy controls. It does not reset custom popup `Anchor`/style or change move/resize policy: the zero-based `Row`/`Column` identify the comment's cell, separately from the popup geometry ([Microsoft reference](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.vml.spreadsheet.commentrowtarget?view=openxml-3.0.1)). This is one synchronization fix in one production file, with no dependency changes.

## Validation

- Release build succeeds with zero errors and the same pre-existing nullable warning as `0a450e43`; `git diff --check` passes.
- Local package regression: **40/40 pass**. The 24 affected cases all failed the VML-target/orphan assertion on unchanged `0a450e43`; the fix passes those plus 16 unaffected-range controls. Covers row/column insert/delete, adjacent comments, deletion of the last comment, standalone and explicit resident sessions, two worksheets, renamed parts, a preceding unrelated VML part, mixed Note/Button shapes, reversed Row/Column order, and preservation of custom layout.
- The runnable eight-case script below also passes against the built executable on macOS arm64 (.NET SDK 10.0.400, openpyxl 3.1.5).
- Native Excel GUI rendering: not performed; validation inspects saved OOXML and reopens it with openpyxl.

<details>
<summary>Runnable regression for the four mutations, standalone and resident</summary>

Requires Python 3 with `openpyxl`. Save as `check_comment_shift.py` and run `python3 check_comment_shift.py /absolute/path/to/officecli`. The unchanged base fails the VML-target assertion; the fix should print `8 cases passed`.

```python
import os
from pathlib import Path
import subprocess
import sys
import tempfile
import xml.etree.ElementTree as ET
import zipfile
from openpyxl import Workbook
from openpyxl.comments import Comment
from openpyxl.utils import get_column_letter

cli = sys.argv[1]
env = dict(os.environ, OFFICECLI_NO_AUTO_RESIDENT="1",
           OFFICECLI_NO_AUTO_INSTALL="1", OFFICECLI_SKIP_UPDATE="1",
           OFFICECLI_RESIDENT_FLUSH="off")
S = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
V = "urn:schemas-microsoft-com:vml"
X = "urn:schemas-microsoft-com:office:excel"
refs = ["A1", "C3", "D5", "D6", "E5"]
cases = [
    (["add", "/Sheet", "--type", "row", "--index", "3"],
     ["A1", "C3", "D6", "D7", "E6"]),
    (["remove", "/Sheet/row[5]"], ["A1", "C3", None, "D5", None]),
    (["add", "/Sheet", "--type", "column", "--index", "3"],
     ["A1", "D3", "E5", "E6", "F5"]),
    (["remove", "/Sheet/col[D]"], ["A1", "C3", None, None, "D5"]),
]

def run(verb, file, *args):
    subprocess.run([cli, verb, str(file), *args], env=env, check=True,
                   capture_output=True, text=True, timeout=30)

def targets(file):
    result = {}
    with zipfile.ZipFile(file) as z:
        for name in z.namelist():
            if not name.endswith(".vml"):
                continue
            for shape in ET.fromstring(z.read(name)).iter(f"{{{V}}}shape"):
                data = shape.find(f"{{{X}}}ClientData")
                if data is None or data.get("ObjectType") != "Note":
                    continue
                row = int(data.find(f"{{{X}}}Row").text) + 1
                col = int(data.find(f"{{{X}}}Column").text) + 1
                result[(name, shape.get("id"))] = f"{get_column_letter(col)}{row}"
    return result

with tempfile.TemporaryDirectory(prefix="comment-shift-") as temporary:
    for resident in (False, True):
        for i, (command, expected) in enumerate(cases):
            file = Path(temporary) / f"{resident}-{i}.xlsx"
            wb = Workbook()
            for ref in refs:
                wb.active[ref] = ref
                wb.active[ref].comment = Comment(ref, "regression")
            wb.save(file)
            original = targets(file)
            if resident:
                run("open", file)
            try:
                run(command[0], file, *command[1:])
            finally:
                if resident:
                    run("close", file)
            moved = dict(zip(refs, expected))
            with zipfile.ZipFile(file) as z:
                actual = {}
                for name in z.namelist():
                    if name.endswith(".xml"):
                        for c in ET.fromstring(z.read(name)).iter(f"{{{S}}}comment"):
                            actual[c.get("ref")] = "".join(c.itertext())
                assert actual == {new: old for old, new in moved.items() if new}
            assert targets(file) == {key: moved[old] for key, old in original.items()
                                     if moved[old]}, (resident, command, targets(file))
print("8 cases passed")
```

</details>
