### PR TITLE
feat(excel): range style presets — set '/Sheet1/B2:T6' --prop stylepreset=…

### DIFF
--- a/src/officecli/CommandBuilder.Set.cs
+++ b/src/officecli/CommandBuilder.Set.cs
@@ -14,7 +14,7 @@ static partial class CommandBuilder
         var forceOption = new Option<bool>("--force") { Description = "Force write even if document is protected" };
         var setFileArg = new Argument<FileInfo>("file") { Description = "Office document path (required even with open/close mode)" };
         var setPathArg = new Argument<string>("path") { Description = "DOM path to the element. The 'selected' pseudo-path is deprecated for mutations: use `get selected` to capture path(s) first, then `set <path>` (or a `batch` file for multi-select) so the target lives in the command line, not in transient watch-server state." };
-        var propsOpt = new Option<string[]>("--prop") { Description = "Property to set (key=value)", AllowMultipleArgumentsPerToken = true };
+        var propsOpt = new Option<string[]>("--prop") { Description = "Property to set (key=value). xlsx range paths accept stylepreset=table_header|table_banded|kpi_card|metric_positive|metric_negative|note_gray (free-range styling; ListObject tables use add --type table --prop style=…)", AllowMultipleArgumentsPerToken = true };
         // Selector: top-level alternative to --prop find=VALUE. r"..." prefix triggers regex (project-wide CONSISTENCY(find-regex)).
         var findOpt = new Option<string?>("--find") { Description = "Find this text/pattern (literal substring; `r\"...\"` prefix enables regex). Equivalent to --prop find=VALUE." };
         // Action paired with --find: replacement text. Top-level alternative to --prop replace=VALUE.

--- a/src/officecli/Core/ThemeHandler.cs
+++ b/src/officecli/Core/ThemeHandler.cs
@@ -141,6 +141,25 @@ internal static class ThemeHandler
 
     // ==================== Color Slot Helpers ====================
 
+    /// <summary>
+    /// Read a color-scheme slot (accent1…accent6, dk1/lt1…) as raw hex.
+    /// Used by handlers that derive styling from the workbook theme (xlsx
+    /// stylepreset accents) — the read half of TrySetTheme's write half.
+    /// Returns null when the part/slot is missing or the slot carries no
+    /// resolvable RGB.
+    /// </summary>
+    public static string? TryReadColorSlot(DocumentFormat.OpenXml.Packaging.ThemePart? themePart, string slotName)
+    {
+        var colorScheme = themePart?.Theme?.ThemeElements?.ColorScheme;
+        if (colorScheme == null) return null;
+        foreach (var (key, getter, _) in ColorSlots)
+        {
+            if (!key.Equals(slotName, StringComparison.OrdinalIgnoreCase)) continue;
+            return ReadColorSlot(getter(colorScheme));
+        }
+        return null;
+    }
+
     private static string? ReadColorSlot(A.Color2Type? slot)
     {
         if (slot == null) return null;

--- a/src/officecli/Handlers/Excel/ExcelHandler.Set.Cells.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Set.Cells.cs
@@ -708,6 +708,12 @@ public partial class ExcelHandler
                                  || p.Value.Equals("rich", StringComparison.OrdinalIgnoreCase))))
                         unsupported.Add("runs (only valid with type=richtext)");
                     break;
+                case "stylepreset":
+                    // Range-level preset landed on a cell-anchored path — point
+                    // at the range form instead of letting it die as a bare
+                    // unsupported key (03 §6: presets style free-form ranges).
+                    unsupported.Add("stylepreset (apply it to a range path: set '/Sheet1/B2:T6' --prop stylepreset=kpi_card)");
+                    break;
                 default:
                     // Legacy richtext mini-spec keys (run1=, run2=, …) are read
                     // inside ApplyRichTextToCell — same false-unsupported hole

--- a/src/officecli/Handlers/Excel/ExcelHandler.Set.Ranges.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.Set.Ranges.cs
@@ -25,6 +25,7 @@ public partial class ExcelHandler
 
         // Separate range-level props from cell-level props
         var cellProps = new Dictionary<string, string>();
