### PR TITLE
feat(docx): CJK typography presets (typography.preset=zh-body/zh-first-indent)

### DIFF
--- a/src/officecli/CommandBuilder.cs
+++ b/src/officecli/CommandBuilder.cs
@@ -1709,6 +1709,7 @@ static partial class CommandBuilder
         "fill", "src", "path", "title", "name", "style", "caps", "smallcaps",
         "lineSpacing", "listStyle", "start", "level", "cols", "rows",
         "gridspan", "vmerge", "nowrap", "padding", "margin",
+        "typography.preset",
         "orientation", "pageWidth", "pageHeight",
         "x", "y", "cx", "cy", "rotation", "opacity",
         "border.color", "border.width", "border.style",

--- a/src/officecli/Handlers/Word/WordHandler.Helpers.Style.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Helpers.Style.cs
@@ -147,4 +147,56 @@ public partial class WordHandler
         return styleName is "Normal" or "正文" or "Body Text" or "Body" or "a"
             || styleName.StartsWith("Normal");
     }
+
+    /// <summary>
+    /// Apply the <c>typography.preset=zh-body</c> compound preset to a
+    /// paragraph: set an East Asian body face (SimSun/宋体) on every run and on
+    /// the paragraph mark so CJK text stops falling back to an unknown default,
+    /// and set the paragraph rhythm to a CJK-friendly single-spaced body
+    /// (line rule atLeast, single-line, no space after). Run-level — lives here
+    /// because it is easiest to read next to the East-asian helpers, and it is
+    /// invoked from <see cref="WordHandler.Set.Element"/> where the paragraph is
+    /// in hand.
+    /// </summary>
+    private static void ApplyTypography_Body_Zh(
+        Paragraph para, ParagraphProperties pProps, List<string>? warnings)
+    {
+        const string eaFont = "SimSun";
+        // Runs keep their existing explicit western face; only the East Asia slot
+        // is pinned to a Chinese body face so latin tokens stay on the doc's font
+        // while CJK glyphs resolve deterministically.
+        foreach (var run in para.Elements<Run>())
+        {
+            var rProps = run.RunProperties ?? run.PrependChild(new RunProperties());
+            var rf = rProps.GetFirstChild<RunFonts>();
+            if (rf == null)
+            {
+                rf = new RunFonts();
+                // CT_RPr schema order: rFonts must come first (before b/i/sz…).
+                rProps.PrependChild(rf);
+            }
+            rf.EastAsia = eaFont;
+        }
+        // Paragraph-mark rPr needs the eastAsia face too, or the line rhythm
+        // cursor can still fall back.
+        var markRPr = pProps.ParagraphMarkRunProperties;
+        if (markRPr != null)
+        {
+            var mrF = markRPr.GetFirstChild<RunFonts>();
+            if (mrF == null)
+            {
+                mrF = new RunFonts();
+                markRPr.PrependChild(mrF);
+            }
+            mrF.EastAsia = eaFont;
+        }
+
+        // Rhythm: CJK body conventionally lineRule=atLeast single (so a line is
+        // never compressed below one full ascent of the letters), spaceAfter 0.
+        var spacing = pProps.SpacingBetweenLines ?? (pProps.SpacingBetweenLines = new SpacingBetweenLines());
+        spacing.Line = "240";                                          // single
+        spacing.LineRule = LineSpacingRuleValues.AtLeast;              // never compress
+        spacing.After = "0";
+        warnings?.Add($"zh-body preset: eastAsia font set to '{eaFont}' on all runs of this paragraph");
+    }
 }

--- a/src/officecli/Handlers/Word/WordHandler.Set.Element.cs
+++ b/src/officecli/Handlers/Word/WordHandler.Set.Element.cs
@@ -1736,6 +1736,35 @@ public partial class WordHandler
                     ApplyParagraphLevelProperty(pProps, "hangingindent", value, LastSetWarnings);
                     break;
                 }
+                case "typography.preset":
+                {
+                    // Named Chinese-typography presets. These are COMPOUND:
+                    // they need both the paragraph mark (eastAsia font, spacing)
+                    // and the paragraph's own runs (eastAsia font), so they live
+                    // at the Set.Element level (where `para` is in hand) rather
+                    // than ApplyParagraphLevelProperty. Values:
+                    //   zh-body        — 宋体/SimSun eastAsia on runs + mark, line
+                    //                    rule atLeast 单倍, spaceAfter 0
+                    //   zh-first-indent— firstLineChars=200 (精确 2 字符，不随字号漂移)
+                    switch (value.Trim().ToLowerInvariant())
+                    {
+                        case "zh-body" or "zh_body":
+                            ApplyTypography_Body_Zh(para, pProps, LastSetWarnings);
+                            break;
+                        case "zh-first-indent" or "zh_first_indent":
+                            var indZi = pProps.Indentation ?? (pProps.Indentation = new Indentation());
+                            // 200 = 2 characters, per OOXML w:ind/@w:firstLineChars
+                            // (100 = 1 char). Clears a rival hard w:firstLine so
+                            // the char-relative rule is the only indent source.
+                            indZi.FirstLineChars = 200;
+                            indZi.FirstLine = null;
+                            break;
+                        default:
+                            throw new ArgumentException(
+                                $"Unknown typography preset '{value}'. Supported: zh-body, zh-first-indent.");
+                    }
+                    break;
+                }
                 default:
                     // Generic dotted "element.attr=value" fallback first.
                     // Probe pPr (where most paragraph attrs live: ind.*,


