### PR TITLE
feat(docx): one-command style presets (preset=)

### DIFF
--- a/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Text.cs
@@ -1289,6 +1289,14 @@ public partial class WordHandler
             // Keys consumed by ApplyRunFormatting / TypedAttributeFallback /
             // GenericXmlQuery below leak as false unsupported without this.
             properties.ContainsKey(key);
+            // One-command styled paragraph on Add (cards, kicker, band, quote).
+            // Applies the render-safe preset bundle then consumes the key so the
+            // typed-attr fallback below never flags it as unsupported.
+            if (key.Equals("preset", StringComparison.OrdinalIgnoreCase))
+            {
+                ApplyParagraphPreset(para, pProps, value);
+                continue;
+            }
             // BUG-DUMP9-02: paragraph-mark-only run formatting written under
             // the markRPr.* namespace. Mirrors SetElementParagraph; targets
             // ParagraphMarkRunProperties exclusively (does NOT propagate to

--- a/src/officecli/Handlers/Word/WordHandler.Set.Element.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.Element.cs
@@ -1736,6 +1736,12 @@ public partial class WordHandler
                     ApplyParagraphLevelProperty(pProps, "hangingindent", value, LastSetWarnings);
                     break;
                 }
+                case "preset":
+                    // One-command paragraph styling (cards, kicker, band, quote).
+                    // Resolves the render-safe preset bundle and applies it via
+                    // the normal paragraph/run Set paths.
+                    ApplyParagraphPreset(para, pProps, value);
+                    break;
                 default:
                     // Generic dotted "element.attr=value" fallback first.
                     // Probe pPr (where most paragraph attrs live: ind.*,
@@ -2745,6 +2751,11 @@ public partial class WordHandler
                     }
                     break;
                 }
+                case "preset":
+                    // One-command table-row styling (e.g. table-header band).
+                    // Consumes the key so it isn't flagged unsupported below.
+                    ApplyTableRowPreset(row, value);
+                    break;
                 default:
                     // c1, c2, ... shorthand: set text of specific cell by index
                     if (key.Length >= 2 && key[0] == 'c' && int.TryParse(key.AsSpan(1), out var cIdx))

