### PR TITLE
feat(cli): batch --resume — crash-safe journal for interrupted batches

### DIFF
--- a/src/officecli/CommandBuilder.Batch.cs
+++ b/src/officecli/CommandBuilder.Batch.cs
@@ -62,7 +62,8 @@ static partial class CommandBuilder
     internal static List<BatchResult> ApplyBatchItems(
         OfficeCli.Core.IDocumentHandler handler, List<BatchItem> items,
         bool stopOnError, bool json, bool skipResidentOnlyCommands = false,
-        ICollection<string>? unrecognizedLatex = null)
+        ICollection<string>? unrecognizedLatex = null,
+        OfficeCli.Core.BatchJournalWriter? journal = null)
     {
         var results = new List<BatchResult>();
         for (int bi = 0; bi < items.Count; bi++)
@@ -74,6 +75,7 @@ static partial class CommandBuilder
                 if (cmd is "open" or "close")
                 {
                     results.Add(new BatchResult { Index = bi, Success = true, Output = $"Skipped '{cmd}' (resident mode)" });
+                    journal?.ItemDone(bi, "skipped", null, null);
                     continue;
                 }
             }
@@ -105,11 +107,13 @@ static partial class CommandBuilder
                         }));
                     }
                 }
-                results.Add(new BatchResult { Index = bi, Success = true, Output = output, Warnings = warnings });
+                var successResult = new BatchResult { Index = bi, Success = true, Output = output, Warnings = warnings };
+                results.Add(successResult);
+                journal?.ItemDone(bi, "ok", null, null);
             }
             catch (Exception ex)
             {
-                results.Add(new BatchResult
+                var failureResult = new BatchResult
                 {
                     Index = bi,
                     Success = false,
@@ -117,7 +121,9 @@ static partial class CommandBuilder
                     Error = ex.Message,
                     Code = OfficeCli.Core.OutputFormatter.InferErrorCode(ex),
                     Warnings = OfficeCli.Core.WarningContext.End(),
-                });
+                };
+                results.Add(failureResult);
+                journal?.ItemDone(bi, "failed", failureResult.Code, failureResult.Error);
                 if (stopOnError) break;
             }
             // BUG-BT2: per-item unrecognized-LaTeX diagnostics. The handler
@@ -154,10 +160,11 @@ static partial class CommandBuilder
     /// </summary>
     internal static List<BatchResult> RunNonResidentBatch(
         OfficeCli.Core.IDocumentHandler handler, List<BatchItem> items,
-        bool stopOnError, bool json, ICollection<string>? unrecognizedLatex = null)
+        bool stopOnError, bool json, ICollection<string>? unrecognizedLatex = null,
+        OfficeCli.Core.BatchJournalWriter? journal = null)
     {
         if (handler is OfficeCli.Handlers.WordHandler wh) wh.DeferSave = true;
-        return ApplyBatchItems(handler, items, stopOnError, json, unrecognizedLatex: unrecognizedLatex);
+        return ApplyBatchItems(handler, items, stopOnError, json, unrecognizedLatex: unrecognizedLatex, journal: journal);
     }
 
     private static Command BuildBatchCommand(Option<bool> jsonOption)
@@ -182,10 +189,14 @@ static partial class CommandBuilder
         // old apply-what-succeeds semantics for callers that want partial
         // progress (e.g. lossy replays of dumps with known-unsupported items).
         var batchBestEffortOpt = new Option<bool>("--best-effort") { Description = "Apply the items that succeed even when others fail (pre-atomic legacy semantics). Default: any failure rolls back the whole batch" };
+        var batchResumeOpt = new Option<string?>("--resume") { Arity = ArgumentArity.ZeroOrOne, Description = "Resume an interrupted batch from its journal. Bare --resume picks the newest journal for this file; --resume <path> uses that journal. Mutually exclusive with --commands/--input/--from — the items come from the journal" };
+        var batchForceResumeOpt = new Option<bool>("--force-resume") { Description = "With --resume on an atomic-mode journal: re-run even though the file changed since the interrupted batch started" };
         var batchCommand = new Command("batch", BatchHelpDescription);
         batchCommand.Add(batchFileArg);
         batchCommand.Add(batchInputOpt);
         batchCommand.Add(batchCommandsOpt);
