### PR TITLE
feat(cli): batch failures[] block + best-effort partialRetained in summary

### DIFF
--- a/src/officecli/BatchTypes.cs
+++ b/src/officecli/BatchTypes.cs
@@ -225,6 +225,12 @@ public class BatchResult
     public string? Code { get; set; }
     /// <summary>The original batch item, included when the command fails so the agent can inspect/retry.</summary>
     public BatchItem? Item { get; set; }
+    /// <summary>
+    /// Recovery hint for a failed item ("did you mean border.all?", the exact
+    /// command to retry) when the underlying CliException carried one. Purely
+    /// additive field; null on most failures.
+    /// </summary>
+    public string? Suggestion { get; set; }
     /// <summary>Advisory diagnostics produced while executing this item.</summary>
     internal List<OfficeCli.Core.CliWarning>? Warnings { get; set; }
 }
@@ -275,6 +281,8 @@ internal class BatchResultConverter : JsonConverter<BatchResult>
             writer.WriteString("error", value.Error);
             if (value.Code != null)
                 writer.WriteString("code", value.Code);
+            if (value.Suggestion != null)
+                writer.WriteString("suggestion", value.Suggestion);
             if (value.Item != null)
             {
                 writer.WritePropertyName("item");

--- a/src/officecli/CommandBuilder.Batch.cs
+++ b/src/officecli/CommandBuilder.Batch.cs
@@ -116,6 +116,7 @@ static partial class CommandBuilder
                     Item = item,
                     Error = ex.Message,
                     Code = OfficeCli.Core.OutputFormatter.InferErrorCode(ex),
+                    Suggestion = (ex as CliException)?.Suggestion,
                     Warnings = OfficeCli.Core.WarningContext.End(),
                 });
                 if (stopOnError) break;
@@ -666,13 +667,13 @@ static partial class CommandBuilder
             if (json)
             {
                 using var sw = new System.IO.StringWriter();
-                PrintBatchResults(batchResults, json, items.Count, sw, atomicRolledBack: rolledBack);
+                PrintBatchResults(batchResults, json, items.Count, sw, atomicRolledBack: rolledBack, bestEffort: bestEffort);
                 var inner = sw.ToString().TrimEnd('\n', '\r');
                 Console.WriteLine(OfficeCli.Core.OutputFormatter.WrapEnvelope(inner, batchWarnings, success: batchSuccess));
             }
             else
             {
-                PrintBatchResults(batchResults, json, items.Count, atomicRolledBack: rolledBack);
+                PrintBatchResults(batchResults, json, items.Count, atomicRolledBack: rolledBack, bestEffort: bestEffort);
                 foreach (var w in batchWarnings)
                     Console.Error.WriteLine($"  WARNING: {w.Message}");
             }

--- a/src/officecli/CommandBuilder.cs
+++ b/src/officecli/CommandBuilder.cs
@@ -1366,7 +1366,7 @@ static partial class CommandBuilder
         return true;
     }
 
-    internal static void PrintBatchResults(List<BatchResult> results, bool json, int totalCount = 0, TextWriter? output = null, bool atomicRolledBack = false)
+    internal static void PrintBatchResults(List<BatchResult> results, bool json, int totalCount = 0, TextWriter? output = null, bool atomicRolledBack = false, bool bestEffort = false)
     {
         var @out = output ?? Console.Out;
         if (totalCount == 0) totalCount = results.Count;
@@ -1383,6 +1383,7 @@ static partial class CommandBuilder
                 writer.WriteStartObject();
                 writer.WritePropertyName("results");
                 System.Text.Json.JsonSerializer.Serialize(writer, results, BatchJsonContext.Default.ListBatchResult);
+                WriteBatchFailures(writer, results);
                 writer.WriteStartObject("summary");
                 writer.WriteNumber("total", totalCount);
                 writer.WriteNumber("executed", results.Count);
@@ -1393,6 +1394,11 @@ static partial class CommandBuilder
                 // discarded the batch — parsers keying on the existing
                 // summary fields are unaffected.
                 if (atomicRolledBack) writer.WriteBoolean("atomicRolledBack", true);
+                // Additive: how many successes survive on disk under
+                // --best-effort / --stop-on-error (items the caller can keep
+                // and resume from). Absent in default atomic mode, where a
+                // rollback means nothing was retained.
+                if (bestEffort) writer.WriteNumber("partialRetained", succeeded);
                 writer.WriteEndObject();
                 writer.WriteEndObject();
             }
@@ -1440,6 +1446,7 @@ static partial class CommandBuilder
                         slimWriter.WriteEndObject();
                     }
                     slimWriter.WriteEndArray();
+                    WriteBatchFailures(slimWriter, results);
                     slimWriter.WriteStartObject("summary");
                     slimWriter.WriteNumber("total", totalCount);
                     slimWriter.WriteNumber("executed", results.Count);
@@ -1447,6 +1454,7 @@ static partial class CommandBuilder
                     slimWriter.WriteNumber("failed", failed);
                     slimWriter.WriteNumber("skipped", skipped);
                     if (atomicRolledBack) slimWriter.WriteBoolean("atomicRolledBack", true);
+                    if (bestEffort) slimWriter.WriteNumber("partialRetained", succeeded);
                     slimWriter.WriteEndObject();
                     slimWriter.WriteEndObject();
                 }
