### PR TITLE
feat(excel): formula dependency trace — get --prop trace=precedents|dependents

### DIFF
--- a/src/officecli/CommandBuilder.GetQuery.cs
+++ b/src/officecli/CommandBuilder.GetQuery.cs
@@ -16,12 +16,14 @@ static partial class CommandBuilder
         pathArg.DefaultValueFactory = _ => "/";
         var depthOpt = new Option<int>("--depth") { Description = "Depth of child nodes to include" };
         depthOpt.DefaultValueFactory = _ => 1;
+        var getPropOpt = new Option<string[]>("--prop") { Description = "Property to read (key=value). Supported on xlsx cells: trace=precedents|dependents, depth=N (trace hops, 1-16)", AllowMultipleArgumentsPerToken = true };
         var saveOpt = new Option<string?>("--save") { Description = "Extract the backing binary payload (picture/ole/media) to this file path" };
 
         var getCommand = new Command("get", "Get a document node by path");
         getCommand.Add(getFileArg);
         getCommand.Add(pathArg);
         getCommand.Add(depthOpt);
+        getCommand.Add(getPropOpt);
         getCommand.Add(saveOpt);
         getCommand.Add(jsonOption);
 
@@ -37,6 +39,7 @@ static partial class CommandBuilder
             if (depth > DocumentLimits.MaxRecursionDepth)
                 depth = DocumentLimits.MaxRecursionDepth;
             var savePath = result.GetValue(saveOpt);
+            var (traceMode, traceDepth) = ParseGetTraceProps(result.GetValue(getPropOpt));
 
             // Special pseudo-path "selected" — query the running watch process
             // for the currently-selected element paths and resolve them to nodes.
@@ -51,6 +54,11 @@ static partial class CommandBuilder
                 req.Json = json;
                 req.Args["path"] = path;
                 req.Args["depth"] = depth.ToString();
+                if (traceMode != null)
+                {
+                    req.Args["trace"] = traceMode;
+                    req.Args["traceDepth"] = traceDepth.ToString();
+                }
                 if (!string.IsNullOrEmpty(savePath)) req.Args["save"] = savePath;
             }, json) is {} rc) return rc;
 
@@ -70,6 +78,18 @@ static partial class CommandBuilder
                 else
                     Console.Error.WriteLine($"Error: {err}");
                 return 1;
+            }
+
+            // Formula dependency trace (xlsx cells): attach the trace payload
+            // to the cell node — a pure Format addition, the node itself is
+            // exactly what a plain get would return.
+            OfficeCli.Core.TraceOutput? traceOutput = null;
+            if (traceMode != null)
+            {
+                if (handler is ExcelHandler excelHandler)
+                    traceOutput = excelHandler.AttachTrace(node, node.Path, traceMode, traceDepth, attachToFormat: json);
+                else
+                    throw new OfficeCli.Core.CliException("trace is only supported for xlsx documents.") { Code = "unsupported_type" };
             }
 
             // --save <path>: extract the binary payload backing an OLE /
@@ -102,11 +122,65 @@ static partial class CommandBuilder
                 Console.WriteLine(OutputFormatter.WrapEnvelope(
                     OutputFormatter.FormatNodes(new List<DocumentNode> { node }, OutputFormat.Json)));
             else
+            {
                 Console.WriteLine(OutputFormatter.FormatNode(node, OutputFormat.Text));
+                if (traceOutput != null)
+                    Console.WriteLine(OfficeCli.Core.FormulaTrace.RenderTree(traceOutput, dependents: string.Equals(traceMode, "dependents", StringComparison.OrdinalIgnoreCase)));
+            }
             return 0;
         }, json); });
 
         return getCommand;
+    }
+
+    /// <summary>
+    /// Validate get's --prop set. Only the trace knobs are meaningful on a
+    /// read: trace=precedents|dependents and depth=N (trace hops). Unknown
+    /// keys hard-reject — a silently ignored prop is the bug class #383 was
+    /// about. depth without trace is rejected too (it would be a no-op).
+    /// </summary>
+    private static (string? Mode, int Depth) ParseGetTraceProps(string[]? props)
+    {
+        if (props == null || props.Length == 0) return (null, FormulaTrace.DefaultDepth);
+        var parsed = ParsePropsArray(props);
+        string? mode = null;
+        var depth = FormulaTrace.DefaultDepth;
+        foreach (var key in parsed.Keys)
+        {
+            if (key.Equals("trace", StringComparison.OrdinalIgnoreCase)) continue;
+            if (key.Equals("depth", StringComparison.OrdinalIgnoreCase)) continue;
+            throw new CliException($"Unknown get --prop '{key}'.")
+            {
+                Code = "invalid_argument",
+                Suggestion = "get supports trace=precedents|dependents and depth=N (trace hops)"
+            };
+        }
+        if (parsed.TryGetValue("trace", out var traceValue))
+        {
+            if (!traceValue.Equals("precedents", StringComparison.OrdinalIgnoreCase) &&
+                !traceValue.Equals("dependents", StringComparison.OrdinalIgnoreCase))
+                throw new CliException($"Unknown trace mode: '{traceValue}'.")
+                {
+                    Code = "invalid_argument",
+                    ValidValues = ["precedents", "dependents"],
+                    Suggestion = "trace=precedents walks what the cell depends on; trace=dependents walks who depends on it"
+                };
+            mode = traceValue.ToLowerInvariant();
+        }
+        if (parsed.TryGetValue("depth", out var depthValue))
+        {
+            if (!int.TryParse(depthValue, out var d) || d < 1 || d > FormulaTrace.MaxDepth)
+                throw new CliException($"trace depth must be an integer between 1 and {FormulaTrace.MaxDepth} (got '{depthValue}').")
+                {
+                    Code = "invalid_argument",
+                    Suggestion = "--prop depth=3 walks three hops of the dependency chain"
+                };
+            depth = d;
+        }
+        if (mode == null && parsed.ContainsKey("depth"))
+            throw new CliException("--prop depth is only meaningful together with --prop trace=precedents|dependents.")
+            { Code = "invalid_argument", Suggestion = "add --prop trace=precedents (or dependents)" };
+        return (mode, depth);
     }
 
     private static int GetSelectedAction(string filePath, int depth, bool json)

