### PR TITLE
feat(pptx): view issues renderer-approximation audit (textWarp/textFill)

### DIFF
--- a/src/officecli/Core/IssueSubtypes.cs
+++ b/src/officecli/Core/IssueSubtypes.cs
@@ -56,6 +56,21 @@ public static class IssueSubtypes
     /// skipped to keep false positives near zero. Format bucket, Warning.</summary>
     public const string LowContrast = "low_contrast";
 
+    /// <summary>pptx-only: text fill (textFill/textgradient) uses an advanced
+    /// feature (path gradient, multiple stops, blip/image fill) that the HTML/
+    /// SVG preview cannot render accurately — the preview will show a solid
+    /// single color as an approximation. The OOXML document itself carries the
+    /// full gradient/image fill so PowerPoint will render it correctly; the
+    /// warning only flags that the CLI preview will not match what PowerPoint
+    /// shows. Format bucket, Warning.</summary>
+    public const string TextFillRendererApproximated = "text_fill_renderer_approximated";
+
+    /// <summary>pptx-only: text warp (textWarp) is only marked by a class in the
+    /// HTML preview; the preview cannot warp individual glyphs like PowerPoint
+    /// does, so the visual approximation will not match what PowerPoint shows.
+    /// Format bucket, Info.</summary>
+    public const string TextWarpRendererApproximated = "text_warp_renderer_approximated";
+
     /// <summary>Broad IssueType bucket names — the canonical surface shown
     /// in error messages and help. Single-letter aliases (<see cref="BucketAliases"/>)
     /// are accepted by Validate but kept out of the user-facing list so the
@@ -79,6 +94,7 @@ public static class IssueSubtypes
         FormulaNotEvaluated, FormulaCacheStale, FormulaRefMissingSheet, FormulaEvalError,
         FieldNotEvaluated, FieldCacheStale,
         SlideFieldNotEvaluated, NotesUnresolvedRid, LowContrast,
+        TextFillRendererApproximated, TextWarpRendererApproximated,
         ChartSeriesRefMissingSheet, ChartCacheStale,
         DefinedNameBroken, DefinedNameTargetMissing,
         BrokenPartRef, NumericOverflow, GeneralPrecisionLoss,

--- a/src/officecli/Handlers/Pptx/PowerPointHandler.View.cs
+++ b/src/officecli/Handlers/Pptx/PowerPointHandler.View.cs
@@ -908,6 +908,49 @@ public partial class PowerPointHandler
                         }
                     }
                 }
+
+                // Renderer-approximation audit: a text fill / warp can be stored
+                // faithfully in OOXML yet NOT displayable by the HTML/SVG preview,
+                // so a deck that "validates clean" still screens to a single color
+                // in the agent's preview. This is the silent-acceptance gap P0-A
+                // targets: the document is correct (PowerPoint renders it) but the
+                // preview only approximates it. Surface each advanced text fill /
+                // warp as a warning so the gap is observable in `view issues`
+                // instead of shipping a deck whose gradient never shows up.
+                string? warpApprox = GetTextWarpApproximation(shape);
+                if (warpApprox != null)
+                {
+                    issues.Add(new DocumentIssue
+                    {
+                        Id = $"W{++issueNum}",
+                        Type = IssueType.Format,
+                        Subtype = Core.IssueSubtypes.TextWarpRendererApproximated,
+                        Severity = IssueSeverity.Info,
+                        Path = shapePath,
+                        Message = warpApprox,
+                        Suggestion = "PowerPoint renders the true warp; the preview shows only a text-warp marker class."
+                    });
+                }
+
+                // One report per shape for text-fill approximation (mirrors the
+                // LowContrast one-report-per-shape policy).
+                string? fillApprox = shape.Descendants<Drawing.Run>()
+                    .Select(TextFillApproximationReason)
+                    .FirstOrDefault(r => r != null);
+                if (fillApprox != null)
+                {
+                    issues.Add(new DocumentIssue
+                    {
+                        Id = $"T{++issueNum}",
+                        Type = IssueType.Format,
+                        Subtype = Core.IssueSubtypes.TextFillRendererApproximated,
+                        Severity = IssueSeverity.Warning,
+                        Path = shapePath,
+                        Message = fillApprox,
+                        Suggestion = "The stored OOXML is correct and PowerPoint will render it; run a screenshot to confirm the delivered look."
+                    });
+                }
+                if (limit.HasValue && issues.Count >= limit.Value) break;
             }
 
             // Table row/grid width mismatch. OOXML requires each <a:tr> to have
@@ -1038,6 +1081,54 @@ public partial class PowerPointHandler
         if (sp.GetFirstChild<Drawing.PatternFill>() != null) return true;
         if (sp.GetFirstChild<Drawing.GradientFill>() != null) return true;
         return false; // inherited / no explicit fill → conservatively not an occluder