+        batchCommand.Add(batchResumeOpt);
+        batchCommand.Add(batchForceResumeOpt);
         batchCommand.Add(batchForceOpt);
         batchCommand.Add(batchStopOpt);
         batchCommand.Add(batchBestEffortOpt);
@@ -196,6 +207,9 @@ static partial class CommandBuilder
             var file = result.GetValue(batchFileArg)!;
             var inputFile = result.GetValue(batchInputOpt);
             var inlineCommands = result.GetValue(batchCommandsOpt);
+            var resumeAppeared = result.GetResult(batchResumeOpt) is not null;
+            var resumePath = result.GetValue(batchResumeOpt);
+            var forceResume = result.GetValue(batchForceResumeOpt);
             // Default: continue on error. --stop-on-error flips it to strict.
             // --force still acts as the docx-protection bypass (matches set
             // --force semantics) but no longer doubles as the continue-on-
@@ -204,7 +218,16 @@ static partial class CommandBuilder
             var forceFlag = result.GetValue(batchForceOpt);
             var bestEffort = result.GetValue(batchBestEffortOpt);
 
+            // Resolve a symlink up front so the final promote replaces the
+            // TARGET file; a plain rename would overwrite the link itself.
+            // (Needed early: --resume locates journals and hashes the target.)
+            string targetPath;
+            try { targetPath = new FileInfo(file.FullName).ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? file.FullName; }
+            catch { targetPath = file.FullName; }
+
             string jsonText;
+            var resumeNote = "";
+            var resumeSourceJournal = (string?)null;
             // BUG-R7-09 (F-6): previously --commands/--input/stdin were
             // silently prioritized in that order — passing two of them at
             // once dropped the lower-priority source with no warning, so
@@ -242,9 +265,10 @@ static partial class CommandBuilder
                 }
                 catch { /* treat as no confirmed payload */ }
             }
-            if (inlineCommands != null && inputFile != null)
+            var batchSourceCount = (inlineCommands != null ? 1 : 0) + (inputFile != null ? 1 : 0) + (resumeAppeared ? 1 : 0);
+            if (batchSourceCount > 1)
                 throw new ArgumentException(
-                    "batch: --commands and --input are mutually exclusive. Pick one source.");
+                    "batch: --commands, --input, and --resume are mutually exclusive. With --resume the items come from the journal.");
             // '--input -' explicitly opts INTO stdin — don't emit the
             // "stdin will be ignored" warning in that case, since stdin
             // is exactly what will be read.
@@ -257,7 +281,37 @@ static partial class CommandBuilder
                     + "stdin will be ignored. Pass only one source to silence this warning, or set "
                     + "OFFICECLI_BATCH_ALLOW_STDIN_REDIRECT=1.");
             }
-            if (inlineCommands != null)
+            if (resumeAppeared)
+            {
+                // Resume runs the non-resident path; a live resident holds the
+                // file (and may carry in-memory state), so flush+release it
+                // first. The killed run's resident is already gone — this only
+                // catches one opened after the crash.
+                // Flush + release any live resident before the non-resident
+                // resume run (dedicated close API — same as the close command).
+                if (ResidentClient.SendCloseWithResponse(file.FullName, out _))
+                {
+                    // The close round-trip can return before the resident's
+                    // file handle is fully released — wait (bounded) for
+                    // exclusive availability so hashing and the resume run's
+                    // own open can't race the release.
+                    for (var wait = 0; wait < 40; wait++)
+                    {
+                        var released = false;
+                        try
+                        {
+                            using var probe = System.IO.File.Open(targetPath, System.IO.FileMode.Open,
+                                System.IO.FileAccess.ReadWrite, System.IO.FileShare.None);
+                            released = true;
+                        }
+                        catch (System.IO.IOException) { System.Threading.Thread.Sleep(250); }
+                        if (released) break;
+                    }
+                }
+                // Source = the interrupted run's journal; items come from it.
+                (jsonText, resumeNote, resumeSourceJournal) = BuildResumeBatch(targetPath, resumePath, forceResume);
+            }
+            else if (inlineCommands != null)
             {
                 jsonText = inlineCommands;
             }