--- a/src/officecli/Handlers/Word/WordHandler.StylePreset.cs
+++ b/src/officecli/Handlers/Word/WordHandler.StylePreset.cs
@@ -1,0 +1,163 @@
+// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
+// SPDX-License-Identifier: Apache-2.0
+
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeCli.Handlers;
+
+public partial class WordHandler
+{
+    /// <summary>
+    /// One-command style application for Word paragraphs/table rows (the `preset`
+    /// prop). Each preset is a curated bundle of RENDER-SAFE paragraph/run
+    /// properties — solid shading, paragraph borders, keepNext/keepLines,
+    /// run color/size/bold/italic/caps — written through the exact same
+    /// <see cref="ApplyParagraphLevelProperty"/> / <see cref="ApplyRunFormatting"/>
+    /// paths a normal per-element `set` uses, so nothing the preset requests can
+    /// silently render as the wrong thing.
+    ///
+    /// The six presets mirror the six "design building blocks" taught in the
+    /// <c>officecli-docx-design</c> skill (callout card, dark accent card, kicker,
+    /// section color-band, pull quote, table header band), so an agent can apply
+    /// a designed look with one command instead of hand-writing
+    /// <c>shd=... pbdr=... keepLines=...</c> every time.
+    ///
+    /// Only solid fills are used. Gradient fills can degrade to a single colour
+    /// under some renderers, so presets deliberately avoid them to honour the
+    /// "what you ask for is what renders" contract (mirrors the PPTX
+    /// PowerPointHandler.StylePreset design).
+    /// </summary>
+    private void ApplyParagraphPreset(Paragraph para, ParagraphProperties pProps, string presetName)
+    {
+        var bundle = TryGetPresetProps(presetName)
+            ?? throw new ArgumentException(
+                $"Unknown preset: '{presetName}'. " +
+                $"Available: {string.Join(", ", PresetProps.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase))}");
+
+        foreach (var (key, value) in bundle)
+        {
+            // Paragraph-level keys route through the normal paragraph Set path.
+            if (ApplyParagraphLevelProperty(pProps, key, value, LastSetWarnings))
+                continue;
+
+            // Run-level keys apply to each existing run (never create empty runs;
+            // a paragraph with no runs stays empty — the caller supplies text).
+            bool appliedToAnyRun = false;
+            foreach (var run in para.Descendants<Run>())
+            {
+                if (ApplyRunFormatting(run.RunProperties ?? run.PrependChild(new RunProperties()), key, value))
+                    appliedToAnyRun = true;
+            }
+            // Mirror paragraph-mark rPr so the run props survive a cursor blink /
+            // next-typed-text (same reason the mark path exists in Add/Set).
+            if (appliedToAnyRun)
+                ApplyRunFormatting(EnsureMarkRunProperties(pProps), key, value);
+        }
+    }
+
+    /// <summary>
+    /// Apply a table-row preset: shade every cell (tcPr) and format the row's
+    /// runs (e.g. table-header = white bold on the accent band). Mirrors the
+    /// paragraph preset's render-safe contract.
+    /// </summary>
+    private void ApplyTableRowPreset(TableRow row, string presetName)
+    {
+        var bundle = TryGetPresetProps(presetName)
+            ?? throw new ArgumentException(
+                $"Unknown preset: '{presetName}'. " +
+                $"Available: {string.Join(", ", PresetProps.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase))}");
+
+        foreach (var (key, value) in bundle)
+        {
+            if (key.Equals("shd", StringComparison.OrdinalIgnoreCase))
+            {
+                // Row-level shading → each cell's tcPr (shading lives on tcPr).
+                foreach (var cell in row.Elements<TableCell>())
+                {
+                    var tcPr = cell.TableCellProperties ?? cell.PrependChild(new TableCellProperties());
+                    tcPr.RemoveAllChildren<Shading>();
+                    tcPr.AppendChild(ParseShadingValue(value));
+                }
+                continue;
+            }
+            // Run-level keys (color/bold/...) apply to every run in the row.
+            foreach (var run in row.Descendants<Run>())
+                ApplyRunFormatting(run.RunProperties ?? run.PrependChild(new RunProperties()), key, value);
+        }
+    }
+
+    /// <summary>Resolve a preset name to its render-safe prop bundle, or null.</summary>
+    private static Dictionary<string, string>? TryGetPresetProps(string name)
+    {
+        if (string.IsNullOrEmpty(name)) return null;
+        return PresetProps.TryGetValue(name, out var bundle) ? bundle : null;
+    }
+
+    /// <summary>
+    /// Registry of built-in style presets. Keys are case-insensitive; the value
+    /// is the exact prop map handed to the normal paragraph/run Set paths. All
+    /// property KEYS are the documented paragraph/run set-props (shd, pbdr.*,
+    /// keepNext, keepLines, spaceBefore/After, align, color, size, bold, italic,
+    /// caps, font) — never raw XML. Palette follows the docx-design skill's
+    /// accent-first scheme (E6A23C amber accent, 1F4E79 navy, light warm fills).
+    /// </summary>
+    private static readonly Dictionary<string, Dictionary<string, string>> PresetProps =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            // Callout card — light warm fill, thin amber border, stays whole.
+            ["card"] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["shd"] = "solid;FFF4E5",
+                ["pbdr.all"] = "single;1pt;E6A23C",
+                ["keepLines"] = "true",
+                ["spaceAfter"] = "120",
+            },
+
+            // Dark accent card — navy fill, white bold text, 2pt navy border.
+            ["card-dark"] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["shd"] = "solid;1F4E79",
+                ["color"] = "FFFFFF",
+                ["bold"] = "true",
+                ["pbdr.all"] = "single;2pt;1F4E79",
+                ["keepLines"] = "true",
+            },
+
+            // Kicker — amber small caps lead line, glued to the following title.
+            ["kicker"] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["color"] = "E6A23C",
+                ["caps"] = "true",
+                ["size"] = "11",
+                ["spaceAfter"] = "0",
+                ["keepNext"] = "true",
+            },
+
+            // Section color-band — full-width amber rule.
+            ["band"] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["shd"] = "solid;E6A23C",
+                ["spaceBefore"] = "240",
+                ["spaceAfter"] = "0",
+            },
+
+            // Pull quote — centered italic navy serif, thick left rule.
+            ["quote"] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["italic"] = "true",
+                ["color"] = "1F4E79",
+                ["size"] = "16",
+                ["pbdr.left"] = "single;12pt;1F4E79",
+                ["align"] = "center",
+            },
+
+            // Table header band — navy fill + white bold text (row-level).
+            ["table-header"] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["shd"] = "solid;1F4E79",
+                ["color"] = "FFFFFF",
+                ["bold"] = "true",
+            },
+        };
+}


