### PR TITLE
feat(excel): row-height autofit — row and sheet level

### DIFF
--- a/schemas/help/xlsx/row.json
+++ b/schemas/help/xlsx/row.json
@@ -93,6 +93,14 @@
       "readback": "true when the row group is collapsed",
       "enforcement": "report"
     },
-    "customHeight": { "type":"bool", "add":false, "set":false, "get":true, "description":"true when the row carries an explicit height (Row @customHeight). Get-only flag.", "readback":"true when row has a custom height", "enforcement":"report" }
+    "customHeight": { "type":"bool", "add":false, "set":false, "get":true, "description":"true when the row carries an explicit height (Row @customHeight). Get-only flag.", "readback":"true when row has a custom height", "enforcement":"report" },
+    "autofit": {
+      "type": "bool",
+      "description": "auto-fit row height to wrapped cell content (heuristic estimate: wrapped line count x 15pt line pitch, clamped 15-409pt; CJK-aware width table). Write after column widths are final - the wrap estimate depends on them. Excel in-app autofit stays available for font-exact sizing.",
+      "add": false, "set": true, "get": false,
+      "examples": ["--prop autofit=true"],
+      "readback": "resolves to height at Set time (pt-suffixed on row get)",
+      "enforcement": "strict"
+    }
   }
 }

--- a/schemas/help/xlsx/sheet.json
+++ b/schemas/help/xlsx/sheet.json
@@ -266,6 +266,14 @@
       "add": false, "set": false, "get": true,
       "readback": "comma-separated column break indices",
       "enforcement": "report"
+    },
+    "autofit": {
+      "type": "bool",
+      "description": "auto-fit the whole sheet: columns first, then rows (row-height wrap estimates consume the final column widths).",
+      "add": false, "set": true, "get": false,
+      "examples": ["--prop autofit=true"],
+      "readback": "none (write-only operation; per-column/row results read back on col/row get)",
+      "enforcement": "strict"
     }
   },
   "children": [

--- a/src/officecli/Handlers/Excel/ExcelHandler.Set.RowsCols.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Set.RowsCols.cs
@@ -235,6 +235,69 @@ public partial class ExcelHandler
         SaveWorksheet(worksheet);
     }
 
+    /// <summary>
+    /// Heuristic row height (no rendering engine): per cell, the wrapped line
+    /// count is ceil(display width / effective column width) summed over the
+    /// cell's explicit newline segments; the row height is max-lines × 15pt
+    /// line pitch (the 11pt Calibri default), clamped to Excel's 15–409pt
+    /// range. Run AFTER column autofit — the wrap estimate depends on the
+    /// final column widths. Excel's own autofit stays available in-app for
+    /// font-exact sizing.
+    /// </summary>
+    private double CalculateAutoFitHeight(WorksheetPart worksheet, int rowIdx)
+    {
+        const double LinePitchPt = 15.0;
+        const double DefaultColWidthChars = 8.43;
+
+        var ws = GetSheet(worksheet);
+        var sheetData = ws.GetFirstChild<SheetData>();
+        var row = sheetData?.Elements<Row>().FirstOrDefault(r => r.RowIndex?.Value == rowIdx);
+        if (row == null) return LinePitchPt;
+
+        double EffectiveWidth(int colIdx)
+        {
+            var cols = ws.GetFirstChild<Columns>();
+            var col = cols?.Elements<Column>()
+                .FirstOrDefault(c => c.Min?.Value <= colIdx && c.Max?.Value >= colIdx);
+            return col?.Width?.Value is double w && w > 0 ? w : DefaultColWidthChars;
+        }
+
+        var maxLines = 1;
+        foreach (var cell in row.Elements<Cell>())
+        {
+            var cellRef = cell.CellReference?.Value;
+            if (cellRef == null) continue;
+            var (cellCol, _) = ParseCellReference(cellRef);
+            var text = GetCellDisplayValue(cell);
+            if (string.IsNullOrEmpty(text)) continue;
+            var widthChars = EffectiveWidth(ColumnNameToIndex(cellCol));
+            int lines = 0;
+            foreach (var segment in text.Split('\n'))
+            {
+                var segWidth = ParseHelpers.EstimateTextWidthInChars(segment);
+                lines += Math.Max(1, (int)Math.Ceiling(segWidth / widthChars));
+            }
+            if (lines > maxLines) maxLines = lines;
+        }
+
+        return Math.Clamp(maxLines * LinePitchPt, 15, 409);
+    }
+
+    private void AutoFitAllRows(WorksheetPart worksheet)
+    {
+        var ws = GetSheet(worksheet);
+        var sheetData = ws.GetFirstChild<SheetData>();
+        if (sheetData == null) return;
+
+        foreach (var row in sheetData.Elements<Row>())
+        {
+            if (row.RowIndex == null || !row.Elements<Cell>().Any()) continue;
+            row.Height = CalculateAutoFitHeight(worksheet, (int)row.RowIndex.Value);
+            row.CustomHeight = true;
+        }
+        SaveWorksheet(worksheet);
+    }
+
     // ==================== Row Set (height, hidden) ====================
 
     // Set a manual page break's position / span / manual flag, keeping the