@@ -1481,7 +1489,45 @@ static partial class CommandBuilder
             // is a machine-consumed contract — extend by SUFFIX only.
             var atomicNote = atomicRolledBack ? " (atomic: no changes were applied)" : "";
             @out.WriteLine($"\nBatch complete: {succeeded} succeeded, {failed} failed, {results.Count} total{atomicNote}");
+            if (failed > 0)
+            {
+                // Machine-greppable single-line digest; --json failures[] is
+                // the structured form of the same projection.
+                var digest = string.Join("; ", results.Where(r => !r.Success).Take(10)
+                    .Select(r =>
+                    {
+                        var path = r.Item?.Path ?? r.Item?.Parent;
+                        return $"index {r.Index}: {r.Code ?? "error"}{(path != null ? $" at {path}" : "")}";
+                    }));
+                if (failed > 10) digest += $"; … ({failed - 10} more — use --json failures[])";
+                @out.WriteLine($"Failures: {failed} ({digest})");
+            }
         }
+    }
+
+    /// <summary>
+    /// Project failed items into a compact failures[] block — additive
+    /// envelope field, written only when something failed, so consumers read
+    /// one array instead of filtering results[] by success.
+    /// </summary>
+    private static void WriteBatchFailures(System.Text.Json.Utf8JsonWriter writer, List<BatchResult> results)
+    {
+        if (!results.Any(r => !r.Success)) return;
+        writer.WritePropertyName("failures");
+        writer.WriteStartArray();
+        foreach (var r in results)
+        {
+            if (r.Success) continue;
+            writer.WriteStartObject();
+            writer.WriteNumber("index", r.Index);
+            if (r.Code != null) writer.WriteString("code", r.Code);
+            if (r.Error != null) writer.WriteString("error", r.Error);
+            var path = r.Item?.Path ?? r.Item?.Parent;
+            if (path != null) writer.WriteString("path", path);
+            if (r.Suggestion != null) writer.WriteString("suggestion", r.Suggestion);
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
     }
 
     private static string FormatValidationErrors(List<ValidationError> errors)

--- a/src/officecli/ResidentServer.cs
+++ b/src/officecli/ResidentServer.cs
@@ -1365,7 +1365,7 @@ public class ResidentServer : IDisposable
         // envelope.success / exit code in lockstep with the non-resident
         // path.
         _lastBatchHadFailure = anyFailed;
-        CommandBuilder.PrintBatchResults(results, json, items.Count, atomicRolledBack: rolledBack);
+        CommandBuilder.PrintBatchResults(results, json, items.Count, atomicRolledBack: rolledBack, bestEffort: bestEffort);
         // BUG-BT2: emit the collected unrecognized-LaTeX markers so the
         // dispatcher maps them to exit 2 and the envelope warning code, exactly
         // as the single-shot resident add/set path (EmitUnrecognizedLatex) does.


### PR DESCRIPTION
## What

The batch JSON envelope gains two additive fields:

- `data.failures[]` — a compact projection of the failed items (`{index, code, error, path, suggestion}`), written only when something failed. Callers read one array instead of filtering `data.results[]` by `success`. `failures[].suggestion` surfaces the `CliException` recovery hint ("did you mean…") that was previously dropped at the catch site.
- `summary.partialRetained` — present only in `--best-effort` mode (CLI and resident), counting the successes that survive on disk for resume-from workflows. Absent in default atomic mode, where a rollback retains nothing.

Text mode appends one machine-greppable digest line after the frozen `Batch complete` line: `Failures: 1 (index 1: unsupported_property at /Sheet1/D2)` (first 10; `--json` pointer beyond that).

CLI and resident batch both route through `PrintBatchResults`, so both paths report byte-identical envelopes.

## Why

Agents consuming batch output eyeball per-item results and routinely miss the one failed item among hundreds — a real-world 40-city data load misdiagnosed "chart batch failed" for exactly this reason. `failures[]` makes the failure list first-class; `partialRetained` makes "what do I keep" explicit instead of inferred from `--best-effort` semantics.

## Implementation

- `BatchResult.Suggestion` (additive, null on most failures) + populated from `(ex as CliException)?.Suggestion` at the shared ExecuteBatchItems catch; serialized by `BatchResultConverter` and the slim spill path.
- `PrintBatchResults`: `WriteBatchFailures` helper (full + slim writers), `partialRetained` in both summary writers, text digest suffix. Signature extended with `bestEffort`; the resident call site passes its `bestEffort` so both routes stay in lockstep.
- No changes to execution, atomicity, stop-on-error, or the frozen `Batch complete` text (extended by suffix only).

## How to verify

```
officecli batch data.xlsx --commands '[{"command":"set","path":"/Sheet1/D1","props":{"value":"keep"}},{"command":"set","path":"/Sheet1/D2","props":{"border_all":1}}]' --best-effort --json
  → data.failures[0]: {"index":1,"code":"unsupported_property","path":"/Sheet1/D2",...}
    summary: {"succeeded":1,"failed":1,"partialRetained":1}
  same command without --best-effort → atomicRolledBack:true, no partialRetained, D1 not applied
  text mode → "Failures: 1 (index 1: unsupported_property at /Sheet1/D2)"
  all-green batch → no failures[] key
```

Local harness: T-05/T-06 suites green (best-effort/atomic field presence, failures[] shape, text digest, all-green omission).