@@ -422,8 +476,38 @@ static partial class CommandBuilder
             // defers the flush to the next save/close/idle-autosave. A reader
             // that bypasses the resident must flush first (see command-open /
             // command-batch wiki "Persisting changes").
+            // Crash-resume journal (batch --resume). Every mutating batch
+            // records its items and per-item outcomes in a JSONL ledger next
+            // to the target, and DELETES the journal when the run completes
+            // with a verdict — a journal that survives means the process died
+            // mid-run. Journaled batches run the NON-resident path: the
+            // resume semantics need disk to be the source of truth (atomic
+            // temp-copy / best-effort in-place), which is this flow.
+            // OFFICECLI_BATCH_NO_JOURNAL=1 opts out (resident fast path, no
+            // journal → --resume reports journal_not_found).
+            var mutatingBatch = items.Any(it => !ReadOnlyBatchVerbs.Contains(it.Command ?? ""));
+            var journaling = mutatingBatch && Environment.GetEnvironmentVariable("OFFICECLI_BATCH_NO_JOURNAL") != "1";
+            OfficeCli.Core.BatchJournalWriter? journal = null;
+
             if (ResidentClient.TryConnect(file.FullName, out _))
             {
+                // Resident route: the CLI writes the journal header+items, the
+                // resident appends per-item lines and deletes the journal when
+                // its run completes. The resident applies in memory with a
+                // deferred flush, so a killed resident leaves the DISK at the
+                // pre-batch state — the journal records atomic semantics
+                // (resume re-runs everything), which is exact on disk.
+                string? residentJournalPath = null;
+                if (journaling)
+                {
+                    residentJournalPath = OfficeCli.Core.BatchJournal.PathFor(targetPath);
+                    journal = OfficeCli.Core.BatchJournal.Start(
+                        residentJournalPath, targetPath,
+                        OfficeCli.Core.BatchJournal.ComputeSourceHash(targetPath),
+                        items.Count, "atomic");
+                    journal.WriteItems(items);
+                    journal.Dispose(); // keep the file; the resident appends to it
+                }
                 var req = new ResidentRequest
                 {
                     Command = "batch",
@@ -436,6 +520,7 @@ static partial class CommandBuilder
                         ["bestEffort"] = bestEffort.ToString()
                     }
                 };
+                if (residentJournalPath != null) req.Args["journal"] = residentJournalPath;
                 // CONSISTENCY(resident-two-step): long connectTimeoutMs so the
                 // batch waits for its turn in the main-pipe queue instead of
                 // silently timing out under load. Matches TryResident in
@@ -443,6 +528,8 @@ static partial class CommandBuilder
                 var response = ResidentClient.TrySend(file.FullName, req, maxRetries: 3, connectTimeoutMs: 30000);
                 if (response == null)
                 {
+                    if (residentJournalPath != null)
+                        try { System.IO.File.Delete(residentJournalPath); } catch { /* best-effort */ }
                     Console.Error.WriteLine($"Resident for {file.Name} is running but the batch could not be delivered (main pipe busy or unresponsive). Retry, or run 'officecli close {file.Name}' and try again.");
                     return 3;
                 }
@@ -452,6 +539,15 @@ static partial class CommandBuilder
                 if (!string.IsNullOrEmpty(response.Stderr))
                     Console.Error.Write(response.Stderr);
                 return response.ExitCode;
+            }
+
+            if (journaling)
+            {
+                journal = OfficeCli.Core.BatchJournal.Start(
+                    OfficeCli.Core.BatchJournal.PathFor(targetPath), targetPath,
+                    OfficeCli.Core.BatchJournal.ComputeSourceHash(targetPath),
+                    items.Count, bestEffort ? "best-effort" : stopOnError ? "stop-on-error" : "atomic");
+                journal.WriteItems(items);
             }
 
             // Non-resident: open file once, execute all commands, save once.
@@ -469,11 +565,6 @@ static partial class CommandBuilder
             // the legacy run-in-place semantics; all-read-only batches skip the
             // copy (nothing to protect).
             var atomic = !bestEffort && items.Any(it => !ReadOnlyBatchVerbs.Contains(it.Command ?? ""));