@@ -371,6 +434,13 @@ public partial class ExcelHandler
                 case "collapsed":
                     row.Collapsed = value.Equals("true", StringComparison.OrdinalIgnoreCase)
                         || value == "1" || value.Equals("yes", StringComparison.OrdinalIgnoreCase);
+                    break;
+                case "autofit":
+                    if (ParseHelpers.IsTruthy(value))
+                    {
+                        row.Height = CalculateAutoFitHeight(worksheet, (int)rowIdx);
+                        row.CustomHeight = true;
+                    }
                     break;
                 default:
                     // A non-row-attribute key. First try it as a TABLE COLUMN on

--- a/src/officecli/Handlers/Excel/ExcelHandler.Set.Sheet.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Set.Sheet.cs
@@ -417,7 +417,12 @@ public partial class ExcelHandler
                 case "autofit":
                 {
                     if (ParseHelpers.IsTruthy(value))
+                    {
+                        // Columns first, then rows: the row wrap estimate
+                        // depends on the final column widths.
                         AutoFitAllColumns(worksheet);
+                        AutoFitAllRows(worksheet);
+                    }
                     break;
                 }
                 case "zoom" or "zoomscale":


### PR DESCRIPTION
## What

`autofit=true` now works on rows, mirroring the column autofit:

```
officecli set data.xlsx '/Sheet1/row[7]' --prop autofit=true
officecli set data.xlsx /Sheet1 --prop autofit=true   # columns, then rows
```

Heuristic (no rendering engine): per cell, the wrapped line count is the sum over the cell's newline segments of ceil(display width / effective column width); the row height is max-lines × 15pt line pitch (11pt Calibri default), clamped to Excel's 15-409pt range, written with `customHeight=true`. The sheet-level form runs columns FIRST, then rows — the wrap estimate depends on the final column widths.

## Why

Agents had column autofit but no row-height story: wrapped/CJK rows clipped with no recovery except hand-computed heights (a real 40-city KPI row needed two rounds of manual tuning). Excel's in-app autofit stays available for font-exact sizing; this gives the CLI a sane default.

## Implementation

- `CalculateAutoFitHeight` + `AutoFitAllRows` in `ExcelHandler.Set.RowsCols.cs` (next to the existing column autofit, reusing `GetCellDisplayValue` + `ParseHelpers.EstimateTextWidthInChars`, incl. its CJK width table).
- `set row[N] --prop autofit=true` case in the row property switch; sheet-level `autofit` extended to rows after columns.

## How to verify

```
set a 60-char string in A1, then:
officecli set data.xlsx '/Sheet1/row[1]' --prop autofit=true
  → row height 120pt (8 wrapped lines × 15pt), customHeight set
single-line row → 15pt
officecli set data.xlsx /Sheet1 --prop autofit=true
  → columns widen, rows re-fit after; validate clean
```

Local harness T-07: 4 suites / 9 assertions green (wrapped, CJK, single-line, sheet-level order, numeric_overflow suggestion intact).