--- a/src/officecli/Core/FormulaTrace.cs
+++ b/src/officecli/Core/FormulaTrace.cs
@@ -1,0 +1,384 @@
+// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace OfficeCli.Core;
+
+/// <summary>
+/// One reference collected from a formula's token stream. Single cells carry
+/// R1==R2 and C1==C2; an unbounded side (whole-column / whole-row forms like
+/// A:A, 1:5) marks the open bound with 0 and is resolved against the sheet's
+/// used range by the consumer. <see cref="Sheet"/> is null for a same-sheet
+/// reference — resolve against the formula's own sheet.
+/// </summary>
+/// <remarks>
+/// There is no table-formula AST: the evaluator's recursive-descent parser
+/// consumes the token stream directly, and defined names are folded by the
+/// tokenizer itself (simple bodies emit their literal ref token; formula
+/// bodies are inlined). The token stream is therefore the single source of
+/// truth for dependency tracing.
+/// </remarks>
+internal sealed record TraceRef(string? Sheet, int R1, int C1, int R2, int C2);
+
+/// <summary>A cell address inside a trace walk. Sheet is always the canonical
+/// workbook sheet name by the time the engine sees it.</summary>
+internal readonly record struct TraceCell(string Sheet, string CellRef);
+
+/// <summary>One BFS hop: the visited cell, and the cells it depends on
+/// (precedents) or that depend on it (dependents). Nodes are display paths in
+/// the get path grammar: same-sheet "/Sheet1/B2", cross-sheet "/Sheet2!B2".</summary>
+internal sealed record TraceEdge(string From, List<string> To);
+
+internal sealed record TraceOutput(string Root, List<TraceEdge> Edges, bool Truncated);
+
+/// <summary>
+/// Read-only view over a workbook for <see cref="FormulaTrace.Trace"/>.
+/// Implemented by the Excel handler; every member must be side-effect free.
+/// </summary>
+internal interface IFormulaTraceSource
+{
+    /// <summary>Token references of the formula at <paramref name="cell"/>, or
+    /// null when the cell has no formula or its text does not tokenize.</summary>
+    List<TraceRef>? RefsOf(TraceCell cell);
+
+    /// <summary>Populated bounds (max row, max col; 0 when the sheet is empty),
+    /// used to resolve unbounded range sides.</summary>
+    (int MaxRow, int MaxCol) UsedRange(string sheet);
+
+    /// <summary>Cells whose formulas reference the given cell, in deterministic
+    /// build order. Empty when nothing references it.</summary>
+    List<TraceCell> DependentsOf(string sheet, int row, int col);
+}
+
+/// <summary>
+/// Formula dependency tracing over the evaluator's token stream (B2 task /
+/// 03 §9). Precedents walk the refs of each visited cell's formula; dependents
+/// answer through the source's reverse index. Pure graph walk — no evaluation,
+/// no writes. Cycles terminate via a visited set while still being REPORTED:
+/// edges list every ref of a cell, so A1=B1 / B1=A1 shows both hops.
+/// </summary>
+internal static class FormulaTrace
+{
+    internal const int DefaultDepth = 1;
+    internal const int MaxDepth = 16;
+    /// <summary>Leaf cap per range reference: a SUM over 100k cells must not
+    /// materialize 100k edge nodes. Row-major from the range's top-left; the
+    /// overflow sets <see cref="TraceOutput.Truncated"/>.</summary>
+    internal const int MaxLeafCellsPerRange = 5000;
+    /// <summary>Global leaf budget across the whole trace output.</summary>
+    internal const int MaxTotalLeaves = 20000;
+    /// <summary>Global edge budget (wide dependent fan-out protection).</summary>
+    internal const int MaxEdges = 5000;
+
+    public static TraceOutput Trace(IFormulaTraceSource src, string rootSheet, string rootCell,
+        bool dependents, int depth)
+    {
+        depth = Math.Clamp(depth, 1, MaxDepth);
+        var edges = new List<TraceEdge>();
+        var truncated = false;
+        long totalLeaves = 0;
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var rootDisplay = FormatCell(new TraceCell(rootSheet, rootCell), rootSheet);
+        var queue = new Queue<(TraceCell Cell, string Display)>();
+        queue.Enqueue((new TraceCell(rootSheet, rootCell), rootDisplay));
+        visited.Add(Key(rootSheet, rootCell));
+
+        for (var level = 0; level < depth && queue.Count > 0 && edges.Count < MaxEdges; level++)
+        {
+            var levelSize = queue.Count;
+            while (levelSize-- > 0 && edges.Count < MaxEdges)
+            {
+                var (cell, display) = queue.Dequeue();
+
+                var to = new List<string>();
+                var targets = new List<TraceCell>();
+                if (dependents)
+                {
+                    var (row, col) = ParseCellRef(cell.CellRef);
+                    targets = src.DependentsOf(cell.Sheet, row, col);
+                }
+                else
+                {
+                    var refs = src.RefsOf(cell);
+                    if (refs != null)
+                        foreach (var rf in refs)
+                        {
+                            if (totalLeaves >= MaxTotalLeaves) { truncated = true; break; }
+                            foreach (var leaf in ExpandRef(src, rf, cell.Sheet, ref truncated))
+                            {
+                                if (totalLeaves >= MaxTotalLeaves) { truncated = true; break; }
+                                targets.Add(leaf);
+                                totalLeaves++;
+                            }
+                        }
+                }
+
+                foreach (var t in targets)
+                    AddUnique(to, FormatCell(t, cell.Sheet));
+                if (to.Count == 0) continue;
+
+                edges.Add(new TraceEdge(display, to));
+                if (edges.Count >= MaxEdges) { truncated = true; break; }
+                foreach (var t in targets)
+                {
+                    if (visited.Add(Key(t.Sheet, t.CellRef)))
+                        queue.Enqueue((t, FormatCell(t, cell.Sheet)));
+                }
+            }
+        }
+        return new TraceOutput(rootDisplay, edges, truncated);
+    }
+
+    /// <summary>
+    /// Resolve one reference into cell leaves. Unbounded sides clamp to the
+    /// sheet's used range; a range wider than <see cref="MaxLeafCellsPerRange"/>
+    /// truncates row-major from the top-left and flags the output.
+    /// </summary>
+    private static List<TraceCell> ExpandRef(IFormulaTraceSource src, TraceRef rf, string ownerSheet, ref bool truncated)
+    {
+        var sheet = rf.Sheet ?? ownerSheet;
+        int r2, c2;
+        if (rf.R2 == 0 || rf.C2 == 0)
+        {
+            var (maxRow, maxCol) = src.UsedRange(sheet);
+            // An unbounded range on an empty sheet still covers its first cell
+            // (SUM(A:A) depends on A1 the moment A1 exists), so clamp to 1, not 0.
+            r2 = rf.R2 == 0 ? Math.Max(1, maxRow) : rf.R2;
+            c2 = rf.C2 == 0 ? Math.Max(1, maxCol) : rf.C2;
+        }
+        else { r2 = rf.R2; c2 = rf.C2; }
+        var (r1, c1) = (Math.Max(1, rf.R1), Math.Max(1, rf.C1));
+        if (r2 < r1) r2 = r1;
+        if (c2 < c1) c2 = c1;
+
+        var leaves = new List<TraceCell>();
+        var count = (long)(r2 - r1 + 1) * (c2 - c1 + 1);
+        var emitted = 0L;
+        for (var r = r1; r <= r2; r++)
+        {
+            if (emitted >= MaxLeafCellsPerRange) { truncated = true; break; }
+            for (var c = c1; c <= c2; c++)
+            {
+                if (emitted >= MaxLeafCellsPerRange) { truncated = true; break; }
+                leaves.Add(new TraceCell(sheet, $"{ColToName(c)}{r}"));
+                emitted++;
+            }
+        }
+        if (count > MaxLeafCellsPerRange) truncated = true;
+        return leaves;
+    }
+
+    private static bool AddUnique(List<string> list, string item)
+    {
+        if (list.Contains(item)) return false;
+        list.Add(item);
+        return true;
+    }
+
+    private static string Key(string sheet, string cell) => $"{sheet.ToUpperInvariant()}!{cell.ToUpperInvariant()}";
+
+    /// <summary>Same-sheet nodes render under the formula owner's sheet
+    /// ("/Sheet1/B2"); cross-sheet nodes render fully qualified ("/Sheet2!B2").</summary>
+    private static string FormatCell(TraceCell cell, string ownerSheet)
+        => string.Equals(cell.Sheet, ownerSheet, StringComparison.OrdinalIgnoreCase)
+            ? $"/{cell.Sheet}/{cell.CellRef}"
+            : $"/{cell.Sheet}!{cell.CellRef}";
+
+    /// <summary>"B2" → (row 2, col 2). Caller guarantees the cell shape.</summary>
+    internal static (int Row, int Col) ParseCellRef(string cellRef)
+    {
+        var i = 0;
+        while (i < cellRef.Length && char.IsAsciiLetter(cellRef[i])) i++;
+        var col = 0;
+        foreach (var ch in cellRef[..i])
+            col = col * 26 + (char.ToUpperInvariant(ch) - 'A' + 1);
+        return (int.Parse(cellRef[i..]), col);
+    }
+
+    internal static string ColToName(int col)
+    {
+        var sb = new StringBuilder();
+        while (col > 0)
+        {
+            var rem = (col - 1) % 26;
+            sb.Insert(0, (char)('A' + rem));
+            col = (col - 1) / 26;
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Text-mode rendering: indented tree, children under their formula cell.
+    /// A node reachable through multiple parents renders under each; a node on
+    /// its own ancestor path is a circular reference and is marked once.
+    /// </summary>
+    public static string RenderTree(TraceOutput t, bool dependents)
+    {
+        var byFrom = new Dictionary<string, TraceEdge>(StringComparer.Ordinal);
+        foreach (var e in t.Edges) byFrom[e.From] = e;
+        var sb = new StringBuilder();
+        sb.AppendLine($"trace ({(dependents ? "dependents" : "precedents")}) of {t.Root}:");
+        Render(sb, t.Root, byFrom, new HashSet<string>(StringComparer.Ordinal), 0, dependents);
+        if (t.Truncated) sb.AppendLine("(truncated — output exceeded leaf/edge caps)");
+        return sb.ToString().TrimEnd();
+    }
+
+    private static void Render(StringBuilder sb, string node, Dictionary<string, TraceEdge> byFrom,
+        HashSet<string> path, int depth, bool dependents)
+    {
+        sb.Append(' ', depth * 2 + 2);
+        if (depth > 0) sb.Append(dependents ? "-> " : "<- ");
+        sb.AppendLine(node);
+        if (!path.Add(node))
+        {
+            sb.Append(' ', depth * 2 + 4);
+            sb.AppendLine("(circular reference)");
+            return;
+        }
+        if (byFrom.TryGetValue(node, out var edge) && depth < MaxDepth)
+            foreach (var to in edge.To)
+                Render(sb, to, byFrom, path, depth + 1, dependents);
+        path.Remove(node);
+    }
+}
+
+/// <summary>
+/// Trace side of the evaluator partial: expose the token stream without
+/// evaluating. Lives here so the token types (private to the evaluator)
+/// never leak into the trace engine above.
+/// </summary>
+internal partial class FormulaEvaluator
+{
+    /// <summary>
+    /// Collect the reference tokens of a formula WITHOUT evaluating it.
+    /// Defined names are already folded by the tokenizer (simple bodies emit
+    /// their literal ref; formula bodies are inlined), so this covers cell,
+    /// range, sheet-qualified, and named references in one pass. Returns null
+    /// when the formula does not tokenize — trace degrades to "no collectable
+    /// references" rather than failing the whole walk.
+    /// </summary>
+    internal List<TraceRef>? TryCollectRefs(string formula)
+    {
+        try
+        {
+            var tokens = Tokenize(ModernFunctionQualifier.Unqualify(formula));
+            var refs = new List<TraceRef>();
+            foreach (var t in tokens)
+            {
+                switch (t.Type)
+                {
+                    case TT.CellRef:
+                        if (TraceRefParser.TryCellRef(t.Value, out var r1, out var c1))
+                            refs.Add(new TraceRef(null, r1, c1, r1, c1));
+                        break;
+                    case TT.SheetCellRef:
+                        SplitSheetToken(t.Value, out var sheet1, out var ref1);
+                        if (TraceRefParser.TryCellRef(ref1, out var sr, out var sc))
+                            refs.Add(new TraceRef(sheet1, sr, sc, sr, sc));
+                        break;
+                    case TT.Range:
+                        if (TraceRefParser.TryRange(t.Value, out var rng))
+                            refs.Add(rng with { Sheet = null });
+                        break;
+                    case TT.SheetRange:
+                        SplitSheetToken(t.Value, out var sheet2, out var ref2);
+                        if (TraceRefParser.TryRange(ref2, out var rng2))
+                            refs.Add(rng2 with { Sheet = sheet2 });
+                        break;
+                }
+            }
+            return refs;
+        }
+        catch (NameResolutionException) { return null; }
+        catch (NotSupportedException) { return null; }
+        catch (RegexMatchTimeoutException) { return null; }
+    }
+
+    /// <summary>"'My Sheet'!B2" / "Sheet2!B2" → sheet part before the LAST '!'
+    /// (a quoted sheet name may itself contain '!'), ref part after.</summary>
+    private static void SplitSheetToken(string value, out string sheet, out string refPart)
+    {
+        var bang = value.LastIndexOf('!');
+        if (bang < 0) { sheet = ""; refPart = value; return; }
+        sheet = value[..bang];
+        refPart = value[(bang + 1)..];
+    }
+}
+
+/// <summary>Parses the ref-shaped token values the evaluator's tokenizer emits.</summary>
+internal static class TraceRefParser
+{
+    /// <summary>"B2" → row 2, col 2.</summary>
+    public static bool TryCellRef(string s, out int row, out int col)
+    {
+        row = col = 0;
+        if (string.IsNullOrEmpty(s)) return false;
+        var i = 0;
+        while (i < s.Length && char.IsAsciiLetter(s[i])) i++;
+        if (i == 0 || i > 3 || i == s.Length) return false;
+        if (!int.TryParse(s[i..], out row) || row < 1) return false;
+        col = ColFromLetters(s[..i]);
+        return col > 0;
+    }
+
+    /// <summary>
+    /// "A1:C3" → a bounded ref; "A:C" → rows 1..0 (open bottom); "1:5" →
+    /// cols 1..0 (open right). 0 in an end bound always means unbounded.
+    /// </summary>
+    public static bool TryRange(string s, out TraceRef r)
+    {
+        r = new TraceRef(null, 0, 0, 0, 0);
+        var parts = s.Split(':');
+        if (parts.Length != 2) return false;
+        var (a, b) = (parts[0], parts[1]);
+        if (a.Length == 0 || b.Length == 0) return false;
+        if (char.IsAsciiDigit(a[0]) && char.IsAsciiDigit(b[0]))
+        {
+            if (!int.TryParse(a, out var ra) || !int.TryParse(b, out var rb) || ra < 1 || rb < 1) return false;
+            if (rb < ra) (ra, rb) = (rb, ra);
+            r = new TraceRef(null, ra, 1, rb, 0);
+            return true;
+        }
+        var aLetters = AllLetters(a);
+        var bLetters = AllLetters(b);
+        if (aLetters && bLetters)
+        {
+            var ca = ColFromLetters(a);
+            var cb = ColFromLetters(b);
+            if (ca <= 0 || cb <= 0) return false;
+            if (cb < ca) (ca, cb) = (cb, ca);
+            r = new TraceRef(null, 1, ca, 0, cb);
+            return true;
+        }
+        if (!aLetters && !bLetters &&
+            TryCellRef(a, out var r1, out var c1) && TryCellRef(b, out var r2, out var c2))
+        {
+            if (r2 < r1) (r1, r2) = (r2, r1);
+            if (c2 < c1) (c1, c2) = (c2, c1);
+            r = new TraceRef(null, r1, c1, r2, c2);
+            return true;
+        }
+        return false;
+    }
+
+    private static bool AllLetters(string s)
+    {
+        foreach (var ch in s)
+            if (!char.IsAsciiLetter(ch)) return false;
+        return s.Length > 0;
+    }
+
+    private static int ColFromLetters(string letters)
+    {
+        var col = 0;
+        foreach (var ch in letters)
+        {
+            var up = char.ToUpperInvariant(ch);
+            if (up is < 'A' or > 'Z') return 0;
+            col = col * 26 + (up - 'A' + 1);
+        }
+        return col;
+    }
+}

--- a/src/officecli/Core/OutputFormatter.cs
+++ b/src/officecli/Core/OutputFormatter.cs
@@ -113,6 +113,9 @@ internal static class WarningContext
 [JsonSerializable(typeof(List<DocumentIssue>))]
 [JsonSerializable(typeof(Dictionary<string, object?>))]
 [JsonSerializable(typeof(List<Dictionary<string, object?>>))]
+// Trace payloads (get --prop trace=…) hang off Format values: edges are a list
+// of {from, to[]} dicts, and the `to` arrays are string lists.
+[JsonSerializable(typeof(List<string>))]
 [JsonSerializable(typeof(bool))]
 [JsonSerializable(typeof(int))]
 [JsonSerializable(typeof(long))]

--- a/src/officecli/Handlers/Excel/ExcelHandler.Helpers.Cell.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Helpers.Cell.cs
@@ -494,6 +494,8 @@ public partial class ExcelHandler
     /// <summary>
     /// Invalidate the row index cache for a specific SheetData (or all sheets if null).
     /// Must be called whenever rows are structurally modified (removed, shifted).
+    /// The formula-trace reverse index rides the same hook: any mutation that
+    /// invalidates the row index can change which formulas reference what.
     /// </summary>
     private void InvalidateRowIndex(SheetData? sheetData = null)
     {
@@ -501,6 +503,7 @@ public partial class ExcelHandler
             _rowIndex?.Remove(sheetData);
         else
             _rowIndex = null;
+        InvalidateDependentsIndex();
     }
 
     private Cell FindOrCreateCell(SheetData sheetData, string cellRef)

--- a/src/officecli/Handlers/Excel/ExcelHandler.Remove.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Remove.cs
@@ -372,6 +372,10 @@ public partial class ExcelHandler
             // does on recalc and is hard to get right.
             InvalidateFormulaCacheReferencingSheet(workbookPart, sheetName);
 
+            // Formula-trace reverse index: both the removed sheet's own formula
+            // cells and every ref pointing at it just changed meaning.
+            InvalidateDependentsIndex();
+
             // Fix ActiveTab to prevent workbook corruption when deleting the last tab
             var remainingCount = sheets!.Elements<Sheet>().Count();
             var bookViews = workbook.GetFirstChild<BookViews>();

--- a/src/officecli/Handlers/Excel/ExcelHandler.Set.Sheet.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Set.Sheet.cs
@@ -271,6 +271,10 @@ public partial class ExcelHandler
                         }
 
                         workbook.Save();
+                        // The formula-trace reverse index is keyed by sheet
+                        // NAME (both the formula-cell side and the reference
+                        // side) — a rename rewrites exactly that key space.
+                        InvalidateDependentsIndex();
                     }
                     break;
                 }