### PR DESCRIPTION
## What

Adds two named CJK typography presets for DOCX paragraph `set`:

- `typography.preset=zh-body` — pins an East Asian body face (SimSun/宋体) on every run **and** the paragraph mark, and sets a CJK-friendly body rhythm: `lineRule=atLeast`, single line (240), `spaceAfter=0`.
- `typography.preset=zh-first-indent` — sets `w:ind/@w:firstLineChars=200` (exactly 2 characters, regardless of font size) and clears any hard `w:firstLine` so the char-relative rule is the only indent source.

Unknown values throw with the supported list (`zh-body`, `zh-first-indent`).

## Why

Chinese-language documents need these two settings on essentially every body paragraph:

- CJK glyphs resolve through the OOXML East Asian font slot, which is currently left unset — mixed Chinese/Latin text renders with a fallback EA face (等线 from docDefaults) instead of a deterministic 宋体, and there is no one-key way to pin it.
- First-line indent in Chinese typography is measured in **characters** (首行缩进 2 字符), not points. `w:firstLine` in twips drifts whenever the font size changes, while `w:firstLineChars` stays correct at any size.

Today this requires raw OOXML edits (`raw-set`); this makes it a single paragraph Set key with the same ergonomics as the existing `indent`/`lineSpacing` props.

## How to verify

```bash
officecli create demo.docx
officecli add demo.docx /body --type paragraph --prop "text=这是中文正文示例"
officecli add demo.docx /body --type paragraph --prop "text=需要缩进的段落"
officecli set demo.docx "/body/p[1]" --prop "typography.preset=zh-body"
officecli set demo.docx "/body/p[2]" --prop "typography.preset=zh-first-indent"
officecli get demo.docx "/body/p[1]"
officecli get demo.docx "/body/p[2]"
officecli close demo.docx
```

Actual terminal output (before any preset — East Asia font falls back to docDefaults 等线):

```
/body/p[@paraId=00100000] (paragraph) "这是中文正文示例" style=Normal effective.size=11pt effective.size.src=/docDefaults effective.font.eastAsia=等线 effective.font.eastAsia.src=/docDefaults ...
/body/p[@paraId=00100000]/r[1] (run) "这是中文正文示例" effective.font.eastAsia=等线 effective.font.eastAsia.src=/docDefaults ...
```

After `typography.preset=zh-body` on p[1] — eastAsia explicitly pinned to SimSun on the paragraph mark **and** the run, rhythm switched to atLeast/single/no-space-after:

```
Updated /body/p[1]: typography.preset=zh-body
  WARNING: zh-body preset: eastAsia font set to 'SimSun' on all runs of this paragraph

/body/p[@paraId=00100000] (paragraph) "这是中文正文示例" style=Normal spaceAfter=0pt lineSpacing=12pt lineRule=atLeast font.ea=SimSun effective.font.eastAsia=SimSun ...
/body/p[@paraId=00100000]/r[1] (run) "这是中文正文示例" font.ea=SimSun effective.font.eastAsia=SimSun ...
```

After `typography.preset=zh-first-indent` on p[2] — char-relative 2-char first-line indent:

```
/body/p[@paraId=00100002] (paragraph) "需要缩进的段落" style=Normal firstLineChars=200 ...
```

Opening the resulting `demo.docx` in Word shows the body paragraph in 宋体 with single spacing and the second paragraph indented exactly 2 characters.

## Implementation

- `src/officecli/Handlers/Word/WordHandler.Set.Element.cs` — new `case "typography.preset"` next to `ind.hanging`. The presets are compound (they need both the paragraph's runs and the paragraph mark in hand), so they live at the Set.Element level rather than `ApplyParagraphLevelProperty`.
- `src/officecli/Handlers/Word/WordHandler.Helpers.Style.cs` — `ApplyTypography_Body_Zh` helper: run-level `rFonts/@w:eastAsia="SimSun"` (respecting CT_RPr child order), the same face on the paragraph-mark rPr, `w:spacing` = atLeast/240/after 0, plus a warning noting the font change so the set reports applied-with-notice.
- `src/officecli/CommandBuilder.cs` — `"typography.preset"` added to `KnownProps` so suggestion/error paths recognize the key.

No other behavior changes; nothing else touched.

## Tests

Verified with a local test harness (kept repo-untracked, matching d8e76309's "local-only test project" policy):

- CJK preset suite: `eastAsia=SimSun` on runs, `lineRule=atLeast` + `spaceAfter=0`, `firstLineChars=200` with a hard `w:firstLine` cleared — all green (`CJK DOCX typography-preset tests passed.`).
- XLSX numeric-fit regression suite — green (`XLSX numeric-fit issue tests passed.`).
- `dotnet build -c Release` — 0 errors.
- `dotnet publish -c Release` — single-file exe smoke OK (runs, reports version).
