### PR TITLE
fix(cli): accept --props comma batch form on mutating verbs

### DIFF
--- a/src/officecli/CommandBuilder.Add.cs
+++ b/src/officecli/CommandBuilder.Add.cs
@@ -40,6 +40,7 @@ static partial class CommandBuilder
         var addAfterOpt = new Option<string?>("--after") { Description = "Insert after the element at this path (e.g. p[@paraId=1A2B3C4D])" };
         var addBeforeOpt = new Option<string?>("--before") { Description = "Insert before the element at this path" };
         var addPropsOpt = new Option<string[]>("--prop") { Description = "Property to set (key=value, e.g. --prop src=image.png --prop width=6in)", AllowMultipleArgumentsPerToken = true };
+        var addPropsBatchOpt = CreatePropsBatchOption();
         var forceOption = new Option<bool>("--force") { Description = "Force write even if document is protected" };
 
         var addCommand = new Command("add", "Add a new element to the document") { TreatUnmatchedTokensAsErrors = false };
@@ -51,6 +52,7 @@ static partial class CommandBuilder
         addCommand.Add(addAfterOpt);
         addCommand.Add(addBeforeOpt);
         addCommand.Add(addPropsOpt);
+        addCommand.Add(addPropsBatchOpt);
         addCommand.Add(jsonOption);
         addCommand.Add(forceOption);
 
@@ -66,7 +68,7 @@ static partial class CommandBuilder
             var index = result.GetValue(addIndexOpt);
             var after = MsysPathHint.Restore(result.GetValue(addAfterOpt));
             var before = MsysPathHint.Restore(result.GetValue(addBeforeOpt));
-            var props = result.GetValue(addPropsOpt);
+            var props = MergePropFlags(result.GetValue(addPropsOpt), result.GetValue(addPropsBatchOpt));
             var force = result.GetValue(forceOption);
 
             // Validate mutual exclusivity of --index, --after, --before
@@ -347,12 +349,14 @@ static partial class CommandBuilder
             Description = "Modifier property (key=value). Phase 4: --prop trackChange.author=<name> on a Word Run or Paragraph path records a w:del revision instead of physically deleting.",
             AllowMultipleArgumentsPerToken = true,
         };
+        var removePropsBatchOpt = CreatePropsBatchOption();
 
         var removeCommand = new Command("remove", "Remove an element from the document");
         removeCommand.Add(removeFileArg);
         removeCommand.Add(removePathArg);
         removeCommand.Add(shiftOption);
         removeCommand.Add(removePropsOpt);