-            // Resolve a symlink up front so the final promote replaces the
-            // TARGET file; a plain rename would overwrite the link itself.
-            string targetPath;
-            try { targetPath = new FileInfo(file.FullName).ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? file.FullName; }
-            catch { targetPath = file.FullName; }
             string? tmpPath = null;
             var workPath = targetPath;
             if (atomic)
@@ -583,13 +674,14 @@ static partial class CommandBuilder
                             Console.Error.WriteLine($"ERROR: {protBlock}");
                         if (tmpPath != null)
                             try { System.IO.File.Delete(tmpPath); } catch { /* best-effort */ }
+                        journal?.Complete();
                         return 1;
                     }
                 }
                 // DeferSave + replay loop, shared with the MCP batch surface. The
                 // handler's using-Dispose performs the single FinalizeDeferredIds +
                 // Save flush.
-                batchResults = RunNonResidentBatch(handler, items, stopOnError, json, batchUnrecognizedLatex);
+                batchResults = RunNonResidentBatch(handler, items, stopOnError, json, batchUnrecognizedLatex, journal);
                 batchSuccessLocal = batchResults.Count == 0 || !batchResults.Any(r => !r.Success);
                 // Watch preview: only when the document actually changes — the
                 // atomic rollback leaves the file exactly as the preview
@@ -603,6 +695,7 @@ static partial class CommandBuilder
                 // SafeRun): never leave the temp copy behind, never promote it.
                 if (tmpPath != null)
                     try { System.IO.File.Delete(tmpPath); } catch { /* best-effort */ }
+                journal?.Complete();
                 throw;
             }
             // The using-Dispose above fully serialized the (temp) document;
@@ -624,6 +717,7 @@ static partial class CommandBuilder
                     catch
                     {
                         try { System.IO.File.Delete(tmpPath); } catch { /* best-effort */ }
+                        journal?.Complete();
                         throw;
                     }
                 }
@@ -663,6 +757,13 @@ static partial class CommandBuilder
                 });
             }
             var rolledBack = atomic && !batchSuccess;
+            // Run completed with a verdict — the journal has served its purpose,
+            // and a consumed resume source journal goes with it.
+            journal?.Complete();
+            if (resumeSourceJournal != null)
+                try { System.IO.File.Delete(resumeSourceJournal); } catch { /* best-effort */ }
+            if (resumeNote != "")
+                batchWarnings.Add(new OfficeCli.Core.CliWarning { Message = resumeNote, Code = "batch_resumed" });
             if (json)
             {
                 using var sw = new System.IO.StringWriter();
@@ -679,8 +780,9 @@ static partial class CommandBuilder
             // (watch notify happened inside the handler scope above)
             // Exit precedence: a failed item (exit 1) outranks an
             // unrecognized-LaTeX-only warning (exit 2 mirrors single-shot).
+            // The batch_resumed notice is informational — never drives exit 2.
             if (!batchSuccess) return 1;
-            return batchWarnings.Count > 0 ? 2 : 0;
+            return batchWarnings.Any(w => w.Code != "batch_resumed") ? 2 : 0;
         }, json); });
 
         return batchCommand;
@@ -690,6 +792,59 @@ static partial class CommandBuilder
     // StreamReader's detect-encoding; the stdin reader feeds raw chars.
     private static string StripBom(string s)
         => !string.IsNullOrEmpty(s) && s[0] == '﻿' ? s.Substring(1) : s;
