### PR TITLE
feat(docx): chart sourceTable sugar

### DIFF
--- a/src/officecli/CommandBuilder.cs
+++ b/src/officecli/CommandBuilder.cs
@@ -1679,6 +1679,7 @@ static partial class CommandBuilder
         "axisPosition", "crosses", "crossesAt", "crossBetween", "axisOrientation", "logBase",
         "dispUnits", "labelOffset", "tickLabelSkip",
         "gridlines", "minorGridlines", "plotFill", "chartFill",
+        "sourceTable",
         "colors", "gradient", "gradients", "lineWidth", "lineDash",
         "marker", "markerSize", "transparency", "smooth", "showMarker",
         "scatterStyle", "radarStyle", "varyColors", "dispBlanksAs",

--- a/src/officecli/Handlers/Word/WordHandler.Add.Media.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Add.Media.cs
@@ -34,9 +34,41 @@ public partial class WordHandler
         var categories = Core.ChartHelper.ParseCategories(properties);
         var seriesData = Core.ChartHelper.ParseSeriesData(properties);
 
+        // ROUND-2: `sourceTable=<path>` sugar — pull categories + series from an
+        // existing table instead of hand-writing `data=Series:x,y`. Only fills
+        // the gaps when the caller did NOT already supply explicit data; an
+        // explicit `data=`/`seriesN=` always wins (it is the curated source).
+        // NOTE: distinct from the chart's built-in `datatable` prop (a boolean
+        // that toggles drawing the source data table under the chart).
+        if (properties.TryGetValue("sourcetable", out var tblPath) && !string.IsNullOrWhiteSpace(tblPath)
+            && (seriesData.Count == 0 || categories == null || categories.Length == 0))
+        {
+            var table = ResolveTableForChart(tblPath, out var resolveErr);
+            if (table == null)
+            {
+                throw new ArgumentException(
+                    $"sourceTable='{tblPath}' did not resolve to a table.{resolveErr}");
+            }
+            var (tblCategories, tblSeries, tblWarnings) = ExtractChartDataFromTable(table);
+            if (seriesData.Count == 0 && tblSeries.Count > 0)
+                seriesData = tblSeries;
+            if (seriesData.Count == 0 && tblSeries.Count == 0)
+                throw new ArgumentException(
+                    $"sourceTable='{tblPath}' resolved to a table but no numeric values could be parsed. " +
+                    "Check the table has numeric data cells (see the sourceTable recipe in the docx-design skill).");
+            if ((categories == null || categories.Length == 0) && tblCategories != null)
+                categories = tblCategories;
+            foreach (var w in tblWarnings)
+                LastAddWarnings.Add(w);
+            // Consume the sourceTable key so downstream chart builders (which
+            // iterate props for deferred/unknown keys) never see it.
+            properties.Remove("sourceTable");
+            properties.Remove("sourcetable");
+        }
+
         if (seriesData.Count == 0)
             throw new ArgumentException("Chart requires data. Use: data=\"Series1:1,2,3;Series2:4,5,6\" " +
-                "or series1=\"Revenue:100,200,300\"");
+                "or series1=\"Revenue:100,200,300\" or sourceTable=/body/tbl[1]");
 
         // Dimensions (default: 15cm x 10cm)
         long chartCx = properties.TryGetValue("width", out var chartWStr) ? ParseEmu(chartWStr) : 5400000;