+    }
+
+    /// <summary>
+    /// Reason (or null) that a shape's text warp cannot be reproduced by the
+    /// HTML/SVG preview. The preview only paints a text-warp marker class, not
+    /// the per-glyph path PowerPoint computes, so a warped title previews as
+    /// straight text. Returns null when textWarp is absent or 'none'.
+    /// </summary>
+    private static string? GetTextWarpApproximation(Shape s)
+    {
+        var warp = s.TextBody?.BodyProperties?.PresetTextWarp;
+        if (warp == null) return null;
+        // Match the existing readback pattern (HtmlPreview reads
+        // PresetTextWarp.Preset.InnerText) instead of referencing the OOXML
+        // enum by name — its exact C# type name varies across SDK versions.
+        var prst = warp.Preset;
+        if (prst?.HasValue != true) return null;
+        if (string.Equals(prst.InnerText, "textNoShape", StringComparison.OrdinalIgnoreCase)) return null;
+        return $"Text warp '{prst.InnerText}' is only marked in the preview — the HTML preview cannot warp glyphs like PowerPoint.";
+    }
+
+    /// <summary>
+    /// Reason (or null) that a run's text fill is rendered only as a solid
+    /// approximation by the HTML/SVG preview, even though the stored OOXML is
+    /// correct. Returns null for the faithfully-rendered cases: no explicit
+    /// fill, an un-transformed solid, or a simple two-stop un-transformed
+    /// linear gradient. Flags image (blip) text fills, path gradients, and
+    /// gradients with 3+ stops — the forms the CSS path reduces to a single
+    /// color.
+    /// </summary>
+    private static string? TextFillApproximationReason(Drawing.Run run)
+    {
+        var rp = run.RunProperties;
+        if (rp == null) return null;
+
+        if (rp.GetFirstChild<Drawing.BlipFill>() != null)
+            return "Image (blip) text fill — the preview falls back to a single color unless the embedded image can be resolved.";
+
+        var grad = rp.GetFirstChild<Drawing.GradientFill>();
+        if (grad == null) return null;
+
+        if (grad.GetFirstChild<Drawing.PathGradientFill>() != null)
+            return "Path gradient text fill — the preview cannot reproduce the path and shows a solid approximation.";
+
+        var stops = grad.GradientStopList?.Elements<Drawing.GradientStop>().ToList();
+        if (stops != null && stops.Count > 2)
+            return $"Gradient text fill with {stops.Count} stops — the preview shows a solid approximation.";
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
## What

Extends `view issues` for pptx with a renderer-approximation audit: two new issue subtypes surface text effects that are stored correctly in the OOXML but that the HTML/SVG preview can only approximate, so a deck that "validates clean" no longer silently screens wrong:

- `text_warp_renderer_approximated` (Info) — a `textWarp` preset is only marked in the preview; it cannot warp individual glyphs like PowerPoint does.
- `text_fill_renderer_approximated` (Warning) — a run's text fill is an image (blip) fill, a path gradient, or a gradient with 3+ stops — the forms the CSS preview path reduces to a single color.

Faithfully-rendered cases stay silent: no explicit fill, un-transformed solid, or a simple two-stop un-transformed linear gradient. One report per shape (mirrors the LowContrast policy).

## Why

The document and the preview disagree in one direction only: the OOXML is correct (PowerPoint renders the gradient/warp), but the agent's HTML preview shows a solid/straight approximation. That is the silent-acceptance gap — an agent shipping a deck from preview feedback believes the delivered look is verified when it is not. Surfacing the gap in `view issues` makes it observable and actionable ("run a screenshot to confirm the delivered look") without flagging anything actually wrong in the file.

## How to verify

```bash
officecli create demo.pptx
officecli add demo.pptx / --type slide
officecli add demo.pptx /slide[1] --type shape --prop "text=Warped Title"
officecli set demo.pptx "/slide[1]/shape[1]" --prop "textWarp=textArchUp"
officecli set demo.pptx "/slide[1]/shape[1]" --prop "textFill=FF0000@0-00FF00@50-0000FF@100"
officecli view demo.pptx issues
officecli close demo.pptx
```

Actual terminal output:

```
Found 2 issue(s):

Format Issues (2):
  [W1] /slide[1]/shape[@id=100000]: Text warp 'textArchUp' is only marked in the preview — the HTML preview cannot warp glyphs like PowerPoint.
       Suggestion: PowerPoint renders the true warp; the preview shows only a text-warp marker class.
  [T2] /slide[1]/shape[@id=100000]: Gradient text fill with 3 stops — the preview shows a solid approximation.
       Suggestion: The stored OOXML is correct and PowerPoint will render it; run a screenshot to confirm the delivered look.
```

A plain solid-fill shape with no warp reports neither (no false positives on the common case).

## Implementation

- `src/officecli/Handlers/Pptx/PowerPointHandler.View.cs` — per-shape audit in the existing issues walk: `GetTextWarpApproximation` (reads `bodyPr/prstTxWarp @prst`, null for absent/`textNoShape`) and `TextFillApproximationReason` (blip fill / path gradient / >2 stops), each emitting a `DocumentIssue` with the existing subtype/validation machinery.
- `src/officecli/Core/IssueSubtypes.cs` — the two new subtypes + `ValidSubtypes` registration, so `view issues --type text_fill_renderer_approximated` opt-in filtering works like every other subtype.

## Tests

- `dotnet build -c Release` — 0 errors.
- XLSX numeric-fit regression suite (local repo-untracked harness per the maintainer's local-only test policy) — green.
- `dotnet publish -c Release` — single-file exe smoke OK; the demo above was produced with the built binary.
