### PR TITLE
fix(xlsx): preserve files when set rejects a missing sheet

### DIFF
--- a/src/officecli/Handlers/Excel/ExcelHandler.Set.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Set.cs
@@ -16,8 +16,27 @@ namespace OfficeCli.Handlers;
 
 public partial class ExcelHandler
 {
+    // Resolve sheet-scoped paths before either the handler or a resident marks
+    // the document dirty. A missing sheet must not turn a rejected set into a
+    // save. Keep selector and workbook-level dispatch in Set itself.
+    internal void ValidateSetSheet(string path)
+    {
+        if (!string.IsNullOrEmpty(path)
+            && (!path.StartsWith("/") || AttributeFilter.IsContentFilterPath(path)))
+            return;
+
+        path = ResolveSheetIndexInPath(NormalizeExcelPath(path));
+        if (path == "/" || Regex.IsMatch(path.TrimStart('/'), @"^namedrange\[(.+?)\]$", RegexOptions.IgnoreCase))
+            return;
+
+        var sheetName = path.TrimStart('/').Split('/', 2)[0];
+        if (FindWorksheet(sheetName) == null)
+            throw SheetNotFoundException(sheetName);
+    }
+
     public List<string> Set(string path, Dictionary<string, string> properties)
     {
+        ValidateSetSheet(path);
         Modified = true;
         // Batch Set: route to the shared filter engine when the path is a bare
         // selector (no `/`) OR a `/`-scoped path that carries a content filter

--- a/src/officecli/ResidentServer.cs
+++ b/src/officecli/ResidentServer.cs
@@ -1095,6 +1095,10 @@ public class ResidentServer : IDisposable
                 ExecuteQuery(request, format);
                 break;
             case "set":
+                // Reject missing Excel sheets before promotion latches _dirty;
+                // otherwise save/idle-autosave can rewrite an untouched file.
+                if (_handler is ExcelHandler excel)
+                    excel.ValidateSetSheet(request.GetArg("path"));
                 PromoteToEditable();
                 ExecuteSet(request);
                 NotifyWatchSlideChanged(request.GetArg("path"));


### PR DESCRIPTION
## Problem

Follow-up to #390 and upstream e3623a3d.

Upstream e3623a3d restores the handler's `Modified` flag after a rejected mutation, fixing direct invocation. The resident still calls `PromoteToEditable()` before Set resolves the worksheet, so a rejected sheet-scoped command can leave the resident dirty and a later explicit or idle save can rewrite the workbook.

## Change

Validate the worksheet before resident promotion. Reuse the existing path normalization, sheet-index resolution and missing-sheet diagnostic; leave upstream's `MarkModified` wrapper and direct Set behavior intact. Workbook-level paths and selector dispatch keep their existing handling.

This is deliberately limited to early sheet/path resolution: it does not introduce transactional Set, discard partial edits, or change batch rollback and global Save behavior. Earlier successful resident edits remain pending and can still be saved.

## Validation

The script below uses only Python's standard library and a built `officecli` executable. It checks direct invocation as a control and then resident save/close. It passed against this narrowed patch on upstream main `5a938d2d`.

```python
import hashlib, os, pathlib, subprocess, sys, tempfile

cli = str(pathlib.Path(sys.argv[1]).resolve())
env = dict(os.environ, OFFICECLI_NO_AUTO_RESIDENT="1",
           OFFICECLI_NO_AUTO_INSTALL="1", OFFICECLI_SKIP_UPDATE="1",
           OFFICECLI_RESIDENT_FLUSH="off")

def run(*args, expected=0):
    result = subprocess.run([cli, *map(str, args)], env=env,
                            capture_output=True, text=True, timeout=30)
    assert result.returncode == expected, (result.stdout, result.stderr)

def sha(path):
    return hashlib.sha256(path.read_bytes()).hexdigest()

with tempfile.TemporaryDirectory(prefix="officecli-rejected-set-") as tmp:
    for resident in (False, True):
        path = pathlib.Path(tmp) / f"case-{resident}.xlsx"
        run("create", path)
        before = sha(path)
        if resident:
            run("open", path)
        try:
            run("set", path, "/NoSuchSheet/A1", "--prop", "value=1", expected=1)
            if resident:
                run("save", path)
        finally:
            if resident:
                run("close", path)
        assert sha(path) == before, f"rejected set rewrote {path.name}"
print("Direct and resident byte-preservation checks passed")
```

Run as `python3 check.py /absolute/path/to/officecli`.

Additional local synthetic-package coverage: missing worksheet, out-of-range sheet index and missing-sheet sparkline path; direct execution, resident flush-off, flush-each and one-second idle saves; preservation of earlier unflushed edits and clean state after an explicit save; atomic batch rollback; valid workbook, range, sheet-index, bang-notation and named-range Set paths, including in-memory sheet renames with `!` in the name.

Both Release builds passed on macOS arm64 / .NET 10.0.400, with the same pre-existing CS8602 warning in `ExcelHandler.SheetShift.cs`. On unmodified upstream `5a938d2d`, direct execution passes, but nine missing-sheet resident scenarios and the already-saved resident scenario still fail preservation/clean-state checks. All 30 regression scenarios pass with this patch, and the standalone script above passes independently.

These checks inspect file bytes and saved OOXML, not native Excel GUI rendering. Windows runtime validation was not performed.