--- a/src/officecli/Handlers/Word/WordHandler.Helpers.ChartTable.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Helpers.ChartTable.cs
@@ -8,17 +8,24 @@ namespace OfficeCli.Handlers;
 
 public partial class WordHandler
 {
-    // Convention for `add --type chart --prop dataTable=<tablePath>`:
+    // Convention for `add --type chart --prop sourceTable=<tablePath>`:
     //   - The FIRST data row is the HEADER: each column (from index 1 on) becomes
     //     one series whose name is that column's header cell; index 0 is the
-    //     categories label header and is not a series.
+    //     categories label header and is not a series. Only the SERIES columns
+    //     (1..) vote on header detection — a label-first data column (e.g. a
+    //     headerless "Q1|100" table) must not be mistaken for a header row.
     //   - The FIRST data COLUMN (col 0) under the header is the categories axis
     //     (row labels). Every remaining column is a series of numeric values.
-    //   - If the first row is ENTIRELY numeric (no real header), the table is
-    //     treated as headerless: each column is a series named "Series N", and
-    //     the categories fall back to first column if non-numeric else 1..N.
-    //   - Cells that cannot parse as a number are skipped with a warning — never
-    //     aborts, so a mixed numeric/label table still yields the numeric points.
+    //   - If no series column carries a header label, the table is treated as
+    //     headerless: when col 0 is entirely non-numeric it becomes the
+    //     categories axis and columns 1.. become "Series N"; otherwise every
+    //     column is a series named "Series N" and categories fall back to 1..N.
+    //   - Extraction is ROW-ATOMIC: a data row contributes its category label
+    //     AND all of its series values, or nothing at all. Skipping a bad cell
+    //     while keeping its label would shift categories against values, so a
+    //     row with any non-numeric series cell is dropped whole with a warning
+    //     — never aborts, so a mixed numeric/label table still charts the
+    //     clean rows.
     private static (string[]? Categories, List<(string name, double[] values)> Series, List<string> Warnings)
         ExtractChartDataFromTable(Table tbl)
     {
@@ -48,55 +55,105 @@ public partial class WordHandler
         bool IsNumericCell(string s)
             => TryParseNumeric(s, out _);
 
-        // Heuristic header: row 0 is a header only when it contains at least one
-        // non-numeric label — i.e. it is NOT entirely numeric, AND it has more
-        // than the first cell filled. A fully-numeric first row is data.
+        // Heuristic header: row 0 is a header only when at least one SERIES
+        // column (index 1 on) carries a non-numeric label. Col 0 is the
+        // categories corner and never votes — otherwise a headerless table
+        // like "Q1|100 / Q2|150" would eat its first data row as a header.
         var firstRow = rows[0];
         var hasHeader = firstRow.Count > 1
-            && firstRow.Any(c => !string.IsNullOrWhiteSpace(c) && !IsNumericCell(c));
+            && firstRow.Skip(1).Any(c => !string.IsNullOrWhiteSpace(c) && !IsNumericCell(c));
 
         var series = new List<(string name, double[] values)>();
         List<string>? categories = null;
 
+        // Ragged-row-safe cell read: a short row yields "" (non-numeric) for
+        // missing cells instead of throwing IndexOutOfRangeException.
+        static string CellAt(List<string> row, int ci)
+            => ci < row.Count ? row[ci] : "";
+
         if (hasHeader)
         {
-            // Series = columns 1..; categories = column 0 beneath the header.
-            categories = new List<string>();
+            // Series = columns 1.., named by the header row; categories = col 0.
+            var names = new List<string>();
             for (int ci = 1; ci < colCount; ci++)
-            {
-                var name = ci < firstRow.Count && !string.IsNullOrWhiteSpace(firstRow[ci])
+                names.Add(ci < firstRow.Count && !string.IsNullOrWhiteSpace(firstRow[ci])
                     ? firstRow[ci].Trim()
-                    : $"Series {ci}";
-                var vals = new List<double>();
-                for (int ri = 1; ri < rows.Count; ri++)
-                {
-                    var cellText = ri < rows[ri].Count ? rows[ri][ci] : "";
-                    if (TryParseNumeric(cellText, out var d)) vals.Add(d);
-                    else if (ci == 0) { /* categories column */ }
-                }
-                series.Add((name, vals.ToArray()));
-            }
-            // Categories labels: column 0 of each data row (non-empty).
+                    : $"Series {ci}");
+            var valLists = names.Select(_ => new List<double>()).ToList();
+            categories = new List<string>();
             for (int ri = 1; ri < rows.Count; ri++)
             {
-                var label = ri < rows[ri].Count ? rows[ri][0] : "";
-                if (!string.IsNullOrWhiteSpace(label)) categories.Add(label.Trim());
+                var row = rows[ri];
+                // Row-atomic: parse every series cell first; a single bad cell
+                // drops the whole row (label included) with a warning, so the
+                // categories array can never drift out of alignment with values.
+                var parsed = new double[names.Count];
+                var ok = true;
+                for (int k = 0; k < names.Count; k++)
+                {
+                    var cellText = CellAt(row, k + 1);
+                    if (!TryParseNumeric(cellText, out parsed[k]))
+                    {
+                        warnings.Add(
+                            $"sourceTable: skipped row {ri + 1} " +
+                            $"(column {k + 2} value '{cellText}' is not numeric); " +
+                            "row dropped so categories stay aligned with values.");
+                        ok = false;
+                        break;
+                    }
+                }
+                if (!ok) continue;
+                categories.Add(CellAt(row, 0).Trim());
+                for (int k = 0; k < names.Count; k++) valLists[k].Add(parsed[k]);
             }
+            for (int k = 0; k < names.Count; k++) series.Add((names[k], valLists[k].ToArray()));
         }
         else
         {
-            // Headerless: every column is a series (default names); categories
-            // derive from column 0 when it is non-numeric, else 1..N.
-            for (int ci = 0; ci < colCount; ci++)
+            // Headerless: when col 0 is entirely non-numeric (label column) it
+            // becomes the categories axis and columns 1.. become the series;
+            // otherwise every column is a numeric series and categories stay
+            // null (the chart builder falls back to 1..N).
+            var col0IsLabels = colCount > 1
+                && rows.All(r => r.Count == 0 || !IsNumericCell(r[0]));
+            var firstDataCol = col0IsLabels ? 1 : 0;
+            var names = new List<string>();
+            for (int ci = firstDataCol; ci < colCount; ci++)
+                names.Add($"Series {ci - firstDataCol + 1}");
+            var valLists = names.Select(_ => new List<double>()).ToList();
+            var headerlessCats = col0IsLabels ? new List<string>() : null;
+            for (int ri = 0; ri < rows.Count; ri++)
             {
-                var vals = new List<double>();
-                for (int ri = 0; ri < rows.Count; ri++)
+                var row = rows[ri];
+                var parsed = new double[names.Count];
+                var ok = true;
+                for (int k = 0; k < names.Count; k++)
                 {
-                    var cellText = ri < rows[ri].Count ? rows[ri][ci] : "";
-                    if (TryParseNumeric(cellText, out var d)) vals.Add(d);
+                    var cellText = CellAt(row, firstDataCol + k);
+                    if (!TryParseNumeric(cellText, out parsed[k]))
+                    {
+                        warnings.Add(
+                            $"sourceTable: skipped row {ri + 1} " +
+                            $"(column {firstDataCol + k + 1} value '{cellText}' is not numeric); " +
+                            "row dropped so categories stay aligned with values.");
+                        ok = false;
+                        break;
+                    }
                 }
-                series.Add(($"Series {ci + 1}", vals.ToArray()));
+                if (!ok) continue;
+                headerlessCats?.Add(CellAt(row, 0).Trim());
+                for (int k = 0; k < names.Count; k++) valLists[k].Add(parsed[k]);
             }
+            // Drop series with no surviving points (e.g. an all-label column);
+            // an empty series would render as a phantom legend entry.
+            for (int k = 0; k < names.Count; k++)
+            {
+                if (valLists[k].Count == 0)
+                    warnings.Add($"sourceTable: column {firstDataCol + k + 1} has no numeric values; dropped from the chart.");
+                else
+                    series.Add((names[k], valLists[k].ToArray()));
+            }
+            categories = headerlessCats;
         }
 
         return (categories?.Count > 0 ? categories.ToArray() : null, series, warnings);

--- a/src/officecli/Handlers/Word/WordHandler.Helpers.ChartTable.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Helpers.ChartTable.cs
@@ -1,0 +1,142 @@
+// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Globalization;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeCli.Handlers;
+
+public partial class WordHandler
+{
+    // Convention for `add --type chart --prop dataTable=<tablePath>`:
+    //   - The FIRST data row is the HEADER: each column (from index 1 on) becomes
+    //     one series whose name is that column's header cell; index 0 is the
+    //     categories label header and is not a series.
+    //   - The FIRST data COLUMN (col 0) under the header is the categories axis
+    //     (row labels). Every remaining column is a series of numeric values.
+    //   - If the first row is ENTIRELY numeric (no real header), the table is
+    //     treated as headerless: each column is a series named "Series N", and
+    //     the categories fall back to first column if non-numeric else 1..N.
+    //   - Cells that cannot parse as a number are skipped with a warning — never
+    //     aborts, so a mixed numeric/label table still yields the numeric points.
+    private static (string[]? Categories, List<(string name, double[] values)> Series, List<string> Warnings)
+        ExtractChartDataFromTable(Table tbl)
+    {
+        var warnings = new List<string>();
+
+        // Materialize the table into a rectangular string grid, so the
+        // header/column/row heuristics operate on stable positions.
+        var rows = new List<List<string>>();
+        foreach (var row in tbl.Elements<TableRow>())
+        {
+            var cells = new List<string>();
+            foreach (var cell in row.Elements<TableCell>())
+            {
+                var para = cell.Elements<Paragraph>().FirstOrDefault();
+                cells.Add(para != null ? GetParagraphText(para) : "");
+            }
+            if (cells.Count > 0 || rows.Count == 0)
+                rows.Add(cells);
+        }
+        if (rows.Count == 0)
+            return (null, new List<(string, double[])>{ }, warnings);
+
+        var colCount = rows.Max(r => r.Count);
+        if (colCount == 0)
+            return (null, new List<(string, double[])>{ }, warnings);
+
+        bool IsNumericCell(string s)
+            => TryParseNumeric(s, out _);
+
+        // Heuristic header: row 0 is a header only when it contains at least one
+        // non-numeric label — i.e. it is NOT entirely numeric, AND it has more
+        // than the first cell filled. A fully-numeric first row is data.
+        var firstRow = rows[0];
+        var hasHeader = firstRow.Count > 1
+            && firstRow.Any(c => !string.IsNullOrWhiteSpace(c) && !IsNumericCell(c));
+
+        var series = new List<(string name, double[] values)>();
+        List<string>? categories = null;
+
+        if (hasHeader)
+        {
+            // Series = columns 1..; categories = column 0 beneath the header.
+            categories = new List<string>();
+            for (int ci = 1; ci < colCount; ci++)
+            {
+                var name = ci < firstRow.Count && !string.IsNullOrWhiteSpace(firstRow[ci])
+                    ? firstRow[ci].Trim()
+                    : $"Series {ci}";
+                var vals = new List<double>();
+                for (int ri = 1; ri < rows.Count; ri++)
+                {
+                    var cellText = ri < rows[ri].Count ? rows[ri][ci] : "";
+                    if (TryParseNumeric(cellText, out var d)) vals.Add(d);
+                    else if (ci == 0) { /* categories column */ }
+                }
+                series.Add((name, vals.ToArray()));
+            }
+            // Categories labels: column 0 of each data row (non-empty).
+            for (int ri = 1; ri < rows.Count; ri++)
+            {
+                var label = ri < rows[ri].Count ? rows[ri][0] : "";
+                if (!string.IsNullOrWhiteSpace(label)) categories.Add(label.Trim());
+            }
+        }
+        else
+        {
+            // Headerless: every column is a series (default names); categories
+            // derive from column 0 when it is non-numeric, else 1..N.
+            for (int ci = 0; ci < colCount; ci++)
+            {
+                var vals = new List<double>();
+                for (int ri = 0; ri < rows.Count; ri++)
+                {
+                    var cellText = ri < rows[ri].Count ? rows[ri][ci] : "";
+                    if (TryParseNumeric(cellText, out var d)) vals.Add(d);
+                }
+                series.Add(($"Series {ci + 1}", vals.ToArray()));
+            }
+        }
+
+        return (categories?.Count > 0 ? categories.ToArray() : null, series, warnings);
+    }
+
+    // Lenient numeric parse: strips thousands commas, a leading currency symbol,
+    // and a trailing '%' (keeping the raw magnitude), then parses as invariant
+    // double. False for empty / non-numeric — callers warn+skip.
+    private static bool TryParseNumeric(string raw, out double value)
+    {
+        value = 0;
+        if (string.IsNullOrWhiteSpace(raw)) return false;
+        var s = raw.Trim();
+        s = s.Replace(",", "").Replace("$", "").Replace("¥", "").Replace("%", "");
+        if (s.Length == 0) return false;
+        return double.TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands | NumberStyles.AllowCurrencySymbol,
+            CultureInfo.InvariantCulture, out value);
+    }
+
+    // Resolve a document-rooted table path (`/body/t[1]`, `/body/t[2]`) to the
+    // Table element, producing a human-readable context on failure (mirrors the
+    // Set path's error shape). Returns null when unresolvable; `resolveErr`
+    // carries the path-not-found detail.
+    private Table? ResolveTableForChart(string tablePath, out string resolveErr)
+    {
+        resolveErr = "";
+        if (string.IsNullOrWhiteSpace(tablePath)) return null;
+        Table? table;
+        try
+        {
+            var parts = ParsePath(tablePath);
+            table = NavigateToElement(parts, out var ctx) as Table;
+            if (table == null)
+                resolveErr = ctx != null ? $"Path resolved but is not a table. {ctx}" : "";
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        {
+            table = null;
+            resolveErr = $" Path parse error: {ex.Message}";
+        }
+        return table;
+    }
+}

--- a/tests/OfficeCli.NumericFit.Tests/Program.cs
+++ b/tests/OfficeCli.NumericFit.Tests/Program.cs
@@ -16,6 +16,7 @@ var date1904Path = Path.Combine(Path.GetTempPath(), $"officecli-numeric-fit-1904
 var generalPath = Path.Combine(Path.GetTempPath(), $"officecli-general-precision-{Guid.NewGuid():N}.xlsx");
 var stylelessPath = Path.Combine(Path.GetTempPath(), $"officecli-general-styleless-{Guid.NewGuid():N}.xlsx");
 var chartDocxPath = Path.Combine(Path.GetTempPath(), $"officecli-tablechart-{Guid.NewGuid():N}.docx");
+var chartEdgeDocxPath = Path.Combine(Path.GetTempPath(), $"officecli-tablechart-edge-{Guid.NewGuid():N}.docx");
 try
 {
     CreateStandardFixture(standardPath);
@@ -35,6 +36,10 @@ try
     CreateBlankDocx(chartDocxPath);
     VerifyDocxTableToChart(chartDocxPath);
     Console.WriteLine("TABLE->CHART DOCX sourceTable sugar tests passed.");
+
+    CreateBlankDocx(chartEdgeDocxPath);
+    VerifyDocxTableToChartEdgeCases(chartEdgeDocxPath);
+    Console.WriteLine("TABLE->CHART DOCX sourceTable edge-case tests passed.");
 }
 finally
 {
@@ -43,6 +48,7 @@ finally
     if (File.Exists(generalPath)) File.Delete(generalPath);
     if (File.Exists(stylelessPath)) File.Delete(stylelessPath);
     if (File.Exists(chartDocxPath)) File.Delete(chartDocxPath);
+    if (File.Exists(chartEdgeDocxPath)) File.Delete(chartEdgeDocxPath);
 }
 
 static void VerifyStandardWorkbook(string path)
@@ -599,6 +605,7 @@ static void VerifyDocxTableToChart(string path)
 {
     // Create a table with a header row (Quarter) + one numeric column (Revenue),
     // then a chart whose categories/series come from the table via dataTable=.
+    string chartPath;
     using (var handler = new WordHandler(path, editable: true))
     {
         // Table `data=` parse grid: ',' per cell, ';' per row (DelimitedText
@@ -609,7 +616,7 @@ static void VerifyDocxTableToChart(string path)
             ["header"] = "true",
         });
         // Windowed: blank seed paragraph precedes the table, so /body/tbl[1] is it.
-        var chartPath = handler.Add("/body", "chart", null, new Dictionary<string, string>
+        chartPath = handler.Add("/body", "chart", null, new Dictionary<string, string>
         {
             ["sourceTable"] = "/body/tbl[1]",
             ["chartType"] = "column",
@@ -622,4 +629,82 @@ static void VerifyDocxTableToChart(string path)
     // real chart, not a silent no-op).
     Assert(doc.MainDocumentPart!.ChartParts.Any(),
         "dataTable chart should create a ChartPart in the package");
+
+    // Full grid must survive: the old `ri < rows[ri].Count` guard dropped every
+    // data row past the first (only Q1/100 reached the chart).
+    using (var handler = new WordHandler(path, editable: false))
+    {
+        var node = handler.Query("chart").First(n => n.Path == chartPath);
+        Assert(node.Format.TryGetValue("series1", out var s1) && s1?.ToString() == "Revenue:100,150,200,250",
+            "header table should chart all four quarters, got series1=" + (s1?.ToString() ?? "<none>"));
+        Assert(node.Format.TryGetValue("categories", out var cats) && cats?.ToString() == "Q1,Q2,Q3,Q4",
+            "header table categories should be Q1..Q4, got " + (cats?.ToString() ?? "<none>"));
+    }
+}
+
+static void VerifyDocxTableToChartEdgeCases(string path)
+{
+    using (var handler = new WordHandler(path, editable: true))
+    {
+        // 1. Ragged table: a short row must not throw IndexOutOfRangeException.
+        handler.Add("/body", "table", null, new Dictionary<string, string>
+        {
+            ["data"] = "Item,Sales;OnlyLabel;B,200",
+        });
+        var raggedChart = handler.Add("/body", "chart", null, new Dictionary<string, string>
+        {
+            ["sourceTable"] = "/body/tbl[1]",
+            ["chartType"] = "column",
+        });
+        Assert(raggedChart.StartsWith("/chart["), "ragged-table chart should resolve, got " + raggedChart);
+
+        // 2. Headerless label-first-column table: "Q1|100" rows are DATA, not a
+        // header — col 0 becomes categories, the numeric column the series.
+        handler.Add("/body", "table", null, new Dictionary<string, string>
+        {
+            ["data"] = "Q1,100;Q2,150;Q3,200",
+        });
+        var bareChart = handler.Add("/body", "chart", null, new Dictionary<string, string>
+        {
+            ["sourceTable"] = "/body/tbl[2]",
+            ["chartType"] = "column",
+        });
+        Assert(bareChart.StartsWith("/chart["), "headerless chart should resolve, got " + bareChart);
+
+        // 3. Stray non-numeric cell: the bad row drops whole (label included) so
+        // categories can never drift out of alignment with values.
+        handler.Add("/body", "table", null, new Dictionary<string, string>
+        {
+            ["data"] = "Item,Sales;A,10;B,N/A;C,30",
+        });
+        var gapChart = handler.Add("/body", "chart", null, new Dictionary<string, string>
+        {
+            ["sourceTable"] = "/body/tbl[3]",
+            ["chartType"] = "column",
+        });
+        Assert(gapChart.StartsWith("/chart["), "gap-table chart should resolve, got " + gapChart);
+
+        var charts = handler.Query("chart").ToDictionary(n => n.Path);
+        var ragged = charts[raggedChart];
+        Assert(ragged.Format.TryGetValue("series1", out var rs) && rs?.ToString() == "Sales:200",
+            "ragged table should chart only the complete row, got series1=" + (rs?.ToString() ?? "<none>"));
+        Assert(ragged.Format.TryGetValue("categories", out var rc) && rc?.ToString() == "B",
+            "ragged table categories should be just B, got " + (rc?.ToString() ?? "<none>"));
+
+        var bare = charts[bareChart];
+        Assert(bare.Format.TryGetValue("series1", out var bs) && bs?.ToString() == "Series 1:100,150,200",
+            "headerless table should keep all rows as data, got series1=" + (bs?.ToString() ?? "<none>"));
+        Assert(bare.Format.TryGetValue("categories", out var bc) && bc?.ToString() == "Q1,Q2,Q3",
+            "headerless col 0 should become categories, got " + (bc?.ToString() ?? "<none>"));
+
+        var gap = charts[gapChart];
+        Assert(gap.Format.TryGetValue("series1", out var gs) && gs?.ToString() == "Sales:10,30",
+            "N/A row should drop its values, got series1=" + (gs?.ToString() ?? "<none>"));
+        Assert(gap.Format.TryGetValue("categories", out var gc) && gc?.ToString() == "A,C",
+            "N/A row should drop its label too (alignment), got " + (gc?.ToString() ?? "<none>"));
+    }
+
+    using var doc = WordprocessingDocument.Open(path, false);
+    Assert(doc.MainDocumentPart!.ChartParts.Count() == 3,
+        "edge-case docx should contain three ChartParts");
 }

--- a/tests/OfficeCli.NumericFit.Tests/Program.cs
+++ b/tests/OfficeCli.NumericFit.Tests/Program.cs
@@ -6,6 +6,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeCli.Core;
 using OfficeCli.Handlers;
+using W = DocumentFormat.OpenXml.Wordprocessing;
 
 const string NumericOverflowSubtype = "numeric_overflow";
 const string GeneralPrecisionSubtype = "general_precision_loss";
@@ -14,6 +15,7 @@ var standardPath = Path.Combine(Path.GetTempPath(), $"officecli-numeric-fit-{Gui
 var date1904Path = Path.Combine(Path.GetTempPath(), $"officecli-numeric-fit-1904-{Guid.NewGuid():N}.xlsx");
 var generalPath = Path.Combine(Path.GetTempPath(), $"officecli-general-precision-{Guid.NewGuid():N}.xlsx");
 var stylelessPath = Path.Combine(Path.GetTempPath(), $"officecli-general-styleless-{Guid.NewGuid():N}.xlsx");
+var chartDocxPath = Path.Combine(Path.GetTempPath(), $"officecli-tablechart-{Guid.NewGuid():N}.docx");
 try
 {
     CreateStandardFixture(standardPath);
@@ -29,6 +31,10 @@ try
     VerifyStylelessWorkbook(stylelessPath);
 
     Console.WriteLine("XLSX numeric-fit issue tests passed.");
+
+    CreateBlankDocx(chartDocxPath);
+    VerifyDocxTableToChart(chartDocxPath);
+    Console.WriteLine("TABLE->CHART DOCX sourceTable sugar tests passed.");
 }
 finally
 {
@@ -36,6 +42,7 @@ finally
     if (File.Exists(date1904Path)) File.Delete(date1904Path);
     if (File.Exists(generalPath)) File.Delete(generalPath);
     if (File.Exists(stylelessPath)) File.Delete(stylelessPath);
+    if (File.Exists(chartDocxPath)) File.Delete(chartDocxPath);
 }
 
 static void VerifyStandardWorkbook(string path)
@@ -578,4 +585,41 @@ static void VerifyStylelessWorkbook(string path)
             .Where(issue => issue.Subtype == GeneralPrecisionSubtype)
             .Select(issue => issue.Path),
         "styleless workbook is all-General");
+}
+
+static void CreateBlankDocx(string path)
+{
+    using var doc = WordprocessingDocument.Create(path, WordprocessingDocumentType.Document);
+    var mainPart = doc.AddMainDocumentPart();
+    mainPart.Document = new W.Document(new W.Body(new W.Paragraph()));
+    mainPart.Document.Save();
+}
+
+static void VerifyDocxTableToChart(string path)
+{
+    // Create a table with a header row (Quarter) + one numeric column (Revenue),
+    // then a chart whose categories/series come from the table via dataTable=.
+    using (var handler = new WordHandler(path, editable: true))
+    {
+        // Table `data=` parse grid: ',' per cell, ';' per row (DelimitedText
+        // falls back to `,`/`;` because the value is not a resolvable file src).
+        handler.Add("/body", "table", null, new Dictionary<string, string>
+        {
+            ["data"] = "Quarter,Revenue;Q1,100;Q2,150;Q3,200;Q4,250",
+            ["header"] = "true",
+        });
+        // Windowed: blank seed paragraph precedes the table, so /body/tbl[1] is it.
+        var chartPath = handler.Add("/body", "chart", null, new Dictionary<string, string>
+        {
+            ["sourceTable"] = "/body/tbl[1]",
+            ["chartType"] = "column",
+        });
+        Assert(chartPath.StartsWith("/chart["), "sourceTable chart should resolve to a /chart[N] path, got " + chartPath);
+    }
+
+    using var doc = WordprocessingDocument.Open(path, false);
+    // The chart part must be physically present (the dataTable sugar produced a
+    // real chart, not a silent no-op).
+    Assert(doc.MainDocumentPart!.ChartParts.Any(),
+        "dataTable chart should create a ChartPart in the package");
 }


### PR DESCRIPTION
## What

add --type chart --prop sourceTable=<tablePath> reads an existing table's
cells and auto-builds categories + series (header row -> series names,
first column -> categories, headerless numeric tables fall back to
Series N). Explicit data=/seriesN= still wins. Distinct from the built-in
chart `datatable` boolean prop.

## Why

Building charts from an existing table previously required hand-extracting
cells into `data=` / `seriesN=` props. The sugar lets an agent point at
a table path and get a header-aware chart in one command.

## Implementation

- New `WordHandler.Helpers.ChartTable.cs` (ExtractChartDataFromTable +
  ResolveTableForChart); wired into AddChart; registered `sourceTable` in
  KnownProps.
- Extraction rules (see the method's comment block):
  - Header detection only considers series columns (1..) — a headerless
    label-first-column table (`Q1|100`) keeps all rows as data, with col 0
    as categories when entirely non-numeric.
  - Ragged-row-safe cell reads (missing cells read as empty, never throw).
  - Row-atomic: a row with any non-numeric series cell drops whole (label
    included) with a warning, so categories stay aligned with values.

## Tests

table->chart sourceTable sugar green (header -> series names, first column
-> categories, headerless fallback); edge-case suite green (ragged short
row, headerless Q1 table, N/A-row alignment); full regression green;
Release single-file publish smoke-verified end-to-end (table->chart renders
all four quarters from header).

## How to verify (Rule 2: terminal output + command sequence)

```bash
officecli create demo.docx
officecli add demo.docx "/body" --type table --prop data="Quarter,Revenue;Q1,100;Q2,150;Q3,200;Q4,250" --prop header=true
# => Added table at /body/tbl[1]

officecli add demo.docx "/body" --type chart --prop sourceTable="/body/tbl[1]" --prop chartType=column
# => Added chart at /chart[1]

officecli query demo.docx "chart" --json
# => chartType "column", seriesCount 1, series1 "Revenue:100,150,200,250", categories "Q1,Q2,Q3,Q4"
```

Real terminal output (from the published single-file exe):

```
Added table at /body/tbl[1]
WARNING: UNSUPPORTED props on /body/tbl[1]: header (not supported)

Added chart at /chart[1]

{
  "path": "/chart[1]",
  "type": "chart",
  "format": {
    "chartType": "column",
    "seriesCount": 1,
    "series1": "Revenue:100,150,200,250",
    "categories": "Q1,Q2,Q3,Q4"
  }
}
```

Closes: N/A (atomic PR per CONTRIBUTING.md)