+
+    /// <summary>
+    /// Rebuild the batch from an interrupted run's journal (`batch --resume`).
+    /// An atomic-mode interruption leaves the original file untouched (the
+    /// temp copy is orphan-swept), so every item re-runs — hash-guarded
+    /// against external edits unless --force-resume. A best-effort
+    /// interruption applied its ok items in place, so only the
+    /// failed/skipped/never-started items re-run (no hash guard: the journal
+    /// statuses describe what ran, and the resume run itself carries the
+    /// normal atomic protection).
+    /// </summary>
+    private static (string jsonText, string note, string journalPath) BuildResumeBatch(string targetPath, string? resumePath, bool forceResume)
+    {
+        var journalPath = string.IsNullOrEmpty(resumePath)
+            ? OfficeCli.Core.BatchJournal.FindLatest(targetPath)
+            : resumePath;
+        if (journalPath == null || !System.IO.File.Exists(journalPath))
+            throw new OfficeCli.Core.CliException(
+                $"No interrupted batch journal found for {targetPath}.")
+            {
+                Code = "journal_not_found",
+                Suggestion = "--resume recovers a batch whose process was killed mid-run; completed runs delete their journal, so just re-run the batch from its original source."
+            };
+        var state = OfficeCli.Core.BatchJournal.Read(journalPath)
+            ?? throw new OfficeCli.Core.CliException($"Journal '{journalPath}' has no readable header.")
+            { Code = "journal_unreadable" };
+        if (state.AllItems.Count == 0)
+            throw new OfficeCli.Core.CliException($"Journal '{journalPath}' records no items to re-run.")
+            { Code = "journal_unreadable" };
+
+        var rerunAll = state.Mode != "best-effort";
+        if (rerunAll && !forceResume && !string.IsNullOrEmpty(state.SourceHash))
+        {
+            var currentHash = OfficeCli.Core.BatchJournal.ComputeSourceHash(targetPath);
+            if (currentHash != state.SourceHash)
+                throw new OfficeCli.Core.CliException(
+                    "The file changed since the interrupted batch started (journal sourceHash mismatch).")
+                {
+                    Code = "journal_hash_mismatch",
+                    Suggestion = "Inspect the file, then pass --force-resume to re-run the batch anyway."
+                };
+        }
+        var okCount = state.Items.Values.Count(s => s == "ok");
+        var rerun = rerunAll
+            ? state.AllItems
+            : state.AllItems.Where((_, i) => state.Items.GetValueOrDefault(i) != "ok").ToList();
+        if (rerun.Count == 0)
+            throw new OfficeCli.Core.CliException("Nothing to resume: every item in the journal already succeeded.")
+            { Code = "journal_nothing_to_resume" };
+        var note = $"resumed from {System.IO.Path.GetFileName(journalPath)}: re-running {rerun.Count} of {state.Total} item(s)" +
+                   (rerunAll ? " (atomic run interrupted — full re-run)" : $", skipping {okCount} already-applied");
+        return (System.Text.Json.JsonSerializer.Serialize(rerun, BatchJsonContext.Default.ListBatchItem), note, journalPath);
+    }
 
     /// <summary>
     /// UTF-8 view of the process's stdin, used everywhere this CLI reads piped