### PR DESCRIPTION
## What

Adds a reusable style-preset layer for docx: `preset=card|card-dark|kicker|band|quote|table-header` on `add paragraph` / `set paragraph`, plus `table-header` on `set table-row`. PPTX already had a `preset=` concept; docx previously forced hand-writing `shd=` / `pbdr=` / `keepLines=` stacks for the same few moods every time.

*(Rebuilt on current `main` on 2026-09-11 after maintainer feedback on #377: the local-only test suite no longer ships in the PR, and a How-to-verify section was added below.)*

## Why

Agent workflows (markdown import → styled doc) repeatedly rebuild the same paragraph decoration stacks — callout cards, kickers, quote bands. Presets make one-command styled output possible and remove the most common property-typo failure mode. They are **fixed declarative bundles, not heuristics**: nothing is inferred from content or data — the same input always produces the same explicit prop set, applied through the normal Set paths.

## How to verify

```bash
officecli create demo.docx
officecli add demo.docx /body --type paragraph --prop "text=QUARTERLY REVIEW" --prop "preset=kicker"
officecli add demo.docx /body --type paragraph --prop "text=Revenue held steady across all regions." --prop "preset=card"
officecli get demo.docx "/body/p[2]"
officecli close demo.docx
```

Actual terminal output — one command produced the whole card bundle (warm fill, 4-side + between amber border, keepLines, spacing):

```
/body/p[@paraId=00100002] (paragraph) "Revenue held steady across all regions." style=Normal spaceAfter=6pt keepLines=true fill=#FFF4E5 pbdr.top=single pbdr.top.sz=8 pbdr.top.color=#E6A23C pbdr.bottom=single pbdr.bottom.sz=8 pbdr.bottom.color=#E6A23C pbdr.left=single pbdr.left.sz=8 pbdr.left.color=#E6A23C pbdr.right=single pbdr.right.sz=8 pbdr.right.color=#E6A23C pbdr.between=single pbdr.between.sz=8 pbdr.between.color=#E6A23C ...
```

An unknown name errors listing the available presets (self-documenting); opening the doc in Word shows the styled card.

## Implementation

- New `WordHandler.StylePreset.cs`: six render-safe presets (solid fills only, no gradients). Paragraph-level keys go through `ApplyParagraphLevelProperty`, run-level keys through `ApplyRunFormatting` (existing runs + paragraph-mark rPr) — the exact paths a normal per-prop `set` uses, so nothing a preset requests can take a silent-degradation path.
- Table-row `preset=table-header` shades each cell (tcPr) + formats row runs.
- Hooks: `WordHandler.Add.Text.cs` (consume `preset` on add) and `WordHandler.Set.Element.cs` (`case "preset"` for paragraph + table-row set).
- Unknown preset errors list available names (self-documenting help path).

## Tests

- `dotnet build -c Release` — 0 errors.
- XLSX numeric-fit regression suite (local repo-untracked harness, per the maintainer's local-only test policy) — green.
- `dotnet publish -c Release` — single-file exe smoke OK; the demo above was produced with the built binary.
