### PR TITLE
fix(cli): normalize separator typos in prop keys; suggest bracket selectors

### DIFF
--- a/src/officecli/CommandBuilder.cs
+++ b/src/officecli/CommandBuilder.cs
@@ -779,6 +779,20 @@ static partial class CommandBuilder
             var rawKey = u.Contains(' ') ? u[..u.IndexOf(' ')] : u;
             if (props.TryGetValue(rawKey, out var val))
             {
+                // Separator normalization first (border_all → border.all,
+                // font-color → font.color): an exact normalized match is
+                // distance-0 semantics and beats a fuzzy distance-1 guess.
+                // Rides the same auto-correct channel as the distance-1
+                // fix below — the handler's own prop whitelist validates
+                // the normalized key, so a normalized miss just falls
+                // through to the unsupported path.
+                var normalized = NormalizePropertyKey(rawKey);
+                if (!string.Equals(normalized, rawKey, StringComparison.Ordinal)
+                    && handler.Set(path, new Dictionary<string, string> { [normalized] = val }).Count == 0)
+                {
+                    autoCorrected.Add((rawKey, normalized, val));
+                    continue;
+                }
                 var (suggestion, dist, isUnique) = SuggestPropertyWithDistance(rawKey, scope);
                 if (suggestion != null && dist == 1 && isUnique
                     && handler.Set(path, new Dictionary<string, string> { [suggestion] = val }).Count == 0)
@@ -1744,6 +1758,15 @@ static partial class CommandBuilder
         var (best, _, _) = SuggestPropertyWithDistance(input);
         return best;
     }
+
+    /// <summary>
+    /// snake_case / kebab-case → dotted form (border_all → border.all,
+    /// font-color → font.color). Only separators between word characters
+    /// become dots — a trailing "border_" typo stays "border_" so the
+    /// fuzzy suggester still sees the original shape.
+    /// </summary>
+    internal static string NormalizePropertyKey(string key) =>
+        System.Text.RegularExpressions.Regex.Replace(key.Trim(), @"(?<=[A-Za-z0-9])[_-](?=[A-Za-z0-9])", ".");
 
     /// <summary>
     /// Scoped variant: filters the suggestion pool against a target document

--- a/src/officecli/Handlers/Excel/ExcelHandler.Set.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Set.cs
@@ -279,7 +279,24 @@ public partial class ExcelHandler
             var xmlSegments = GenericXmlQuery.ParsePathSegments(cellRef);
             var target = GenericXmlQuery.NavigateByPath(GetSheet(worksheet), xmlSegments);
             if (target == null)
+            {
+                // Common selector misspellings: "column A" / "col/A" /
+                // "row 5" / "row/5" are the space and slash forms of the
+                // bracket selectors col[A] / row[5] — point at the exact
+                // form instead of a bare not_found (Issue #351 family).
+                var selMatch = Regex.Match(cellRef,
+                    @"^(?:column|col)[\s/]+([A-Za-z]{1,3})$|^(?:row)[\s/]+(\d{1,7})$",
+                    RegexOptions.IgnoreCase);
+                if (selMatch.Success)
+                {
+                    var hint = selMatch.Groups[1].Success
+                        ? $"col[{selMatch.Groups[1].Value.ToUpperInvariant()}]"
+                        : $"row[{selMatch.Groups[2].Value}]";
+                    throw new ArgumentException(
+                        $"Element not found: {cellRef}. Did you mean '{hint}'? Columns and rows use the bracket form (col[A], row[1]) on the target sheet.");
+                }
                 throw new ArgumentException($"Element not found: {cellRef}");
+            }
             var unsup = new List<string>();
             foreach (var (key, value) in properties)
             {


### PR DESCRIPTION
## What

Two self-documenting-error additions:

1. **Property-key separator normalization** in `ApplySetWithCorrection` (the one shared core behind CLI set / batch / MCP / resident): an unsupported key that becomes valid when snake_case/kebab-case separators turn into dots is retried as the dotted form through the same auto-correct channel as the existing distance-1 fix. `border_all=thin` now applies `border.all=thin` and reports `Auto-corrected 'border_all' to 'border.all'` (code `auto_corrected`). The handler's own prop whitelist validates the normalized key — a normalized miss falls through to the unsupported path unchanged. Normalization runs before the fuzzy distance-1 suggester: an exact normalized match outranks a fuzzy guess.

2. **Excel selector hints**: the column/row space and slash forms (`column A`, `col/A`, `row 5`, `row/5`) now point at the exact bracket form instead of a bare `not_found`:
   `Element not found: column A. Did you mean 'col[A]'? Columns and rows use the bracket form (col[A], row[1]) on the target sheet.`

## Why

Agents at 40-city data-load scale repeatedly wrote `border_all` (silently no-oping for hundreds of cells before anyone noticed) and `/Sheet1/column A` (failing with no way out) — the Issue #351 silent/misleading-failure family. Both shapes are now either auto-corrected with a visible receipt, or self-documenting.

## Implementation

- `NormalizePropertyKey` in CommandBuilder.cs: separators *between* word characters become dots (a trailing `border_` stays `border_` so the fuzzy suggester still sees the original shape).
- ExcelHandler.Set.cs generic-fallback failure: regex match on the space/slash selector forms → targeted hint, else the original error.

## How to verify

```
officecli set data.xlsx /Sheet1/A1 --prop border_all=thin --json
  → success + warnings[{code:auto_corrected, message:Auto-corrected 'border_all' to 'border.all'}]; border.all applied
officecli set data.xlsx /Sheet1/A1 --prop font-color=FF0000 --json
  → font.color applied
officecli set data.xlsx '/Sheet1/column A' --prop width=12
  → not_found + "Did you mean 'col[A]'"
officecli set data.xlsx /Sheet1/A1 --prop bol=true
  → distance-1 channel unchanged ('bol' → 'bold')
```

Local harness T-02: 5 suites / 9 assertions green (snake_case, kebab_case with file-fact readback, both selector forms, row form, distance-1 regression guard).