--- a/src/officecli/Core/BatchJournal.cs
+++ b/src/officecli/Core/BatchJournal.cs
@@ -1,0 +1,223 @@
+// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Security.Cryptography;
+using System.Text.Json;
+using OfficeCli;
+
+namespace OfficeCli.Core;
+
+/// <summary>
+/// Crash-resume ledger for non-resident batches (`batch --resume`).
+///
+/// The journal is an append-only JSONL file next to the target document
+/// (".{stem}.batch-journal-{timestamp}.jsonl"): a header line, one line with
+/// the full item payload list (so --resume needs no source re-supply), then
+/// one line per finished item — each appended with a flush so a kill -9
+/// leaves a readable prefix. A torn trailing line is ignored on read. JSON is
+/// written via Utf8JsonWriter / source-gen context and read via JsonDocument
+/// — no reflection, safe under publish trimming.
+///
+/// Lifecycle invariant: the journal is DELETED when a batch run completes
+/// normally (committed, rolled back, or best-effort finished-with-failures —
+/// the caller saw the verdict either way). A journal that still exists
+/// therefore means exactly one thing: the process died mid-run.
+///
+/// Resume semantics (implemented in CommandBuilder.Batch):
+///   - atomic-mode interruption: the original file was never touched (the
+///     temp copy is orphan-swept), so resume re-runs EVERY item; the
+///     sourceHash guard refuses when the file changed since the interrupted
+///     run started (external edits would be stomped) unless forced.
+///   - best-effort interruption: ok items are already applied in place, so
+///     resume re-runs only failed/skipped/never-started items as a fresh
+///     atomic batch. No hash guard — the statuses describe what ran; the
+///     resume run itself carries the normal atomic protection.
+/// </summary>
+internal static class BatchJournal
+{
+    /// <summary>Journal path for a target document: same directory, dotted prefix.</summary>
+    public static string PathFor(string targetPath)
+    {
+        var stem = System.IO.Path.GetFileNameWithoutExtension(targetPath);
+        if (stem.Length > 40) stem = stem[..40];
+        return System.IO.Path.Combine(
+            System.IO.Path.GetDirectoryName(targetPath) ?? ".",
+            $".{stem}.batch-journal-{DateTime.UtcNow:yyyyMMdd-HHmmss}-{Guid.NewGuid().ToString("N")[..6]}.jsonl");
+    }
+
+    /// <summary>Newest active (interrupted) journal for a target document, or null.</summary>
+    public static string? FindLatest(string targetPath)
+    {
+        var dir = System.IO.Path.GetDirectoryName(targetPath) ?? ".";
+        var stem = System.IO.Path.GetFileNameWithoutExtension(targetPath);
+        if (stem.Length > 40) stem = stem[..40];
+        try
+        {
+            var journals = System.IO.Directory.GetFiles(dir, $".{stem}.batch-journal-*.jsonl");
+            return journals.Length == 0
+                ? null
+                : journals.OrderByDescending(System.IO.File.GetLastWriteTimeUtc).First();
+        }
+        catch { return null; }
+    }
+
+    /// <summary>SHA-256 of the target at batch start. Empty when the file
+    /// cannot be read (a live resident holds it exclusively — the resident
+    /// batch route): the journal then records no hash and the resume guard
+    /// is skipped for that journal.</summary>
+    public static string ComputeSourceHash(string targetPath)
+    {
+        try
+        {
+            using var stream = System.IO.File.OpenRead(targetPath);
+            return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return "";
+        }
+    }
+
+    public static BatchJournalWriter Start(string journalPath, string targetPath, string sourceHash, int total, string mode) =>
+        new(journalPath, writer =>
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "header");
+            writer.WriteNumber("v", 1);
+            writer.WriteString("startedAt", DateTime.UtcNow.ToString("o"));
+            writer.WriteString("file", targetPath);
+            writer.WriteString("sourceHash", sourceHash);
+            writer.WriteNumber("total", total);
+            writer.WriteString("mode", mode);
+            writer.WriteEndObject();
+        });
+
+    /// <summary>
+    /// Fold a journal file into its recorded state. Torn/malformed lines
+    /// (kill -9 mid-append) are skipped; a journal without a header yields
+    /// null (nothing recoverable).
+    /// </summary>
+    public static BatchJournalState? Read(string journalPath)
+    {
+        if (!System.IO.File.Exists(journalPath)) return null;
+        BatchJournalState? state = null;
+        foreach (var raw in System.IO.File.ReadLines(journalPath))
+        {
+            if (string.IsNullOrWhiteSpace(raw)) continue;
+            JsonDocument doc;
+            try { doc = JsonDocument.Parse(raw); }
+            catch { continue; /* torn trailing line */ }
+            using (doc)
+            {
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object) continue;
+                if (!root.TryGetProperty("type", out var typeEl)) continue;
+                switch (typeEl.GetString())
+                {
+                    case "header":
+                        state = new BatchJournalState
+                        {
+                            Path = journalPath,
+                            SourceHash = root.TryGetProperty("sourceHash", out var hashEl) ? hashEl.GetString() ?? "" : "",
+                            Total = root.TryGetProperty("total", out var totalEl) ? totalEl.GetInt32() : 0,
+                            Mode = root.TryGetProperty("mode", out var modeEl) ? modeEl.GetString() ?? "atomic" : "atomic",
+                        };
+                        break;
+                    case "items" when state != null && root.TryGetProperty("items", out var itemsEl):
+                        try
+                        {
+                            state.AllItems = JsonSerializer.Deserialize(
+                                itemsEl.GetRawText(), OfficeCli.BatchJsonContext.Default.ListBatchItem) ?? [];
+                        }
+                        catch { /* torn items line — resume reports nothing to re-run */ }
+                        break;
+                    case "item" when state != null:
+                        if (root.TryGetProperty("index", out var idxEl))
+                            state.Items[idxEl.GetInt32()] =
+                                root.TryGetProperty("status", out var stEl) ? stEl.GetString() ?? "pending" : "pending";
+                        break;
+                }
+            }
+        }
+        return state;
+    }
+}
+
+/// <summary>Append-only journal writer; every line is flushed immediately (kill-safe).</summary>
+internal sealed class BatchJournalWriter : IDisposable
+{
+    private readonly string _path;
+    private readonly System.IO.StreamWriter _writer;
+
+    internal BatchJournalWriter(string path, Action<Utf8JsonWriter>? writeHeader)
+    {
+        _path = path;
+        _writer = new System.IO.StreamWriter(path, append: writeHeader == null) { AutoFlush = true };
+        if (writeHeader != null) RawLine(writeHeader);
+    }
+
+    /// <summary>Append to an existing journal (the resident side of a
+    /// CLI-created journal: the CLI wrote header+items, the resident appends
+    /// item lines and completes).</summary>
+    public static BatchJournalWriter Attach(string journalPath) => new(journalPath, writeHeader: null);
+
+    /// <summary>Second journal line: the full item payload list for --resume.</summary>
+    public void WriteItems(List<BatchItem> items) =>
+        RawLine(writer =>
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "items");
+            writer.WritePropertyName("items");
+            JsonSerializer.Serialize(writer, items, BatchJsonContext.Default.ListBatchItem);
+            writer.WriteEndObject();
+        });
+
+    /// <summary>Append one item-completion line.</summary>
+    public void ItemDone(int index, string status, string? code, string? errorPreview) =>
+        RawLine(writer =>
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "item");
+            writer.WriteNumber("index", index);
+            writer.WriteString("status", status);
+            if (code != null) writer.WriteString("code", code);
+            if (errorPreview != null)
+            {
+                if (errorPreview.Length > 160) errorPreview = errorPreview[..160];
+                writer.WriteString("errorPreview", errorPreview);
+            }
+            writer.WriteEndObject();
+        });
+
+    private void RawLine(Action<Utf8JsonWriter> write)
+    {
+        using var buffer = new System.IO.MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            write(writer);
+            writer.Flush();
+        }
+        _writer.WriteLine(System.Text.Encoding.UTF8.GetString(buffer.ToArray()));
+    }
+
+    /// <summary>Delete the journal — the run completed and the caller saw its verdict.</summary>
+    public void Complete()
+    {
+        Dispose();
+        try { System.IO.File.Delete(_path); } catch { /* best-effort */ }
+    }
+
+    public void Dispose() => _writer.Dispose();
+}
+
+internal class BatchJournalState
+{
+    public string Path { get; set; } = "";
+    public string SourceHash { get; set; } = "";
+    public int Total { get; set; }
+    public string Mode { get; set; } = "atomic";
+    /// <summary>The original batch items, recorded up front for --resume.</summary>
+    public List<BatchItem> AllItems { get; set; } = [];
+    /// <summary>index → recorded status ("ok" / "failed" / "skipped").</summary>
+    public Dictionary<int, string> Items { get; } = new();
+}

