### PR TITLE
fix(pptx): gradient comma stop spelling silently degraded to a solid color

### DIFF
--- a/src/officecli/Handlers/Pptx/PowerPointHandler.Background.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.Background.cs
@@ -897,19 +897,29 @@ public partial class PowerPointHandler
         if (value.StartsWith("linear;", StringComparison.OrdinalIgnoreCase))
             value = value[7..].Replace(';', '-');
 
+        // BUG-P2 (silent single-stop degradation): the documented multi-stop
+        // form uses dashes ("FF0000@0-0000FF@100"), but a very common
+        // CSS-like spelling spells the stops with commas instead
+        // ("FF0000@0,0000FF@100"). The code below only splits on '-', so a
+        // comma-spelling collapsed to ONE segment → duplicated into a solid
+        // single colour with no error or warning — exactly the "accepted but
+        // renders as something else" class of footgun. Normalize commas to
+        // dashes up front (colours/angles contain no commas) so both spellings
+        // produce the intended multi-stop gradient.
+        var colorSpec = value.Replace(',', '-');
+
         // Check for radial/path prefix
         string? gradientType = null;
-        string colorSpec = value;
 
         if (value.StartsWith("radial:", StringComparison.OrdinalIgnoreCase))
         {
             gradientType = "radial";
-            colorSpec = value[7..];
+            colorSpec = value[7..].Replace(',', '-');
         }
         else if (value.StartsWith("path:", StringComparison.OrdinalIgnoreCase))
         {
             gradientType = "path";
-            colorSpec = value[5..];
+            colorSpec = value[5..].Replace(',', '-');
         }
 
         var parts = colorSpec.Split('-');


### PR DESCRIPTION
## What

Bug fix: `gradient=` on a pptx shape (and the radial/path forms) now accepts the common CSS-like **comma** stop spelling (`FF0000@0,0000FF@100`) as an alias of the documented dash form (`FF0000@0-0000FF@100`), instead of silently degrading the spec to a solid single color.

## Why

The comma spelling is a natural mistake (CSS gradients are comma-separated), and it used to be **accepted silently with the wrong result** — the worst failure class: the input parses, no error or warning appears, and the rendered fill is not what the user asked for:

```text
# Before this fix — blue stop silently vanished, no warning:
officecli set deck.pptx "/slide[1]/shape[1]" --prop "gradient=FF0000@0,0000FF@100"
# → applied: gradient=linear;#FF0000;#FF0000;90     ❌ solid red (0000FF lost)

# After this fix:
officecli set deck.pptx "/slide[1]/shape[1]" --prop "gradient=FF0000@0,0000FF@100"
# → applied: gradient=linear;#FF0000;#0000FF;90     ✓ same as the dash spelling
```

Root cause: the multi-stop parser splits on `-` only, so a comma-spelled spec collapsed to ONE segment that was then duplicated into both stops of a "gradient" that is visually a solid. Colors and angles contain no commas, so normalizing `,` → `-` up front is unambiguous.

## How to verify

```bash
officecli create demo.pptx
officecli add demo.pptx / --type slide
officecli add demo.pptx /slide[1] --type shape --prop "text=demo"
officecli set demo.pptx "/slide[1]/shape[1]" --prop "gradient=FF0000@0,0000FF@100"
officecli get demo.pptx "/slide[1]/shape[1]"
officecli close demo.pptx
```

`get` must report `gradient=linear;#FF0000;#0000FF;90` — and the exact same readback as `--prop "gradient=FF0000@0-0000FF@100"` (the documented spelling). Also spot-check `radial:FF0000@0,0000FF@100-center` and `LINEAR;FF0000;0000FF;45` still behave as documented.

## Implementation

One normalization in the shared gradient parser (`PowerPointHandler.Background.cs`): after the `linear;` round-trip prefix is translated, `colorSpec = value.Replace(',', '-')` — and the same normalization applied to the `radial:` / `path:` sub-specs which are sliced off `value` before the shared split. Nothing else touched.

## Tests

- `dotnet build -c Release` — 0 errors.
- XLSX numeric-fit regression suite (local repo-untracked harness per the maintainer's local-only test policy) — green.
- `dotnet publish -c Release` — single-file exe smoke OK; before/after behavior demonstrated above with the built binary.