+        string? stylePreset = null;
         // CONSISTENCY(range-action): sort/sortHeader are consumed together as a
         // range action (see sheet-level dispatch). If sort is present, apply it
         // after cell-level props are processed.
@@ -166,6 +167,11 @@ public partial class ExcelHandler
                     }
                     break;
                 }
+                case "stylepreset":
+                    // Range style preset (03 §6) — expanded after cellProps so
+                    // the preset bundle wins conflicts deterministically.
+                    stylePreset = value;
+                    break;
                 default:
                     // Treat as cell-level property to apply to every cell in the range
                     cellProps[key] = value;
@@ -215,6 +221,11 @@ public partial class ExcelHandler
                 throw;
             }
         }
+
+        // Apply the style preset after explicit cellProps (preset wins conflicts;
+        // its own per-row expansion is atomic via its internal sheetData backup).
+        if (stylePreset != null)
+            unsupported.AddRange(ApplyStylePresetRange(worksheet, rangeRef, stylePreset, cellProps));
 
         // Apply sort after cell-level props (range-action handler)
         if (sortSpec != null)

--- a/src/officecli/Handlers/Excel/ExcelHandler.StylePreset.cs
+++ b/src/officecli/Handlers/Excel/ExcelHandler.StylePreset.cs
@@ -1,0 +1,205 @@
+// Copyright 2026 OfficeCLI (https://OfficeCLI.AI)
+// SPDX-License-Identifier: Apache-2.0
+
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeCli.Handlers;
+
+public partial class ExcelHandler
+{
+    // ===== Range style presets (set '/Sheet1/range[B2:T6]' --prop stylepreset=…, 03 §6) =====
+    //
+    // One-command styling for free-form ranges. Each preset is a curated bundle
+    // of EXISTING cell style props (fill, font.color, bold, size, italic,
+    // border.all, alignment.horizontal) — expanded through the very same
+    // ApplyCellProperties path a hand-written `set` uses, so nothing a preset
+    // requests can silently render as something else ("expand, don't invent" —
+    // mirrors WordHandler.StylePreset from PR #376). Accent-keyed colors
+    // (ACCENT1 / ACCENT1_TINT) resolve from the workbook theme part at apply
+    // time with a fixed Office-default fallback, so a theme-less file still
+    // gets sensible colors. Division of labor with ListObjects: `add --type
+    // table --prop style=mediumN` styles a real table (banding that scales
+    // with the table); stylepreset styles a free range — that's why table_banded
+    // refuses ranges taller than 1000 rows and points at add table instead.
+
+    /// <summary>A resolved preset: the props applied to every cell, plus an
+    /// optional per-row override bundle (table_banded's zebra stripe).</summary>
+    private sealed record StylePreset(Dictionary<string, string> Props, Dictionary<string, string>? OddRowProps = null);
+
+    /// <summary>
+    /// Registry of built-in xlsx range presets. All values are existing cell
+    /// style-prop values, with two accent tokens: ACCENT1 (theme accent1 or
+    /// the Office default 4472C4) and ACCENT1_TINT (accent1 blended 85% toward
+    /// white — a light band/background tone). Colors mix deterministically so
+    /// the equivalence test can recompute the exact hex from the readback
+    /// theme accent.
+    /// </summary>
+    private static readonly Dictionary<string, StylePreset> StylePresets =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            // Header band: accent fill, white bold, centered.
+            ["table_header"] = new StylePreset(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["fill"] = "ACCENT1",
+                ["font.color"] = "FFFFFF",
+                ["bold"] = "true",
+                ["alignment.horizontal"] = "center",
+            }),
+
+            // Zebra rows: odd range-rows carry the light accent band, even rows
+            // untouched (explicit cellProps from the same call still apply).
+            ["table_banded"] = new StylePreset(
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+                OddRowProps: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["fill"] = "ACCENT1_TINT",
+                }),
+
+            // KPI card: light accent panel, accent bold number, centered.
+            ["kpi_card"] = new StylePreset(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["fill"] = "ACCENT1_TINT",
+                ["font.color"] = "ACCENT1",
+                ["bold"] = "true",
+                ["size"] = "20",
+                ["alignment.horizontal"] = "center",
+            }),
+
+            // Excel's canonical "Good" / "Bad" semantic pair (fixed, not themed —
+            // good/bad must stay green/red whatever the workbook theme is).
+            ["metric_positive"] = new StylePreset(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["font.color"] = "006100",
+                ["fill"] = "C6EFCE",
+            }),
+            ["metric_negative"] = new StylePreset(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["font.color"] = "9C0006",
+                ["fill"] = "FFC7CE",
+            }),
+
+            // Muted note text.
+            ["note_gray"] = new StylePreset(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["font.color"] = "808080",
+                ["italic"] = "true",
+                ["fill"] = "F2F2F2",
+            }),
+        };
+
+    /// <summary>Office default theme accent1, used when the workbook has no
+    /// theme part or an unreadable accent slot.</summary>
+    private const string FallbackAccent1 = "4472C4";
+
+    /// <summary>
+    /// Apply a style preset to every cell of the range (atomic: restore on
+    /// failure). Called from SetRange after explicit cellProps so the preset's
+    /// bundle wins conflicts deterministically. Returns the unsupported list
+    /// collected from the first cell only, mirroring SetRange's convention.
+    /// </summary>
+    private List<string> ApplyStylePresetRange(WorksheetPart worksheet, string rangeRef, string presetName,
+        Dictionary<string, string> explicitProps)
+    {
+        if (!StylePresets.TryGetValue(presetName, out var preset))
+            throw new Core.CliException($"Unknown stylepreset: '{presetName}'.")
+            {
+                Code = "invalid_value",
+                ValidValues = StylePresets.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase).ToArray(),
+                Suggestion = "ListObject tables take built-in styles instead: add <file> /Sheet1 --type table --prop style=medium2",
+            };
+
+        var parts = rangeRef.Split(':');
+        if (parts.Length != 2)
+            throw new Core.CliException($"stylepreset needs a rectangular range path like /Sheet1/range[B2:T6] (got '{rangeRef}').")
+            { Code = "invalid_argument" };
+        var (startCol, startRow) = ParseCellReference(parts[0]);
+        var (endCol, endRow) = ParseCellReference(parts[1]);
+        var startColIdx = ColumnNameToIndex(startCol);
+        var endColIdx = ColumnNameToIndex(endCol);
+
+        var rowCount = endRow - startRow + 1;
+        if (rowCount > 1000)
+            throw new Core.CliException(
+                $"table_banded expands to one fill per row and {rangeRef} spans {rowCount} rows (cap 1000).")
+            {
+                Code = "invalid_argument",
+                Suggestion = "use add <file> /Sheet1 --type table --prop style=medium2 — a ListObject bands rows natively and scales with the table",
+            };
+
+        var accent1 = ResolveThemeAccent1();
+        var ws = GetSheet(worksheet);
+        var sheetData = ws.GetFirstChild<SheetData>();
+        if (sheetData == null)
+        {
+            sheetData = new SheetData();
+            ws.Append(sheetData);
+        }
+        var sheetDataBackup = (SheetData)sheetData.CloneNode(true);
+        var unsupported = new List<string>();
+        try
+        {
+            for (var row = startRow; row <= endRow; row++)
+            {
+                // table_banded: odd range-rows (1st, 3rd, …) carry the stripe.
+                var bundle = preset.OddRowProps != null
+                    ? ((row - startRow) % 2 == 0 ? preset.OddRowProps : null)
+                    : preset.Props;
+                if (bundle == null) continue;
+                var props = new Dictionary<string, string>(explicitProps, StringComparer.OrdinalIgnoreCase);
+                foreach (var (key, value) in bundle)
+                    props[key] = ResolveAccentTokens(value, accent1);
+                for (var colIdx = startColIdx; colIdx <= endColIdx; colIdx++)
+                {
+                    var cellRef = $"{IndexToColumnName(colIdx)}{row}";
+                    var cell = FindOrCreateCell(sheetData, cellRef);
+                    var cellUnsupported = ApplyCellProperties(cell, worksheet, props);
+                    PruneEmptyCell(cell);
+                    if (row == startRow && colIdx == startColIdx)
+                        unsupported.AddRange(cellUnsupported);
+                }
+            }
+        }
+        catch
+        {
+            ws.ReplaceChild(sheetDataBackup, sheetData);
+            InvalidateRowIndex();
+            throw;
+        }
+        return unsupported;
+    }
+
+    /// <summary>Replace the accent tokens in a preset value with the resolved
+    /// theme hex. Anything without a token passes through untouched.</summary>
+    private static string ResolveAccentTokens(string value, string accent1) => value switch
+    {
+        "ACCENT1" => accent1,
+        "ACCENT1_TINT" => BlendTowardWhite(accent1, 0.15),
+        _ => value,
+    };
+
+    /// <summary>Theme accent1 hex (RRGGBB) or the Office fallback.</summary>
+    private string ResolveThemeAccent1()
+        => Core.ThemeHandler.TryReadColorSlot(_doc.WorkbookPart?.ThemePart, "accent1") is { Length: > 0 } hex
+            ? hex.TrimStart('#').ToUpperInvariant()
+            : FallbackAccent1;
+
+    /// <summary>
+    /// Blend a hex color toward white. <paramref name="colorFraction"/> is the
+    /// share of the original color (0.15 = light tint used for banding/card
+    /// fills); per-channel and rounding are fixed so the result is
+    /// reproducible byte-for-byte by the equivalence test.
+    /// </summary>
+    internal static string BlendTowardWhite(string hex, double colorFraction)
+    {
+        var v = hex.TrimStart('#');
+        if (v.Length != 6 || !int.TryParse(v, System.Globalization.NumberStyles.HexNumber,
+                System.Globalization.CultureInfo.InvariantCulture, out var rgb))
+            return hex;
+        var r = (rgb >> 16) & 0xFF;
+        var g = (rgb >> 8) & 0xFF;
+        var b = rgb & 0xFF;
+        static int Blend(int c, double f) => (int)Math.Round(c * f + 255 * (1 - f), MidpointRounding.AwayFromZero);
+        return $"{Blend(r, colorFraction):X2}{Blend(g, colorFraction):X2}{Blend(b, colorFraction):X2}";
+    }
+}


