### PR TITLE
feat(cli): batch --from <file> — text-script channel, one command per line

### DIFF
--- a/src/officecli/CommandBuilder.Batch.cs
+++ b/src/officecli/CommandBuilder.Batch.cs
@@ -23,7 +23,8 @@ static partial class CommandBuilder
         + "\"path\" (set/remove/get target), \"selector\" (query filter; \"path\" is accepted as an alias), \"type\" (element type for add), "
         + "\"props\" (a key->value map of --prop values), \"to\"/\"after\"/\"before\" (move), "
         + "\"path2\" (swap's second path).\n\n"
-        + "Pass the array via --commands, or as the same JSON on stdin / --input <file>. Example:\n"
+        + "Pass the array via --commands, as the same JSON on stdin / --input <file>, or as a text script via --from <file> "
+        + "(one CLI-style command per line: set/add/remove/move/swap; '#' comments; trailing '\\' continues a line). Example:\n"
         + "[\n"
         + "  {\"command\":\"add\",\"parent\":\"/slide[1]\",\"type\":\"shape\",\"props\":{\"text\":\"Hi\",\"x\":\"1cm\",\"y\":\"2cm\"}},\n"
         + "  {\"command\":\"set\",\"path\":\"/slide[1]/shape[1]\",\"props\":{\"bold\":\"true\"}},\n"
@@ -165,6 +166,7 @@ static partial class CommandBuilder
         var batchFileArg = new Argument<FileInfo>("file") { Description = "Office document path" };
         var batchInputOpt = new Option<FileInfo?>("--input") { Description = "JSON file containing batch commands. If omitted, reads from stdin" };
         var batchCommandsOpt = new Option<string?>("--commands") { Description = "Inline JSON array of batch commands (alternative to --input or stdin)" };
+        var batchFromOpt = new Option<FileInfo?>("--from") { Description = "Text script file, one CLI-style command per line (verbs: set/add/remove/move/swap; '#' comments; trailing '\\' continues a line). Alternative to --input/--commands" };
         // BUG-R4-BT2: default flipped to continue-on-error. A 700-command
         // dump replay losing 80% of the document on the first failing item
         // (e.g. one unsupported prop) is a far worse default than reporting
@@ -186,6 +188,7 @@ static partial class CommandBuilder
         batchCommand.Add(batchFileArg);
         batchCommand.Add(batchInputOpt);
         batchCommand.Add(batchCommandsOpt);
+        batchCommand.Add(batchFromOpt);
         batchCommand.Add(batchForceOpt);
         batchCommand.Add(batchStopOpt);
         batchCommand.Add(batchBestEffortOpt);
@@ -196,6 +199,7 @@ static partial class CommandBuilder
             var file = result.GetValue(batchFileArg)!;
             var inputFile = result.GetValue(batchInputOpt);
             var inlineCommands = result.GetValue(batchCommandsOpt);
+            var fromFile = result.GetValue(batchFromOpt);
             // Default: continue on error. --stop-on-error flips it to strict.
             // --force still acts as the docx-protection bypass (matches set
             // --force semantics) but no longer doubles as the continue-on-
@@ -242,14 +246,15 @@ static partial class CommandBuilder
                 }
                 catch { /* treat as no confirmed payload */ }
             }
-            if (inlineCommands != null && inputFile != null)
+            var batchSourceCount = (inlineCommands != null ? 1 : 0) + (inputFile != null ? 1 : 0) + (fromFile != null ? 1 : 0);
+            if (batchSourceCount > 1)
                 throw new ArgumentException(
-                    "batch: --commands and --input are mutually exclusive. Pick one source.");
+                    "batch: --commands, --input, and --from are mutually exclusive. Pick one source.");
             // '--input -' explicitly opts INTO stdin — don't emit the
             // "stdin will be ignored" warning in that case, since stdin
             // is exactly what will be read.
             var inputIsStdinAlias = inputFile != null && inputFile.Name == "-";