+        removeCommand.Add(removePropsBatchOpt);
         removeCommand.Add(jsonOption);
 
         removeCommand.SetAction(result => { var json = result.GetValue(jsonOption); return SafeRun(() =>
@@ -360,7 +364,7 @@ static partial class CommandBuilder
             var file = result.GetValue(removeFileArg)!;
             var path = MsysPathHint.Restore(result.GetValue(removePathArg)!)!;
             var shift = result.GetValue(shiftOption);
-            var props = result.GetValue(removePropsOpt);
+            var props = MergePropFlags(result.GetValue(removePropsOpt), result.GetValue(removePropsBatchOpt));
             var parsedProps = (props != null && props.Length > 0) ? ParsePropsArray(props) : null;
 
             // Agent-safety: reject a bare unscoped selector (`run`, `shape[...]`) —
@@ -419,6 +423,7 @@ static partial class CommandBuilder
         // run-level move-tracking branch in WordHandler. Other handlers
         // (xlsx/pptx) accept the option for parity but ignore the values.
         var movePropsOpt = new Option<string[]>("--prop") { Description = "Property to set on the move (e.g. --prop trackChange.author=Alice for tracked moves)", AllowMultipleArgumentsPerToken = true };
+        var movePropsBatchOpt = CreatePropsBatchOption();
 
         var moveCommand = new Command("move", "Move an element to a new position or parent");
         moveCommand.Add(moveFileArg);
@@ -428,6 +433,7 @@ static partial class CommandBuilder
         moveCommand.Add(moveAfterOpt);
         moveCommand.Add(moveBeforeOpt);
         moveCommand.Add(movePropsOpt);
+        moveCommand.Add(movePropsBatchOpt);
         moveCommand.Add(jsonOption);
 
         moveCommand.SetAction(result => { var json = result.GetValue(jsonOption); return SafeRun(() =>
@@ -438,7 +444,7 @@ static partial class CommandBuilder
             var index = result.GetValue(moveIndexOpt);
             var after = MsysPathHint.Restore(result.GetValue(moveAfterOpt));
             var before = MsysPathHint.Restore(result.GetValue(moveBeforeOpt));
-            var props = result.GetValue(movePropsOpt);
+            var props = MergePropFlags(result.GetValue(movePropsOpt), result.GetValue(movePropsBatchOpt));
 
             // Validate mutual exclusivity of --index, --after, --before
             var posCount = (index.HasValue ? 1 : 0) + (after != null ? 1 : 0) + (before != null ? 1 : 0);

--- a/src/officecli/CommandBuilder.Mark.cs
+++ b/src/officecli/CommandBuilder.Mark.cs
@@ -27,19 +27,21 @@ static partial class CommandBuilder
             Description = "Mark property: find=..., color=..., note=..., tofix=..., regex=true",
             AllowMultipleArgumentsPerToken = true,
         };
+        var propsBatchOpt = CreatePropsBatchOption();
 
         var cmd = new Command(name,
             "Attach an in-memory advisory mark to a document element via the watch process. Path must be in data-path format (e.g. /body/p[1]); 'selected' marks all selected elements.");
         cmd.Add(fileArg);
         cmd.Add(pathArg);
         cmd.Add(propsOpt);
+        cmd.Add(propsBatchOpt);
         cmd.Add(jsonOption);
 
         cmd.SetAction(result => { var json = result.GetValue(jsonOption); return SafeRun(() =>
         {
             var file = result.GetValue(fileArg)!;
             var path = OfficeCli.Core.MsysPathHint.Restore(result.GetValue(pathArg)!)!;
-            var rawProps = result.GetValue(propsOpt) ?? Array.Empty<string>();
+            var rawProps = MergePropFlags(result.GetValue(propsOpt), result.GetValue(propsBatchOpt));
 
             var props = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             string? deprecatedExpectValue = null;

--- a/src/officecli/CommandBuilder.Set.cs
+++ b/src/officecli/CommandBuilder.Set.cs
@@ -15,6 +15,7 @@ static partial class CommandBuilder
         var setFileArg = new Argument<FileInfo>("file") { Description = "Office document path (required even with open/close mode)" };
         var setPathArg = new Argument<string>("path") { Description = "DOM path to the element. The 'selected' pseudo-path is deprecated for mutations: use `get selected` to capture path(s) first, then `set <path>` (or a `batch` file for multi-select) so the target lives in the command line, not in transient watch-server state." };
         var propsOpt = new Option<string[]>("--prop") { Description = "Property to set (key=value)", AllowMultipleArgumentsPerToken = true };
+        var propsBatchOpt = CreatePropsBatchOption();
         // Selector: top-level alternative to --prop find=VALUE. r"..." prefix triggers regex (project-wide CONSISTENCY(find-regex)).
         var findOpt = new Option<string?>("--find") { Description = "Find this text/pattern (literal substring; `r\"...\"` prefix enables regex). Equivalent to --prop find=VALUE." };
         // Action paired with --find: replacement text. Top-level alternative to --prop replace=VALUE.
@@ -24,6 +25,7 @@ static partial class CommandBuilder
         setCommand.Add(setFileArg);
         setCommand.Add(setPathArg);
         setCommand.Add(propsOpt);
+        setCommand.Add(propsBatchOpt);
         setCommand.Add(findOpt);
         setCommand.Add(replaceOpt);
         setCommand.Add(jsonOption);
@@ -39,7 +41,7 @@ static partial class CommandBuilder
             if (json) OfficeCli.Core.WarningContext.Begin();
             var file = result.GetValue(setFileArg)!;
             var path = MsysPathHint.Restore(result.GetValue(setPathArg)!)!;
-            var props = result.GetValue(propsOpt);
+            var props = MergePropFlags(result.GetValue(propsOpt), result.GetValue(propsBatchOpt));
             var findFlag = result.GetValue(findOpt);
             var replaceFlag = result.GetValue(replaceOpt);
             var force = result.GetValue(forceOption);

--- a/src/officecli/CommandBuilder.cs
+++ b/src/officecli/CommandBuilder.cs
@@ -1585,17 +1585,104 @@ static partial class CommandBuilder
             // because `--props` (with trailing s) is not a known option, so the
             // JSON value goes into UnmatchedTokens too. Catch the typo so the
             // existing warning machinery emits a clear hint instead of letting
-            // the agent ship a shape with no text.
+            // the agent ship a shape with no text. (`--props` is a registered
+            // option on set/add/remove/move/mark, so this branch only fires on
+            // commands without it and on the `-props` / `--prop=` spellings.)
             if (token is "--props" or "-props" or "--prop=" && i + 1 < tokens.Count)
             {
                 var nextToken = tokens[i + 1];
                 if (!nextToken.StartsWith("--"))
                 {
-                    result.Add($"--prop {nextToken}");
+                    // No "--prop " prefix here — every consumer re-adds it when
+                    // building the suggestion, and RejectUnknownOptionTokens
+                    // derives claimed keys by splitting on '='.
+                    result.Add(nextToken);
                     i++;
                     continue;
                 }
             }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Shared registration for the `--props` batch form accepted by the
+    /// mutating verbs (set/add/remove/move/mark). Kept next to
+    /// <see cref="MergePropFlags"/> so the flag, its merge rule and its
+    /// error text stay one concern.
+    /// </summary>
+    internal static System.CommandLine.Option<string[]> CreatePropsBatchOption() =>
+        new("--props")
+        {
+            Description = "Comma-separated properties (k=v,k2=v2), equivalent to repeating --prop. A value containing a comma: wrap it in single quotes (k='a,b').",
+            AllowMultipleArgumentsPerToken = true
+        };
+
+    /// <summary>
+    /// Merge `--prop k=v` entries with `--props` comma-batch entries into one
+    /// k=v array. Each --props value is split on commas that are not inside
+    /// single quotes; one pair of surrounding quotes is stripped from a
+    /// segment ('a,b' → a,b), mirroring the shell convention documented for
+    /// --prop. --prop values are never split, so comma-bearing values
+    /// (--prop data="S1:1,2,3") keep working unchanged.
+    /// </summary>
+    internal static string[] MergePropFlags(string[]? prop, string[]? propsBatch)
+    {
+        if (propsBatch == null || propsBatch.Length == 0)
+            return prop ?? Array.Empty<string>();
+        var merged = new List<string>(prop ?? Array.Empty<string>());
+        foreach (var batch in propsBatch)
+            merged.AddRange(SplitPropsBatch(batch));
+        return merged.ToArray();
+    }
+
+    /// <summary>
+    /// Split one --props value into k=v segments on top-level commas.
+    /// A segment without '=' (or an empty segment from a stray comma) is a
+    /// hard error — the batch is rejected up front, never partially applied.
+    /// </summary>
+    private static List<string> SplitPropsBatch(string batch)
+    {
+        var pieces = new List<string>();
+        var current = new System.Text.StringBuilder();
+        bool inQuote = false;
+        foreach (var ch in batch)
+        {
+            if (ch == '\'') { inQuote = !inQuote; current.Append(ch); }
+            else if (ch == ',' && !inQuote) { pieces.Add(current.ToString()); current.Clear(); }
+            else current.Append(ch);
+        }
+        if (inQuote)
+            throw new OfficeCli.Core.CliException($"Invalid --props '{batch}': unterminated single quote.")
+            {
+                Code = "invalid_argument",
+                Suggestion = "Quote only the value that contains a comma: --props \"text='a,b',bold=true\" — or pass repeated --prop k=v."
+            };
+        pieces.Add(current.ToString());
+        var result = new List<string>(pieces.Count);
+        foreach (var rawPiece in pieces)
+        {
+            var piece = rawPiece.Trim();
+            if (piece.Length == 0)
+                throw new OfficeCli.Core.CliException($"Invalid --props '{batch}': empty property segment.")
+                {
+                    Code = "invalid_argument",
+                    Suggestion = "Remove stray commas, or pass repeated --prop k=v."
+                };
+            var eq = piece.IndexOf('=');
+            if (eq <= 0)
+                throw new OfficeCli.Core.CliException($"Invalid --props '{batch}': segment '{piece}' is not key=value.")
+                {
+                    Code = "invalid_argument",
+                    Suggestion = "Use --props \"k=v,k2=v2\" (each segment key=value), or pass repeated --prop k=v."
+                };
+            // Quote-stripping is value-side: value='a,b' → value=a,b (mirrors
+            // the documented --prop shell convention where '...' groups, never
+            // becomes content).
+            var value = piece[(eq + 1)..];
+            if (value.Length >= 2 && value.StartsWith('\'') && value.EndsWith('\''))
+                value = value[1..^1];
+            result.Add($"{piece[..eq]}={value}");
         }
         return result;
     }


### PR DESCRIPTION
## What

`--props "k=v,k2=v2"` is now a registered option on `set` / `add` / `remove` / `move` / `mark`, parsed with the same key=value semantics as repeating `--prop`. A value that itself contains a comma is protected by single quotes (`--props "text='a,b',bold=true"` → `text=a,b`, `bold=true`). `--prop` values are never split, so comma-bearing values (`--prop data="S1:1,2,3"`) behave exactly as before. Malformed input (a segment without `=`, a stray comma, an unterminated quote) is rejected up front with `code=invalid_argument` and a `--prop` suggestion — never partially applied.

## Why

Agents habitually guess the plural form. Because `--props` was not a registered option, System.CommandLine shunted the entire value into unmatched tokens, where it was dropped — at best with a warning, at worst via a misleading downstream error. Real-world repro against 1.0.148: a chart add lost `dataRange`/`categories` entirely and reported "Chart requires a 'data' property", which misleads the caller into "fixing" the wrong thing. The existing BUG-BT-R6 typo-catch only turned the silent drop into a warning; the properties still never reached the handler. The warning's suggestion also doubled the flag (`Use: --prop --prop value=...`) because the claimed token was pre-prefixed; the prefix is now added exactly once by consumers.

## Implementation

- `CommandBuilder.CreatePropsBatchOption()` — shared `--props` option factory; `MergePropFlags()` merges `--prop` entries with quote-aware comma-split `--props` entries; `SplitPropsBatch()` does the splitting + up-front validation. All in `CommandBuilder.cs` next to the existing `DetectUnmatchedKeyValues` machinery.
- Wired at the five existing `--prop` registrations (set/add/remove/move/mark). The merge happens at the single point where each verb reads its props, so resident and standalone routes share it with no behavior difference.
- BUG-BT-R6's Pattern 3 stays (for `-props` / `--prop=` spellings and verbs without the option) but no longer injects a `--prop ` prefix into claimed tokens.

## How to verify

```
officecli add data.xlsx /Sheet1 --type chart --props "type=line,anchor=H20,dataRange=Sheet1!B2:B3,categories=Sheet1!A2:A3" --json
  → "Added chart at /Sheet1/chart[1]"   (before: Chart requires a 'data' property)

officecli set data.xlsx /Sheet1/F1 --props "value='a,b',bold=true" --json
  → text "a,b" (comma preserved, quotes stripped), font.bold=true

officecli set data.xlsx /Sheet1/A1 --props "bold" --json
  → invalid_argument + "Use --props \"k=v,k2=v2\" … or pass repeated --prop k=v"

officecli set data.xlsx /Sheet1/A1 --prop value=x,y --json
  → text "x,y" (--prop values untouched)
```

Local regression harness (shells the built exe; resident + `OFFICECLI_NO_AUTO_RESIDENT=1` standalone): 9/9 green — comma-form chart add, quote protection, `--prop` passthrough, three rejection paths with `code`+suggestion, mixed `--prop --props` merge, both execution modes.
`dotnet build -c Release`: 0 errors (1 pre-existing CS8602 warning, untouched by this change). `dotnet publish` single-file smoke-verified end-to-end on the published exe (atomic batch rollback, formula evaluation readback, chart adds, validate 0 errors).