--- a/src/officecli/ResidentServer.cs
+++ b/src/officecli/ResidentServer.cs
@@ -1307,10 +1307,19 @@ public class ResidentServer : IDisposable
         // LastUnrecognizedLatex per item, so a post-loop read would only see
         // the last item's tokens).
         var batchUnrecognizedLatex = new List<string>();
+        // Crash-resume journal: the CLI wrote header+items before routing here
+        // (request arg "journal"); this side appends per-item lines and deletes
+        // the journal when the run completes. The resident applies in memory
+        // with a deferred flush, so a killed resident leaves the disk at the
+        // pre-batch state — matching the atomic mode the journal records.
+        OfficeCli.Core.BatchJournalWriter? journal = null;
+        var residentJournalPath = request.GetArg("journal", "");
+        if (hasMutating && residentJournalPath != "" && System.IO.File.Exists(residentJournalPath))
+            journal = OfficeCli.Core.BatchJournalWriter.Attach(residentJournalPath);
         try
         {
             results = CommandBuilder.ApplyBatchItems(_handler, items, stopOnError, json,
-                skipResidentOnlyCommands: true, unrecognizedLatex: batchUnrecognizedLatex);
+                skipResidentOnlyCommands: true, unrecognizedLatex: batchUnrecognizedLatex, journal: journal);
         }
         finally
         {
@@ -1366,6 +1375,7 @@ public class ResidentServer : IDisposable
         // path.
         _lastBatchHadFailure = anyFailed;
         CommandBuilder.PrintBatchResults(results, json, items.Count, atomicRolledBack: rolledBack);
+        journal?.Complete();
         // BUG-BT2: emit the collected unrecognized-LaTeX markers so the
         // dispatcher maps them to exit 2 and the envelope warning code, exactly
         // as the single-shot resident add/set path (EmitUnrecognizedLatex) does.


### PR DESCRIPTION
## What

Every mutating batch now records a crash-resume journal next to the target (`.{stem}.batch-journal-<ts>.jsonl`): a header line (mode + sourceHash), one line with the full item payloads (resume needs no source re-supply), and one flushed line per finished item — append-only JSONL, kill -9 safe (a torn trailing line is ignored on read). Completing the run with a verdict — committed, rolled back, or best-effort finished — DELETES the journal, so a surviving journal means exactly one thing: the process died mid-run.

```
officecli batch data.xlsx --resume [--force-resume] --json
```

Resume semantics by recorded mode:
- **atomic interruption** — the original file was never touched (the temp copy is orphan-swept), so every item re-runs; guarded by the journal's sourceHash against external edits (`journal_hash_mismatch`, `--force-resume` overrides). The guard is skipped when the journal recorded no hash (see below).
- **best-effort interruption** — ok items were applied in place, so only failed/skipped/never-started items re-run, as a fresh atomic batch. No hash guard: the statuses describe what ran; the resume run itself carries the normal atomic protection.

The envelope carries a `batch_resumed` warning describing what was re-run and skipped (informational — never drives exit 2). Consumed journals are deleted together with the run's own. No journal → `journal_not_found`.

Both execution surfaces journal: the CLI writes header+items, then the non-resident path appends per-item lines; when a live resident takes the batch, the resident attaches to the same journal (the CLI hands over the path via the request). The resident applies in memory with a deferred flush, so a killed resident also leaves the DISK at the pre-batch state — matching the atomic semantics the journal records. The source hash is computed best-effort: an unreadable (resident-locked) target records an empty hash and the guard skips that journal. `OFFICECLI_BATCH_NO_JOURNAL=1` opts out (resident fast path, no resume).

## Why

A killed 40-city-scale batch previously meant guesswork: which items landed, what to re-run. The journal turns interruption into a recoverable state with exact semantics instead of a rebuild-from-scratch, complementing atomic rollback (nothing applied) and `--best-effort` (partial applied) with a third state: interrupted-but-recoverable.

## Implementation

- New `Core/BatchJournal.cs` (~220 lines): JSONL writer (Utf8JsonWriter, flush per line) + reader (JsonDocument, torn-line tolerant) + finder; source-gen serializer for the item payloads (trim-safe, no reflection).
- `CommandBuilder.Batch.cs`: `--resume`/`--force-resume` options (four-way source mutual exclusion), resume branch (flush+release any live resident via the dedicated close API, bounded wait for handle release, hash guard, item selection re-serialized into the existing JSON pipeline), journal lifecycle at every exit path.
- `ApplyBatchItems`: optional journal writer parameter — per-item lines recorded for both execution surfaces; `ResidentServer` attaches to a CLI-created journal and completes it.
- `--resume` is one of the four batch sources and is mutually exclusive with `--commands`/`--input`/`--from`.

## How to verify

```
officecli batch data.xlsx --input big.json --json      # kill the process mid-run
ls .data.batch-journal-*.jsonl                          # journal survived; file untouched
officecli batch data.xlsx --resume --json
  → completes; warning "resumed from .data.batch-journal-…: re-running N of M item(s) (atomic run interrupted — full re-run)"; journal gone
# atomic journal + external file edit since → journal_hash_mismatch (--force-resume overrides)
# best-effort journal with item 0 ok → resume re-runs only the rest ("skipping 1 already-applied")
# no journal → journal_not_found
```

Local harness T-04: 5 suites / 14 assertions green (journal lifecycle on completion, atomic full replay, hash guard + force, best-effort incremental resume, journal_not_found). End-to-end kill test: 30,000-item batch killed at ~9s → journal survived, file untouched → `--resume` completed in ~24s with all 30,000 cells verified. Build 0 errors.