-            if ((inlineCommands != null || (inputFile != null && !inputIsStdinAlias)) && stdinHasInput
+            if ((inlineCommands != null || inputFile != null || fromFile != null) && !(inputIsStdinAlias && inlineCommands == null && fromFile == null) && stdinHasInput
                 && Environment.GetEnvironmentVariable("OFFICECLI_BATCH_ALLOW_STDIN_REDIRECT") == null)
             {
                 Console.Error.WriteLine(
@@ -257,7 +262,25 @@ static partial class CommandBuilder
                     + "stdin will be ignored. Pass only one source to silence this warning, or set "
                     + "OFFICECLI_BATCH_ALLOW_STDIN_REDIRECT=1.");
             }
-            if (inlineCommands != null)
+            if (fromFile != null)
+            {
+                if (!fromFile.Exists)
+                {
+                    throw new FileNotFoundException($"Script file not found: {fromFile.FullName}");
+                }
+                // Text channel: parse CLI-style lines into batch items, then
+                // re-serialize into the exact JSON text path --commands/--input
+                // use, so validation, atomicity, and reporting cannot drift
+                // between the two source formats. Parse errors reject the
+                // whole script before any item runs (batch_parse_error).
+                // Same source-gen serializer the dump->batch pipeline uses
+                // (trim-safe; the reflection Serialize overload adds an
+                // IL2026 trimming warning).
+                jsonText = System.Text.Json.JsonSerializer.Serialize(
+                    OfficeCli.Core.BatchScriptParser.ParseFile(fromFile.FullName),
+                    BatchJsonContext.Default.ListBatchItem);
+            }
+            else if (inlineCommands != null)
             {
                 jsonText = inlineCommands;
             }

--- a/src/officecli/Core/BatchScriptParser.cs
+++ b/src/officecli/Core/BatchScriptParser.cs
@@ -1,0 +1,228 @@
+// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Globalization;
+using System.Text;
+using OfficeCli;
+
+namespace OfficeCli.Core;
+
+/// <summary>
+/// Parser for the batch text channel (`batch --from script.txt`): one
+/// CLI-style command per line, converted to the same <see cref="BatchItem"/>
+/// model the JSON channel deserializes into, so both sources feed one
+/// execution pipeline with identical atomicity and error reporting.
+///
+/// Line grammar:
+///   line := verb operand [--type T | --prop k=v | --from P | --to P |
+///                          --index N | --after P | --before P | --selector S |
+///                          --mode M | --depth N]...
+///   verb := set | add | remove | move | swap
+///
+/// A line whose first non-blank character is '#' is a comment; a trailing '\'
+/// continues onto the next physical line (line numbers in errors report the
+/// first physical line of the logical line). Quoting: single quotes are
+/// literal content (the documented --prop text='$15M' convention), double
+/// quotes group only; an unterminated quote rejects the line.
+///
+/// Every parse error is collected and the whole script is rejected up front
+/// (code batch_parse_error) — a half-parsed script never executes.
+/// Property-name typos are deliberately NOT rejected here: the parse layer
+/// has no per-element wordlist, and the executor's unsupported_property
+/// error already lists the valid props for the exact element being targeted.
+/// </summary>
+internal static class BatchScriptParser
+{
+    internal static readonly string[] SupportedVerbs = ["set", "add", "remove", "move", "swap"];
+
+    private static readonly string[] ValueFlags =
+        ["--type", "--from", "--to", "--after", "--before", "--selector", "--mode"];
+
+    public static List<BatchItem> ParseFile(string path) => Parse(File.ReadAllText(path));
+
+    public static List<BatchItem> Parse(string content)
+    {
+        var errors = new List<string>();
+        var items = new List<BatchItem>();
+
+        var physical = content.Replace("\r\n", "\n").Split('\n');
+        var lineNo = 1;
+        while (lineNo <= physical.Length)
+        {
+            var first = lineNo;
+            var text = physical[lineNo - 1];
+            while (text.TrimEnd().EndsWith('\\') && lineNo < physical.Length)
+            {
+                text = text.TrimEnd()[..^1] + physical[lineNo];
+                lineNo++;
+            }
+            lineNo++;
+
+            var trimmed = text.Trim();
+            if (trimmed.Length == 0 || trimmed.StartsWith('#'))
+                continue;
+            try
+            {
+                items.Add(ParseLine(trimmed, first));
+            }
+            catch (CliException ex)
+            {
+                errors.Add($"line {first}: {ex.Message}");
+            }
+        }
+
+        if (errors.Count > 0)
+            throw new CliException(
+                $"batch script rejected: {errors.Count} parse error(s), nothing executed.\n"
+                + string.Join("\n", errors))
+            {
+                Code = "batch_parse_error",
+                Suggestion = "Fix the listed lines and re-run. Per line: <verb> <path> [--type T] [--prop k=v ...] " +
+                             $"with verb ∈ {string.Join("/", SupportedVerbs)}; '#' comments; '\\' continues a line."
+            };
+        return items;
+    }
+
+    private static BatchItem ParseLine(string line, int lineNo)
+    {
+        var tokens = Tokenize(line, lineNo);
+        var verb = tokens[0].ToLowerInvariant();
+        if (!SupportedVerbs.Contains(verb))
+            throw new CliException($"unknown verb '{tokens[0]}' (supported: {string.Join(", ", SupportedVerbs)})")
+            { Code = "invalid_argument" };
+
+        var item = new BatchItem { Command = verb };
+        var positionals = new List<string>();
+        for (var i = 1; i < tokens.Count; i++)
+        {
+            var tok = tokens[i];
+            if (!tok.StartsWith("--"))
+            {
+                positionals.Add(tok);
+                continue;
+            }
+
+            var flag = tok.ToLowerInvariant();
+            if (flag == "--prop")
+            {
+                if (i + 1 >= tokens.Count)
+                    throw new CliException("--prop needs a key=value value") { Code = "invalid_argument" };
+                var kv = tokens[++i];
+                var eq = kv.IndexOf('=');
+                if (eq <= 0)
+                    throw new CliException($"--prop value '{kv}' is not key=value") { Code = "invalid_argument" };
+                (item.Props ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase))[kv[..eq]] =
+                    kv[(eq + 1)..];
+            }
+            else if (flag is "--index" or "--depth")
+            {
+                if (i + 1 >= tokens.Count)
+                    throw new CliException($"{flag} needs a number") { Code = "invalid_argument" };
+                var raw = tokens[++i];
+                if (!int.TryParse(raw, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var n))
+                    throw new CliException($"{flag} value '{raw}' is not an integer") { Code = "invalid_argument" };
+                if (flag == "--index") item.Index = n;
+                else item.Depth = n;
+            }
+            else if (ValueFlags.Contains(flag))
+            {
+                if (i + 1 >= tokens.Count)
+                    throw new CliException($"{flag} needs a value") { Code = "invalid_argument" };
+                var value = tokens[++i];
+                switch (flag)
+                {
+                    case "--type": item.Type = value; break;
+                    case "--from": item.From = value; break;
+                    case "--to": item.To = value; break;
+                    case "--after": item.After = value; break;
+                    case "--before": item.Before = value; break;
+                    case "--selector": item.Selector = value; break;
+                    case "--mode": item.Mode = value; break;
+                }
+            }
+            else
+            {
+                throw new CliException(
+                    $"unknown option '{tok}' (supported: --prop, --type, --from, --to, --index, --after, --before, --selector, --mode, --depth)")
+                { Code = "invalid_argument" };
+            }
+        }
+
+        switch (verb)
+        {
+            case "set":
+                item.Path = RequirePositional(positionals, "set <path>");
+                RequireNoExtra(positionals, line);
+                if (item.Props == null || item.Props.Count == 0)
+                    throw new CliException("set carries no --prop k=v — a set line without properties would do nothing")
+                    { Code = "invalid_argument" };
+                break;
+            case "add":
+                item.Parent = RequirePositional(positionals, "add <parent>");
+                RequireNoExtra(positionals, line);
+                if (item.Type == null && item.From == null)
+                    throw new CliException("add needs --type <type> (or --from <path> to clone an element)")
+                    { Code = "invalid_argument" };
+                break;
+            case "remove":
+                item.Path = RequirePositional(positionals, "remove <path>");
+                RequireNoExtra(positionals, line);
+                break;
+            case "move":
+                item.Path = RequirePositional(positionals, "move <path>");
+                RequireNoExtra(positionals, line);
+                if (item.To == null && !item.Index.HasValue && item.After == null && item.Before == null)
+                    throw new CliException("move needs a destination: --to / --index / --after / --before")
+                    { Code = "invalid_argument" };
+                break;
+            case "swap":
+                if (positionals.Count != 2)
+                    throw new CliException("swap needs exactly two paths: swap <path1> <path2>")
+                    { Code = "invalid_argument" };
+                item.Path = positionals[0];
+                item.Path2 = positionals[1];
+                break;
+        }
+        return item;
+    }
+
+    private static string RequirePositional(List<string> positionals, string usage)
+    {
+        if (positionals.Count == 0)
+            throw new CliException($"missing path — usage: {usage}") { Code = "invalid_argument" };
+        return positionals[0];
+    }
+
+    private static void RequireNoExtra(List<string> positionals, string line)
+    {
+        if (positionals.Count > 1)
+            throw new CliException(
+                $"unexpected token '{positionals[1]}' — quote it into a --prop value if it belongs to one: {line}")
+            { Code = "invalid_argument" };
+    }
+
+    private static List<string> Tokenize(string line, int lineNo)
+    {
+        var tokens = new List<string>();
+        var current = new StringBuilder();
+        var hasToken = false;
+        bool inSingle = false, inDouble = false;
+        foreach (var ch in line)
+        {
+            if (inSingle) { if (ch == '\'') inSingle = false; else current.Append(ch); }
+            else if (inDouble) { if (ch == '"') inDouble = false; else current.Append(ch); }
+            else if (ch == '\'') { inSingle = true; hasToken = true; }
+            else if (ch == '"') { inDouble = true; hasToken = true; }
+            else if (char.IsWhiteSpace(ch))
+            {
+                if (current.Length > 0 || hasToken) { tokens.Add(current.ToString()); current.Clear(); hasToken = false; }
+            }
+            else current.Append(ch);
+        }
+        if (inSingle || inDouble)
+            throw new CliException("unterminated quote") { Code = "invalid_argument" };
+        if (current.Length > 0 || hasToken)
+            tokens.Add(current.ToString());
+        return tokens;
+    }
+}