### PR DESCRIPTION
feat(excel): range style presets — set '/Sheet1/B2:T6' --prop stylepreset=…

What: six one-command presets for free-form ranges — table_header,
table_banded, kpi_card, metric_positive, metric_negative, note_gray. Each
preset is a bundle of EXISTING cell style props (fill, font.color, bold,
size, italic, alignment.horizontal) expanded through the same
ApplyCellProperties path a hand-written set uses ("expand, don't invent" —
mirrors WordHandler.StylePreset from #376), so nothing a preset requests
can render as something else. Accent-keyed colors (ACCENT1/ACCENT1_TINT)
resolve from the workbook theme part at apply time with the Office default
fallback (4472C4) when no theme part exists. table_banded stripes the odd
range-rows and refuses ranges taller than 1000 rows, pointing at
`add --type table` for native banding. Unknown presets fail listing the
available names; cell-anchored stylepreset hard-rejects pointing at the
range form. Explicit cellProps in the same call apply first — the preset
wins conflicts deterministically.

Why: dashboards and reports need the same handful of range looks (header
band, zebra rows, KPI cards, good/bad metrics, muted notes) — hand-writing
five style props per range is error-prone and agents drift between
conventions. Pure sugar: the expansion adds no new style semantics, so
the break radius is zero.

How to verify:
  officecli set data.xlsx '/Sheet1/B2:T6' --prop stylepreset=kpi_card
  officecli set data.xlsx '/Sheet1/A2:A41' --prop stylepreset=table_banded
  (unknown name → invalid_value with the full preset list)
Build 0 errors; local harness T-12 23 assertions green — including the
equivalence contract (preset expansion attribute-identical to the
hand-written primitive sequence, tint recomputed from the theme readback)
plus banded stripe/cap/error paths and the semantic color pairs.
Regression moat 26/26.