--- a/src/officecli/Handlers/Excel/ExcelHandler.Set.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Set.cs
@@ -19,6 +19,11 @@ public partial class ExcelHandler
     public List<string> Set(string path, Dictionary<string, string> properties)
     {
         Modified = true;
+        // A set can change any cell's formula (the usual trace-index mutation).
+        // The row-index cache invalidation sites don't cover the plain cell
+        // write path, so the trace reverse index drops here at the Set() entry
+        // — the one choke point every set mutation passes through.
+        InvalidateDependentsIndex();
         // Batch Set: route to the shared filter engine when the path is a bare
         // selector (no `/`) OR a `/`-scoped path that carries a content filter
         // (e.g. `/Sheet1/cell[value>5000 or value<300]`). The latter would

--- a/src/officecli/Handlers/Excel/ExcelHandler.Trace.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Trace.cs
@@ -1,0 +1,288 @@
+// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.RegularExpressions;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeCli.Handlers;
+
+public partial class ExcelHandler
+{
+    // ===== Formula dependency trace (get --prop trace=precedents|dependents) =====
+    //
+    // Pure read-only query on top of the formula tokenizer. Precedents walk
+    // the token stream of each visited cell's formula (FormulaEvaluator.
+    // TryCollectRefs — defined names arrive pre-folded, so cell, range,
+    // sheet-qualified and named refs all come out of one pass). Dependents
+    // answer from a lazily-built in-process reverse index: every formula cell
+    // in the workbook scanned once, its refs recorded either as exact single
+    // cells or as clamped range entries, then cached until the document
+    // changes. Invalidation rides the InvalidateRowIndex hook the row-index
+    // cache already uses, so every mutation site that drops the row index
+    // drops this one too; sheet rename/delete add explicit drops (the index
+    // is keyed by sheet NAME, which those operations rewrite).
+
+    /// <summary>
+    /// Trace the formula dependency graph around <paramref name="path"/> and
+    /// (optionally) attach the result to the cell node's Format as the
+    /// "trace" key. JSON output carries it inside the envelope; text output
+    /// renders the indented tree from the returned <see cref="Core.TraceOutput"/> —
+    /// attach only in JSON mode so the one-line node record stays readable.
+    /// Throws CliException with code invalid_argument (malformed path/depth),
+    /// not_found (root cell missing), unsupported_element (precedents on a
+    /// constant cell), or unsupported_type (non-Excel handler).
+    /// </summary>
+    internal Core.TraceOutput AttachTrace(Core.DocumentNode node, string path, string mode, int traceDepth, bool attachToFormat)
+    {
+        if (!string.Equals(mode, "precedents", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(mode, "dependents", StringComparison.OrdinalIgnoreCase))
+            throw new Core.CliException($"Unknown trace mode: '{mode}'.")
+            {
+                Code = "invalid_argument",
+                ValidValues = ["precedents", "dependents"],
+                Suggestion = "trace=precedents walks what the cell depends on; trace=dependents walks who depends on it"
+            };
+        if (traceDepth < 1 || traceDepth > Core.FormulaTrace.MaxDepth)
+            throw new Core.CliException($"trace depth must be an integer between 1 and {Core.FormulaTrace.MaxDepth} (got {traceDepth}).")
+            {
+                Code = "invalid_argument",
+                Suggestion = "--prop depth=3 walks three hops of the dependency chain"
+            };
+        var segments = path.TrimStart('/').Split('/', 2);
+        var cellRef = segments.Length == 2 ? segments[1].ToUpperInvariant() : "";
+        if (cellRef.Contains('/') || !Regex.IsMatch(cellRef, @"^[A-Z]{1,3}\d+$"))
+            throw new Core.CliException($"trace requires a single cell path like /Sheet1/F2 (got '{path}').")
+            {
+                Code = "invalid_argument",
+                Suggestion = "get <file> '/Sheet1/F2' --prop trace=precedents [--prop depth=N]"
+            };
+        var sheetName = segments[0];
+        var wsPart = FindWorksheet(sheetName);
+        var sheetData = wsPart != null ? GetSheet(wsPart).GetFirstChild<SheetData>() : null;
+        var cell = sheetData != null ? FindCell(sheetData, cellRef) : null;
+        if (cell == null)
+            throw new Core.CliException($"Cell /{sheetName}/{cellRef} not found — nothing to trace.")
+            {
+                Code = "not_found",
+                Suggestion = $"set it first, or get /{sheetName}/{cellRef} to inspect the current state"
+            };
+        if (mode == "precedents" && string.IsNullOrEmpty(cell.CellFormula?.Text))
+            throw new Core.CliException($"/{sheetName}/{cellRef} holds a constant — no formula to trace precedents from.")
+            {
+                Code = "unsupported_element",
+                Suggestion = "trace=precedents needs a formula cell; trace=dependents works on any cell (it answers who references it), or get the cell --json and check the 'formula' key"
+            };
+        var source = new TraceSource(this);
+        var output = Core.FormulaTrace.Trace(source, sheetName, cellRef,
+            dependents: string.Equals(mode, "dependents", StringComparison.OrdinalIgnoreCase), traceDepth);
+        if (attachToFormat) node.Format["trace"] = TraceToFormat(output);
+        return output;
+    }
+
+    /// <summary>Envelope shape for the trace payload: only shapes the source-
+    /// generated Format serializer has metadata for (Dictionary values resolve
+    /// polymorphically — a List&lt;object?&gt; here fails at serialization time).</summary>
+    internal static Dictionary<string, object?> TraceToFormat(Core.TraceOutput output)
+    {
+        var edgeList = new List<Dictionary<string, object?>>(output.Edges.Count);
+        foreach (var e in output.Edges)
+            edgeList.Add(new Dictionary<string, object?> { ["from"] = e.From, ["to"] = e.To });
+        return new Dictionary<string, object?>
+        {
+            ["root"] = output.Root,
+            ["edges"] = edgeList,
+            ["truncated"] = output.Truncated,
+        };
+    }
+
+    private sealed class DependentsIndex
+    {
+        /// <summary>"SHEET|CELL" (upper) → source keys "SHEET|CELL", in build order.</summary>
+        public readonly Dictionary<string, List<string>> Exact = new(StringComparer.OrdinalIgnoreCase);
+        /// <summary>Range refs that cover >1 cell (bounds already resolved:
+        /// open sides clamped to the used range at build time).</summary>
+        public readonly List<(string Sheet, int R1, int C1, int R2, int C2, string Src)> Ranges = new();
+        /// <summary>UPPER sheet name → canonical name (display uses real casing).</summary>
+        public readonly Dictionary<string, string> CanonicalSheets = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private DependentsIndex? _dependentsIndex;
+
+    /// <summary>Drop the reverse index so the next dependents query rebuilds it
+    /// from the current document. Called from InvalidateRowIndex (every cell /
+    /// row / import mutation) and explicitly from sheet rename and remove.</summary>
+    internal void InvalidateDependentsIndex() => _dependentsIndex = null;
+
+    private DependentsIndex EnsureDependentsIndex()
+    {
+        if (_dependentsIndex != null) return _dependentsIndex;
+        var idx = new DependentsIndex();
+        var usedRanges = new Dictionary<string, (int MaxRow, int MaxCol)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (sheetName, wsPart) in GetWorksheets())
+        {
+            idx.CanonicalSheets[sheetName.ToUpperInvariant()] = sheetName;
+            var sheetData = GetSheet(wsPart).GetFirstChild<SheetData>();
+            if (sheetData == null) continue;
+            var evaluator = new Core.FormulaEvaluator(sheetData, _doc.WorkbookPart);
+            foreach (var row in sheetData.Elements<Row>())
+            {
+                foreach (var cell in row.Elements<Cell>())
+                {
+                    var formula = cell.CellFormula?.Text;
+                    if (string.IsNullOrEmpty(formula) || cell.CellReference?.Value is not string cref) continue;
+                    var src = $"{sheetName.ToUpperInvariant()}|{cref.ToUpperInvariant()}";
+                    var refs = evaluator.TryCollectRefs(formula);
+                    if (refs == null) continue;
+                    foreach (var rf in refs)
+                    {
+                        var refSheet = CanonicalSheetName(rf.Sheet ?? sheetName);
+                        var refUpper = refSheet.ToUpperInvariant();
+                        idx.CanonicalSheets.TryAdd(refUpper, refSheet);
+                        if (FindWorksheet(refSheet) == null) continue; // dangling sheet ref — nothing to attach to
+                        int r2, c2;
+                        if (rf.R2 == 0 || rf.C2 == 0)
+                        {
+                            var (maxRow, maxCol) = UsedRangeOf(usedRanges, refSheet);
+                            r2 = rf.R2 == 0 ? Math.Max(1, maxRow) : rf.R2;
+                            c2 = rf.C2 == 0 ? Math.Max(1, maxCol) : rf.C2;
+                        }
+                        else { r2 = rf.R2; c2 = rf.C2; }
+                        var (r1, c1) = (Math.Max(1, rf.R1), Math.Max(1, rf.C1));
+                        if (r2 < r1) r2 = r1;
+                        if (c2 < c1) c2 = c1;
+                        if (r1 == r2 && c1 == c2)
+                        {
+                            var key = $"{refUpper}|{Core.FormulaTrace.ColToName(c1)}{r1}";
+                            if (!idx.Exact.TryGetValue(key, out var list))
+                                idx.Exact[key] = list = new List<string>();
+                            if (!list.Contains(src)) list.Add(src);
+                        }
+                        else
+                        {
+                            idx.Ranges.Add((refUpper, r1, c1, r2, c2, src));
+                        }
+                    }
+                }
+            }
+        }
+        _dependentsIndex = idx;
+        return idx;
+    }
+
+    private string CanonicalSheetName(string name)
+    {
+        foreach (var (sheetName, _) in GetWorksheets())
+            if (string.Equals(sheetName, name, StringComparison.OrdinalIgnoreCase))
+                return sheetName;
+        return name;
+    }
+
+    private (int MaxRow, int MaxCol) UsedRangeOf(Dictionary<string, (int, int)> cache, string sheetName)
+    {
+        if (cache.TryGetValue(sheetName, out var cached)) return cached;
+        var (maxRow, maxCol) = (0, 0);
+        if (FindWorksheet(sheetName) is { } wsPart &&
+            GetSheet(wsPart).GetFirstChild<SheetData>() is { } sheetData)
+        {
+            foreach (var row in sheetData.Elements<Row>())
+            {
+                if (row.RowIndex?.Value is { } ri && ri > maxRow) maxRow = (int)ri;
+                foreach (var cell in row.Elements<Cell>())
+                {
+                    if (cell.CellReference?.Value is not string cref) continue;
+                    try
+                    {
+                        var col = ColumnNameToIndex(ParseCellReference(cref).Column);
+                        if (col > maxCol) maxCol = col;
+                    }
+                    catch { /* malformed ref — skip the cell for bound purposes */ }
+                }
+            }
+        }
+        cache[sheetName] = (maxRow, maxCol);
+        return (maxRow, maxCol);
+    }
+
+    /// <summary>Adapter the trace engine walks. Read-only: evaluators are
+    /// constructed per sheet on demand and never asked to evaluate.</summary>
+    private sealed class TraceSource(ExcelHandler owner) : Core.IFormulaTraceSource
+    {
+        private readonly Dictionary<string, SheetData?> _sheetData = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, Core.FormulaEvaluator?> _evaluators = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, (int MaxRow, int MaxCol)> _usedRanges = new(StringComparer.OrdinalIgnoreCase);
+
+        public List<Core.TraceRef>? RefsOf(Core.TraceCell cell)
+        {
+            var sheetData = SheetDataOf(cell.Sheet);
+            if (sheetData == null) return null;
+            var found = FindCell(sheetData, cell.CellRef);
+            var formula = found?.CellFormula?.Text;
+            if (string.IsNullOrEmpty(formula)) return null;
+            var evaluator = EvaluatorOf(cell.Sheet, sheetData);
+            if (evaluator == null) return null;
+            var refs = evaluator.TryCollectRefs(formula);
+            if (refs == null) return null;
+            // Resolve raw token sheet names to canonical workbook names so the
+            // graph keys line up across cells; owner-sheet refs stay null.
+            for (var i = 0; i < refs.Count; i++)
+            {
+                if (refs[i].Sheet == null) continue;
+                var canonical = owner.CanonicalSheetName(refs[i].Sheet!);
+                refs[i] = refs[i] with { Sheet = canonical };
+            }
+            return refs;
+        }
+
+        public (int MaxRow, int MaxCol) UsedRange(string sheet)
+        {
+            if (_usedRanges.TryGetValue(sheet, out var cached)) return cached;
+            var (maxRow, maxCol) = owner.UsedRangeOf(new(), sheet);
+            _usedRanges[sheet] = (maxRow, maxCol);
+            return (maxRow, maxCol);
+        }
+
+        public List<Core.TraceCell> DependentsOf(string sheet, int row, int col)
+        {
+            var idx = owner.EnsureDependentsIndex();
+            var upper = sheet.ToUpperInvariant();
+            var key = $"{upper}|{Core.FormulaTrace.ColToName(col)}{row}";
+            var sources = new List<string>();
+            if (idx.Exact.TryGetValue(key, out var exact))
+                sources.AddRange(exact);
+            foreach (var r in idx.Ranges)
+            {
+                if (!string.Equals(r.Sheet, upper, StringComparison.OrdinalIgnoreCase)) continue;
+                if (row < r.R1 || row > r.R2 || col < r.C1 || col > r.C2) continue;
+                if (!sources.Contains(r.Src)) sources.Add(r.Src);
+            }
+            var result = new List<Core.TraceCell>();
+            foreach (var src in sources)
+            {
+                var pipe = src.IndexOf('|');
+                if (pipe <= 0) continue;
+                var srcUpper = src[..pipe];
+                if (!idx.CanonicalSheets.TryGetValue(srcUpper, out var canonical)) continue;
+                result.Add(new Core.TraceCell(canonical, src[(pipe + 1)..]));
+            }
+            return result;
+        }
+
+        private SheetData? SheetDataOf(string sheet)
+        {
+            if (_sheetData.TryGetValue(sheet, out var cached)) return cached;
+            SheetData? data = null;
+            if (owner.FindWorksheet(sheet) is { } wsPart)
+                data = GetSheet(wsPart).GetFirstChild<SheetData>();
+            _sheetData[sheet] = data;
+            return data;
+        }
+
+        private Core.FormulaEvaluator? EvaluatorOf(string sheet, SheetData sheetData)
+        {
+            if (_evaluators.TryGetValue(sheet, out var cached)) return cached;
+            var ev = new Core.FormulaEvaluator(sheetData, owner._doc.WorkbookPart);
+            _evaluators[sheet] = ev;
+            return ev;
+        }
+    }
+}

--- a/src/officecli/ResidentServer.cs
+++ b/src/officecli/ResidentServer.cs
@@ -1964,6 +1964,32 @@ public class ResidentServer : IDisposable
                 node.Format["savedContentType"] = contentType!;
         }
 
+        // CONSISTENCY(get-trace): mirror CommandBuilder.GetQuery.cs — formula
+        // dependency trace attaches to the cell node (JSON: inside Format;
+        // text: indented tree after the node line). Validation and error
+        // codes live in ExcelHandler.AttachTrace so both modes agree.
+        var traceMode = req.GetArgOrNull("trace");
+        if (traceMode != null)
+        {
+            var traceDepth = req.GetIntArg("traceDepth") ?? OfficeCli.Core.FormulaTrace.DefaultDepth;
+            if (_handler is OfficeCli.Handlers.ExcelHandler excelHandler)
+            {
+                var traceOutput = excelHandler.AttachTrace(node, node.Path, traceMode, traceDepth,
+                    attachToFormat: format == OutputFormat.Json);
+                if (format != OutputFormat.Json)
+                {
+                    Console.WriteLine(OutputFormatter.FormatNode(node, format));
+                    Console.WriteLine(OfficeCli.Core.FormulaTrace.RenderTree(traceOutput,
+                        dependents: string.Equals(traceMode, "dependents", StringComparison.OrdinalIgnoreCase)));
+                    return;
+                }
+            }
+            else
+            {
+                throw new CliException("trace is only supported for xlsx documents.") { Code = "unsupported_type" };
+            }
+        }
+
         // Unified envelope contract: mirror direct-mode CommandBuilder.GetQuery.cs
         // — single-path get JSON returns {matches, results: [node]}, so agents
         // and scripts use one jq path across get / get selected / query. Text


### PR DESCRIPTION
feat(excel): formula dependency trace — get --prop trace=precedents|dependents

What: `get <file> '/Sheet1/F2' --prop trace=precedents [--prop depth=N]`
returns the formula dependency graph around a cell (dependents likewise).
Precedents collect references from the evaluator's token stream — there is
no table-formula AST, and defined names are already folded by the tokenizer,
so cell, range, sheet-qualified, and named references all come out of one
pass. Range leaves expand with caps (<=5000 per range, 20000 leaves / 5000
edges overall; overflow sets `truncated: true`). Dependents answer from a
lazily-built in-process reverse index (every formula cell scanned once,
range refs clamped to the used range), invalidated on every mutation: the
row-index hook, the Set() entry, sheet rename and sheet remove. JSON adds
`format.trace = {root, edges: [{from, to[]}], truncated}` to the existing
cell node — nothing else in the envelope changes; text mode renders an
indented tree. Errors are explicit with codes: precedents on a constant ->
unsupported_element (+suggestion), missing cell -> not_found, bad depth or
unknown prop -> invalid_argument.

Why: formula audits today stop at the cell — nothing shows what a formula
depends on or what breaks when an input changes, so agents re-derive
dependency chains by grepping formula text. A token-stream trace is exact
for the grammar the evaluator itself accepts (including the same defined-
name folding), needs no evaluation, and gives the dependency question a
one-command answer.

How to verify:
  officecli get report.xlsx '/Sheet1/F2' --prop trace=precedents --json
  officecli get report.xlsx '/Sheet1/F2' --prop trace=precedents --prop depth=3 --json
  officecli get report.xlsx '/Sheet1/B2' --prop trace=dependents --json
  (drop --json for the indented text tree)
Build 0 errors; local harness T-11 21 assertions green (chain + cross-sheet
/Sheet1!B1 qualification + reverse-index invalidation rebuild + range-entry
matching + truncation caps + text tree); regression moat 26/26.