### PR DESCRIPTION
## What

`batch` accepts a third source format alongside `--input`/`--commands`:

```
officecli batch data.xlsx --from commands.txt [--best-effort] [--stop-on-error] --json
```

Each line is one CLI-style command — `<verb> <path> [--type T] [--prop k=v ...]` with verb ∈ `set`/`add`/`remove`/`move`/`swap` — the shape an agent writes by hand. `#` full-line comments, blank lines skipped, a trailing `\` continues the line, single quotes are literal content (the documented `--prop text='$15M'` convention), double quotes group only.

The parser converts lines into the same `BatchItem` model the JSON channel deserializes and re-serializes through the identical JSON text path (source-gen serializer, same as the dump→batch pipeline), so validation, atomic-by-default rollback, `--best-effort`/`--stop-on-error`, and result reporting are byte-identical between both source formats. Every parse error is collected and the whole script is rejected up front (`code: batch_parse_error`, one `line N: <reason>` per bad line) — a half-parsed script never executes. `--from` joins the `--commands`/`--input` mutual-exclusion check and the redirected-stdin warning.

## Why

The JSON channel is machine-friendly but hostile to hand-writing: agents composing 40+ operations hit shell length limits and escaping, and `add` items need the `parent`+`type`+`props` shape that is easy to get wrong (a natural `{op,path}` guess is rejected). A text file has no length limit, one documented quote rule, and reads back like the command list it is. File-based input also sidesteps the stdin-swallowing class of problems (cf. #340) — `--from -` is deliberately not offered in v1.

## Implementation

- New `Core/BatchScriptParser.cs` (~200 lines): tokenizer (quote-aware) → per-verb shape validation → `BatchItem`. Line errors carry the physical line number of the logical (continuation-joined) line.
- `CommandBuilder.Batch.cs`: `--from` option + three-way mutual exclusion + one branch that parses and re-serializes into `jsonText`. No changes to validation, execution, atomicity, or reporting — those run unchanged for both source formats.
- Property-name typos are deliberately NOT rejected at parse time: the parse layer has no per-element wordlist, and the executor's `unsupported_property` error already lists the valid props for the exact element being targeted — pre-checking against the cross-format word list would false-positive on element-specific props.

## How to verify

```
printf 'set /Sheet1/A1 --prop value=hello\nadd /Sheet1 --type table --prop name=T --prop range=A1:B2 --prop style=medium2\n' > cmds.txt
officecli batch data.xlsx --from cmds.txt --json
  → "succeeded": 2

printf 'set /Sheet1/A2 --prop bogus\n' > bad.txt
officecli batch data.xlsx --from bad.txt --json
  → success:false, code batch_parse_error, "line 1: --prop value 'bogus' is not key=value", file untouched

officecli batch data.xlsx --from cmds.txt --commands '[...]' --json
  → "batch: --commands, --input, and --from are mutually exclusive. Pick one source."
```

Local harness (tests/ local-only, shells the built exe): T-01 suite 5/5 — happy path (set + add table + add chart in one script), comments/blank/continuation/single-quote `$` literal, whole-script rejection with line numbers and nothing-executed file fact, unknown verb and unknown option, source mutual exclusion. Build 0 errors; `dotnet publish` single-file smoke-verified (8-item Chinese-content script end-to-end on the published exe).
